### PR TITLE
Update parsing and adds highlighting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2022 Jaden Giordano
+Copyright (c) 2022 Matouš Dzivjak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
+        "src/scanner.c",
       ],
       "cflags_c": [
         "-std=c99",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -18,14 +18,14 @@
 use tree_sitter::Language;
 
 extern "C" {
-    fn tree_sitter_jsonnet() -> Language;
+    fn tree_sitter_esdl() -> Language;
 }
 
 /// Get the tree-sitter [Language][] for this grammar.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 pub fn language() -> Language {
-    unsafe { tree_sitter_jsonnet() }
+    unsafe { tree_sitter_esdl() }
 }
 
 /// The content of the [`node-types.json`][] file for this grammar.
@@ -35,7 +35,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
@@ -47,6 +47,6 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(super::language())
-            .expect("Error loading jsonnet language");
+            .expect("Error loading esdl language");
     }
 }

--- a/grammar.js
+++ b/grammar.js
@@ -1,5 +1,9 @@
 module.exports = grammar({
   name: 'esdl',
+  
+  externals: $ => [
+    $._edgeql_chars,
+  ],
 
   extras: $ => [
     $.comment,
@@ -175,22 +179,20 @@ module.exports = grammar({
     function: $ => seq(
       'function',
       field('name', $.identifier),
-      '(',
-      optional($.argspec),
-      ')',
+      $.argspec,
       '->',
       $.returnspec,
       optional(choice(
-        seq('using', '(', 'edgedb', ')'),
-        $.uselang,
-      )),
-      optional(block(repeat(choice(
-        $.annotation,
-        $.computed,
         $.using,
-        $.uselang,
-      )))),
-      ';'
+        seq(
+          block(repeat(choice(
+            $.annotation,
+            $.computed,
+            $.using,
+          ))),
+          ';',
+        ),
+      )),
     ),
     
     extension: $ => seq(
@@ -211,13 +213,18 @@ module.exports = grammar({
     
     using: $ => seq(
       'using',
-      parens($.expression),
+      choice(
+        // TODO: Use proper edgeql language injection once the edgeql grammar is available 
+        parens(alias(choice(
+          $._edgeql_chars,
+          $.escape_sequence,
+        ), $.edgeql_fragment)),
+        seq(
+          field('language', $.identifier),
+          $.string,
+        ),
+      ),
       ';',
-    ),
-
-    uselang: $ => seq(
-      'using',
-      field('language', $.identifier, $.string),
     ),
     
     on: $ => seq(
@@ -247,10 +254,10 @@ module.exports = grammar({
 
     argspec: $ => seq(
       '(',
-      delim(choice(
+      optional(delim(choice(
         $.expression, // value instead (or as well?)
         seq($.identifier, ':', $._scalar_type)
-      )),
+      ))),
       ')',
     ),
     
@@ -262,6 +269,7 @@ module.exports = grammar({
     // TODO: This should be proper expression parsing.
     expression: $ => choice(
       $.string,
+      $.number,
       $.true,
       $.false,
       $.null,
@@ -270,6 +278,10 @@ module.exports = grammar({
       $.fncall,
       $.binary_expression,
       parens($.expression),
+    ),
+    
+    edgeql_expression: $ => choice(
+      $.expression,
     ),
     
     fncall: $ => seq(
@@ -303,9 +315,9 @@ module.exports = grammar({
         (associativity === 'right' ? prec.right : prec.left)(precedence, seq(
           field('left', $.expression),
           field('operator', operator),
-          field('right', $.expression)
-        ))
-      )
+          field('right', $.expression),
+        )),
+      ),
     ),
     
     // PRIMITIVES
@@ -318,6 +330,11 @@ module.exports = grammar({
       )),
       "'"
     ),
+    
+    // TODO: Proper edgeql language injection
+    edgeql: $ => parens(optional(choice(
+      $.expression,
+    ))),
     
     unescaped_single_string_fragment: $ =>
       token.immediate(prec(1, /[^'\\]+/)),
@@ -419,6 +436,43 @@ module.exports = grammar({
     true: $ => "true",
     false: $ => "false",
     null: $ => "null",
+    
+    number: $ => {
+      const hex_literal = seq(
+        choice('0x', '0X'),
+        /[\da-fA-F](_?[\da-fA-F])*/
+      )
+
+      const decimal_digits = /\d(_?\d)*/
+      const signed_integer = seq(optional(choice('-', '+')), decimal_digits)
+      const exponent_part = seq(choice('e', 'E'), signed_integer)
+
+      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/)
+
+      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/)
+
+      const bigint_literal = seq(choice(hex_literal, binary_literal, octal_literal, decimal_digits), 'n')
+
+      const decimal_integer_literal = choice(
+        '0',
+        seq(optional('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits)))
+      )
+
+      const decimal_literal = choice(
+        seq(decimal_integer_literal, '.', optional(decimal_digits), optional(exponent_part)),
+        seq('.', decimal_digits, optional(exponent_part)),
+        seq(decimal_integer_literal, exponent_part),
+        seq(decimal_digits),
+      )
+
+      return token(choice(
+        hex_literal,
+        decimal_literal,
+        binary_literal,
+        octal_literal,
+        bigint_literal,
+      ))
+    },
 
     comment: $ => token(choice(
       seq('#', /.*/),

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
   },
   "tree-sitter": [
     {
-      "scope": "source.jsonnet",
+      "scope": "source.esdl",
       "file-types": [
-        "jsonnet"
+        "esdl"
+      ],
+      "highlights": [
+        "queries/highlights.scm"
       ]
     }
   ]

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,13 @@
+["module"] @keyword
+
+(comment) @comment
+(developer_comment) @comment
+
+(arguments) @property
+(attribute) @attribute
+(call_expression) @function
+(column_type) @type
+(enumeral) @constant
+(identifier) @variable
+(string) @string
+

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -15,6 +15,7 @@
   "required"
   "optional"
   "extension"
+  "function"
 ] @keyword
 
 (modifier) @keyword

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,13 +1,76 @@
-["module"] @keyword
+; Keywords
+[
+  "module"
+  "using"
+  "single"
+  "multi"
+  "link"
+  "property"
+  "constraint"
+  "tuple"
+  "annotation"
+  "abstract"
+  "scalar"
+  "type"
+  "required"
+  "optional"
+  "extension"
+] @keyword
+
+(modifier) @keyword
+(extending) @keyword
+
+(module name: (identifier) @namespace)
+(object_type) @type
 
 (comment) @comment
-(developer_comment) @comment
 
-(arguments) @property
-(attribute) @attribute
-(call_expression) @function
-(column_type) @type
-(enumeral) @constant
+; Properties
+(property) @property
+(link) @property
+
+; Links
 (identifier) @variable
-(string) @string
+(str) @string
+
+; Annotations
+; (annotation) @property
+
+; Builtins
+
+(type) @type
+[
+  "str"
+  "bool"
+  "int16"
+  "int32"
+  "int64"
+  "float32"
+  "float64"
+  "bigint"
+  "decimal"
+  "json"
+  "uuid"
+  "bytes"
+  "datetime"
+  "duration"
+  "sequence"
+  "anytype"
+] @type.builtin
+
+(true) @constant.builtin
+(false) @constant.builtin
+(null) @constant.builtin
+
+; Delimiters
+[
+  ";"
+  ","
+] @punctuation.delimiter
+
+; Operators
+[
+  "->"
+  ":="
+] @operator
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -31,7 +31,8 @@
 
 ; Links
 (identifier) @variable
-(str) @string
+(string) @string
+(edgeql_fragment) @string
 
 ; Annotations
 ; (annotation) @property

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -778,24 +778,8 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "argspec"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
+          "type": "SYMBOL",
+          "name": "argspec"
         },
         {
           "type": "STRING",
@@ -812,29 +796,50 @@
               "type": "CHOICE",
               "members": [
                 {
+                  "type": "SYMBOL",
+                  "name": "using"
+                },
+                {
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": "using"
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "{"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "annotation"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "computed"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "using"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "}"
+                        }
+                      ]
                     },
                     {
                       "type": "STRING",
-                      "value": "("
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "edgedb"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ")"
+                      "value": ";"
                     }
                   ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "uselang"
                 }
               ]
             },
@@ -842,55 +847,6 @@
               "type": "BLANK"
             }
           ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "{"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "annotation"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "computed"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "using"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "uselang"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "STRING",
-                  "value": "}"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ";"
         }
       ]
     },
@@ -987,42 +943,61 @@
           "value": "using"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "("
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_edgeql_chars"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "escape_sequence"
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "edgeql_fragment"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
             },
             {
-              "type": "SYMBOL",
-              "name": "expression"
-            },
-            {
-              "type": "STRING",
-              "value": ")"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "language",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "string"
+                }
+              ]
             }
           ]
         },
         {
           "type": "STRING",
           "value": ";"
-        }
-      ]
-    },
-    "uselang": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "using"
-        },
-        {
-          "type": "FIELD",
-          "name": "language",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          }
         }
       ]
     },
@@ -1154,71 +1129,79 @@
           "value": "("
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                },
-                {
-                  "type": "SEQ",
+                  "type": "CHOICE",
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "expression"
                     },
                     {
-                      "type": "STRING",
-                      "value": ":"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_scalar_type"
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_scalar_type"
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "CHOICE",
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "expression"
+                        "type": "STRING",
+                        "value": ","
                       },
                       {
-                        "type": "SEQ",
+                        "type": "CHOICE",
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "expression"
                           },
                           {
-                            "type": "STRING",
-                            "value": ":"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_scalar_type"
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "identifier"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ":"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "_scalar_type"
+                              }
+                            ]
                           }
                         ]
                       }
                     ]
                   }
-                ]
-              }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },
@@ -1264,6 +1247,10 @@
         {
           "type": "SYMBOL",
           "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
         },
         {
           "type": "SYMBOL",
@@ -1318,6 +1305,15 @@
               "value": ")"
             }
           ]
+        }
+      ]
+    },
+    "edgeql_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
         }
       ]
     },
@@ -2008,6 +2004,36 @@
         }
       ]
     },
+    "edgeql": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "unescaped_single_string_fragment": {
       "type": "IMMEDIATE_TOKEN",
       "content": {
@@ -2400,6 +2426,495 @@
       "type": "STRING",
       "value": "null"
     },
+    "number": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0x"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0X"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[\\da-fA-F](_?[\\da-fA-F])*"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "0"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[1-9]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "_"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\d(_?\\d)*"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\\d(_?\\d)*"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "-"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "+"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\d(_?\\d)*"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "\\d(_?\\d)*"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "-"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "+"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\d(_?\\d)*"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "0"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[1-9]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "_"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\d(_?\\d)*"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "e"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "E"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "-"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "+"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "\\d(_?\\d)*"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "\\d(_?\\d)*"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0b"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0B"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-1](_?[0-1])*"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0o"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0O"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7](_?[0-7])*"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0x"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0X"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\da-fA-F](_?[\\da-fA-F])*"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0b"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0B"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[0-1](_?[0-1])*"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0o"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0O"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[0-7](_?[0-7])*"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "\\d(_?\\d)*"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "comment": {
       "type": "TOKEN",
       "content": {
@@ -2536,7 +3051,12 @@
       }
     ]
   ],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_edgeql_chars"
+    }
+  ],
   "inline": [],
   "supertypes": []
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -311,7 +311,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "expr"
+                      "name": "expression"
                     }
                   ]
                 },
@@ -374,62 +374,72 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "extending"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "SEQ",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": "->"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "type"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
+                  "type": "CHOICE",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": ":="
+                      "type": "SYMBOL",
+                      "name": "extending"
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "expr"
+                      "type": "BLANK"
                     }
                   ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "declarations"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "->"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "type"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ":="
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "expression"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "declarations"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -489,7 +499,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "expr"
+                  "name": "expression"
                 }
               ]
             },
@@ -714,7 +724,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "expr"
+                  "name": "expression"
                 }
               ]
             },
@@ -734,7 +744,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "expr"
+                      "name": "expression"
                     }
                   ]
                 },
@@ -985,7 +995,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "expr"
+              "name": "expression"
             },
             {
               "type": "STRING",
@@ -1032,7 +1042,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "expr"
+              "name": "expression"
             },
             {
               "type": "STRING",
@@ -1058,7 +1068,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "expr"
+              "name": "expression"
             },
             {
               "type": "STRING",
@@ -1085,7 +1095,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "expr"
+          "name": "expression"
         },
         {
           "type": "STRING",
@@ -1151,7 +1161,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "expression"
                 },
                 {
                   "type": "SEQ",
@@ -1186,7 +1196,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "expression"
                       },
                       {
                         "type": "SEQ",
@@ -1248,22 +1258,803 @@
         }
       ]
     },
-    "expr": {
+    "expression": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "str"
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "true"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "false"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "null"
         },
         {
           "type": "SYMBOL",
           "name": "identifier"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "global"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fncall"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "binary_expression"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
         }
       ]
     },
-    "str": {
-      "type": "PATTERN",
-      "value": "'.*'"
+    "fncall": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "binary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": "logical_and",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "&&"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "logical_or",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "||"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_shift",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": ">>"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_shift",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "<<"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "bitwise_and",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "&"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "bitwise_xor",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "^"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "bitwise_or",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "|"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_plus",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "+"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_plus",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "-"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "*"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "/"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "%"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_relation",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "<"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_relation",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "<="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_equality",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_equality",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "!="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_relation",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": ">="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_relation",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": ">"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "unescaped_single_string_fragment"
+                },
+                "named": true,
+                "value": "string_fragment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "escape_sequence"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "'"
+        }
+      ]
+    },
+    "unescaped_single_string_fragment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^'\\\\]+"
+        }
+      }
+    },
+    "escape_sequence": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\\"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^xu0-7]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7]{1,3}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "x[0-9a-fA-F]{2}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "u[0-9a-fA-F]{4}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "u{[0-9a-fA-F]+}"
+              }
+            ]
+          }
+        ]
+      }
     },
     "_scalar_type": {
       "type": "CHOICE",
@@ -1567,8 +2358,35 @@
       ]
     },
     "identifier": {
-      "type": "PATTERN",
-      "value": "[\\w]+"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\x00-\\x1F\\s\\p{Zs}0-9:;`\"'@#.,|^&<=>+\\-*/\\\\%?!~()\\[\\]{}\\uFEFF\\u2060\\u200B]|\\\\u[0-9a-fA-F]{4}|\\\\u\\{[0-9a-fA-F]+\\}"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PATTERN",
+              "value": "[^\\x00-\\x1F\\s\\p{Zs}:;`\"'@#.,|^&<=>+\\-*/\\\\%?!~()\\[\\]{}\\uFEFF\\u2060\\u200B]|\\\\u[0-9a-fA-F]{4}|\\\\u\\{[0-9a-fA-F]+\\}"
+            }
+          }
+        ]
+      }
     },
     "true": {
       "type": "STRING",
@@ -1622,7 +2440,102 @@
     }
   ],
   "conflicts": [],
-  "precedences": [],
+  "precedences": [
+    [
+      {
+        "type": "STRING",
+        "value": "member"
+      },
+      {
+        "type": "STRING",
+        "value": "call"
+      },
+      {
+        "type": "STRING",
+        "value": "unary_void"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_exp"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_times"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_plus"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_shift"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_compare"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_relation"
+      },
+      {
+        "type": "STRING",
+        "value": "binary_equality"
+      },
+      {
+        "type": "STRING",
+        "value": "bitwise_and"
+      },
+      {
+        "type": "STRING",
+        "value": "bitwise_xor"
+      },
+      {
+        "type": "STRING",
+        "value": "bitwise_or"
+      },
+      {
+        "type": "STRING",
+        "value": "logical_and"
+      },
+      {
+        "type": "STRING",
+        "value": "logical_or"
+      },
+      {
+        "type": "STRING",
+        "value": "ternary"
+      }
+    ],
+    [
+      {
+        "type": "STRING",
+        "value": "member"
+      },
+      {
+        "type": "STRING",
+        "value": "new"
+      },
+      {
+        "type": "STRING",
+        "value": "call"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "expression"
+      }
+    ],
+    [
+      {
+        "type": "STRING",
+        "value": "declaration"
+      },
+      {
+        "type": "STRING",
+        "value": "literal"
+      }
+    ]
+  ],
   "externals": [],
   "inline": [],
   "supertypes": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -42,8 +42,41 @@
             {
               "type": "REPEAT",
               "content": {
-                "type": "SYMBOL",
-                "name": "object_type"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "object_type"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "scalar_type_def"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "link"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "property"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "annotation"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "constraint"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "function"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "alias"
+                  }
+                ]
               }
             },
             {
@@ -61,11 +94,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "modifier"
-              }
+              "type": "SYMBOL",
+              "name": "modifier"
             },
             {
               "type": "BLANK"
@@ -77,15 +107,19 @@
           "value": "type"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
         },
         {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "extends"
+              "name": "extending"
             },
             {
               "type": "BLANK"
@@ -98,251 +132,322 @@
         }
       ]
     },
-    "extends": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "extending"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
     "declarations": {
       "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "{"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "property"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "link"
-                  }
-                ]
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "property"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "link"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "annotation"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "constraint"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "index"
               }
-            },
-            {
-              "type": "STRING",
-              "value": "}"
-            }
-          ]
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },
-    "modifier": {
-      "type": "CHOICE",
+    "scalar_type_def": {
+      "type": "SEQ",
       "members": [
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "required"
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifier"
+              }
             },
             {
-              "type": "STRING",
-              "value": "optional"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "single"
-            },
-            {
-              "type": "STRING",
-              "value": "multi"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "abstract"
-            },
-            {
-              "type": "STRING",
-              "value": "delegated"
+              "type": "BLANK"
             }
           ]
         },
         {
           "type": "STRING",
-          "value": "inheritable"
-        }
-      ]
-    },
-    "argspec": {
-      "type": "SEQ",
-      "members": [
+          "value": "scalar"
+        },
+        {
+          "type": "STRING",
+          "value": "type"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "extending"
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "STRING",
-                  "value": ":"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_scalar_type"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ":"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_scalar_type"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "declarations"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
-    "subj_expr": {
-      "type": "STRING",
-      "value": "__subject__"
-    },
-    "constr_expr": {
-      "type": "STRING",
-      "value": "__subject__"
-    },
-    "val": {
-      "type": "CHOICE",
+    "link": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "str"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifier"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "STRING",
+          "value": "link"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "extending"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "->"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":="
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expr"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "declarations"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "property": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifier"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "property"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "extending"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "->"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":="
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expr"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "declarations"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
     "annotation": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_abstract_annotation"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_concrete_annotation"
-        }
-      ]
-    },
-    "_concrete_annotation": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "annotation"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "STRING",
-          "value": ":="
-        },
-        {
-          "type": "SYMBOL",
-          "name": "val"
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        }
-      ]
-    },
-    "_abstract_annotation": {
       "type": "SEQ",
       "members": [
         {
@@ -365,8 +470,188 @@
           "value": "annotation"
         },
         {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "expr"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "annotation"
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "constraint": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "constraint"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argspec"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "on"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "except"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "extending"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "using"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "computed"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "index": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "index"
+        },
+        {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "on"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "except"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -402,39 +687,64 @@
         }
       ]
     },
-    "property": {
+    "alias": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "modifier"
-              }
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "expr"
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "using"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expr"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                }
+              ]
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "property"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "STRING",
-          "value": "->"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "type"
         },
         {
           "type": "STRING",
@@ -442,68 +752,24 @@
         }
       ]
     },
-    "link": {
+    "function": {
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "modifier"
-              }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "STRING",
+          "value": "function"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
         },
         {
           "type": "STRING",
-          "value": "link"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "STRING",
-          "value": "->"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        }
-      ]
-    },
-    "contraint": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "modifier"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "contraint"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "value": "("
         },
         {
           "type": "CHOICE",
@@ -518,18 +784,47 @@
           ]
         },
         {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "returnspec"
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": "on"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "using"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "edgedb"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "subj_expr"
+                  "name": "uselang"
                 }
               ]
             },
@@ -542,8 +837,41 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "extends"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "computed"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "using"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "uselang"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -551,55 +879,385 @@
           ]
         },
         {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "extension": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "using"
+        },
+        {
+          "type": "STRING",
+          "value": "extension"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "extending": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "extending"
+        },
+        {
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "{"
-            },
-            {
-              "type": "REPEAT",
+              "type": "FIELD",
+              "name": "supertype",
               "content": {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "using"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "constr_expr"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "enum"
                   },
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "errmessage"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ":="
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "str"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "type"
                   }
                 ]
               }
             },
             {
-              "type": "STRING",
-              "value": "}"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "supertype",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "enum"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "type"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
             }
           ]
+        }
+      ]
+    },
+    "using": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "using"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "uselang": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "using"
+        },
+        {
+          "type": "FIELD",
+          "name": "language",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+    "on": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "on"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "except": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "except"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "computed": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expr"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "abstract"
+        },
+        {
+          "type": "STRING",
+          "value": "overloaded"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "required"
+            },
+            {
+              "type": "STRING",
+              "value": "optional"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "single"
+            },
+            {
+              "type": "STRING",
+              "value": "multi"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "inheritable"
+        }
+      ]
+    },
+    "argspec": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_scalar_type"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ":"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_scalar_type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "returnspec": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "set of"
+                },
+                {
+                  "type": "STRING",
+                  "value": "optional"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "str"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
         }
       ]
     },
@@ -833,124 +1491,6 @@
         {
           "type": "STRING",
           "value": ">"
-        }
-      ]
-    },
-    "scalar_type_def": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "modifier"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "scalar type"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "extending"
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "FIELD",
-                      "name": "supertype",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "enum"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "type"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "FIELD",
-                            "name": "supertype",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "enum"
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "type"
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "{"
-                },
-                {
-                  "type": "STRING",
-                  "value": "TODO"
-                },
-                {
-                  "type": "STRING",
-                  "value": "}"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,26 +1,59 @@
 [
   {
+    "type": "alias",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "annotation",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "annotation",
           "named": true
         },
         {
-          "type": "identifier",
+          "type": "expr",
           "named": true
         },
         {
           "type": "modifier",
-          "named": true
-        },
-        {
-          "type": "val",
           "named": true
         }
       ]
@@ -57,9 +90,84 @@
     }
   },
   {
-    "type": "constr_expr",
+    "type": "computed",
     "named": true,
-    "fields": {}
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constraint",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "argspec",
+          "named": true
+        },
+        {
+          "type": "computed",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "extending",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "on",
+          "named": true
+        },
+        {
+          "type": "using",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "declarations",
@@ -69,6 +177,18 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "index",
+          "named": true
+        },
         {
           "type": "link",
           "named": true
@@ -96,7 +216,107 @@
     }
   },
   {
-    "type": "extends",
+    "type": "except",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "str",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extending",
+    "named": true,
+    "fields": {
+      "supertype": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "enum",
+            "named": true
+          },
+          {
+            "type": "type",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "argspec",
+          "named": true
+        },
+        {
+          "type": "computed",
+          "named": true
+        },
+        {
+          "type": "returnspec",
+          "named": true
+        },
+        {
+          "type": "uselang",
+          "named": true
+        },
+        {
+          "type": "using",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "index",
     "named": true,
     "fields": {},
     "children": {
@@ -104,7 +324,15 @@
       "required": true,
       "types": [
         {
-          "type": "identifier",
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "on",
           "named": true
         }
       ]
@@ -113,17 +341,40 @@
   {
     "type": "link",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "identifier",
+          "type": "declarations",
+          "named": true
+        },
+        {
+          "type": "expr",
+          "named": true
+        },
+        {
+          "type": "extending",
           "named": true
         },
         {
           "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "type",
           "named": true
         }
       ]
@@ -163,7 +414,18 @@
   {
     "type": "object_type",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -173,11 +435,7 @@
           "named": true
         },
         {
-          "type": "extends",
-          "named": true
-        },
-        {
-          "type": "identifier",
+          "type": "extending",
           "named": true
         },
         {
@@ -188,15 +446,49 @@
     }
   },
   {
-    "type": "property",
+    "type": "on",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "identifier",
+          "type": "expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "property",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "declarations",
+          "named": true
+        },
+        {
+          "type": "expr",
+          "named": true
+        },
+        {
+          "type": "extending",
           "named": true
         },
         {
@@ -211,6 +503,55 @@
     }
   },
   {
+    "type": "returnspec",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "scalar_type_def",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "declarations",
+          "named": true
+        },
+        {
+          "type": "extending",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "schema_declarations",
     "named": true,
     "fields": {},
@@ -219,7 +560,35 @@
       "required": false,
       "types": [
         {
+          "type": "alias",
+          "named": true
+        },
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "function",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
           "type": "object_type",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        },
+        {
+          "type": "scalar_type_def",
           "named": true
         }
       ]
@@ -239,11 +608,6 @@
         }
       ]
     }
-  },
-  {
-    "type": "subj_expr",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "tuple",
@@ -288,7 +652,23 @@
     }
   },
   {
-    "type": "val",
+    "type": "uselang",
+    "named": true,
+    "fields": {
+      "language": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "using",
     "named": true,
     "fields": {},
     "children": {
@@ -296,15 +676,19 @@
       "required": true,
       "types": [
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "str",
+          "type": "expr",
           "named": true
         }
       ]
     }
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
   },
   {
     "type": ",",
@@ -335,15 +719,11 @@
     "named": false
   },
   {
-    "type": "TODO",
-    "named": false
-  },
-  {
-    "type": "__subject__",
-    "named": false
-  },
-  {
     "type": "abstract",
+    "named": false
+  },
+  {
+    "type": "alias",
     "named": false
   },
   {
@@ -391,7 +771,7 @@
     "named": true
   },
   {
-    "type": "contraint",
+    "type": "constraint",
     "named": false
   },
   {
@@ -403,11 +783,11 @@
     "named": false
   },
   {
-    "type": "delegated",
+    "type": "duration",
     "named": false
   },
   {
-    "type": "duration",
+    "type": "edgedb",
     "named": false
   },
   {
@@ -415,11 +795,15 @@
     "named": false
   },
   {
-    "type": "errmessage",
+    "type": "except",
     "named": false
   },
   {
     "type": "extending",
+    "named": false
+  },
+  {
+    "type": "extension",
     "named": false
   },
   {
@@ -431,8 +815,16 @@
     "named": false
   },
   {
+    "type": "function",
+    "named": false
+  },
+  {
     "type": "identifier",
     "named": true
+  },
+  {
+    "type": "index",
+    "named": false
   },
   {
     "type": "inheritable",
@@ -475,6 +867,10 @@
     "named": false
   },
   {
+    "type": "overloaded",
+    "named": false
+  },
+  {
     "type": "property",
     "named": false
   },
@@ -483,11 +879,19 @@
     "named": false
   },
   {
+    "type": "scalar",
+    "named": false
+  },
+  {
     "type": "scalar type",
     "named": false
   },
   {
     "type": "sequence",
+    "named": false
+  },
+  {
+    "type": "set of",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -19,7 +19,7 @@
       "required": true,
       "types": [
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         }
       ]
@@ -49,7 +49,7 @@
           "named": true
         },
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         },
         {
@@ -67,6 +67,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
         {
           "type": "identifier",
           "named": true
@@ -90,6 +94,110 @@
     }
   },
   {
+    "type": "binary_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "!=",
+            "named": false
+          },
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "&",
+            "named": false
+          },
+          {
+            "type": "&&",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<<",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": ">>",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          },
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "computed",
     "named": true,
     "fields": {
@@ -109,7 +217,7 @@
       "required": true,
       "types": [
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         }
       ]
@@ -224,14 +332,14 @@
       "required": true,
       "types": [
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "expr",
+    "type": "expression",
     "named": true,
     "fields": {},
     "children": {
@@ -239,11 +347,35 @@
       "required": true,
       "types": [
         {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "false",
+          "named": true
+        },
+        {
+          "type": "fncall",
+          "named": true
+        },
+        {
           "type": "identifier",
           "named": true
         },
         {
-          "type": "str",
+          "type": "null",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "true",
           "named": true
         }
       ]
@@ -267,6 +399,32 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "fncall",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -362,7 +520,7 @@
           "named": true
         },
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         },
         {
@@ -454,7 +612,7 @@
       "required": true,
       "types": [
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         }
       ]
@@ -484,7 +642,7 @@
           "named": true
         },
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         },
         {
@@ -610,6 +768,25 @@
     }
   },
   {
+    "type": "string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "string_fragment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "tuple",
     "named": true,
     "fields": {},
@@ -676,11 +853,31 @@
       "required": true,
       "types": [
         {
-          "type": "expr",
+          "type": "expression",
           "named": true
         }
       ]
     }
+  },
+  {
+    "type": "!=",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "&",
+    "named": false
+  },
+  {
+    "type": "&&",
+    "named": false
+  },
+  {
+    "type": "'",
+    "named": false
   },
   {
     "type": "(",
@@ -691,11 +888,27 @@
     "named": false
   },
   {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
     "type": ",",
     "named": false
   },
   {
+    "type": "-",
+    "named": false
+  },
+  {
     "type": "->",
+    "named": false
+  },
+  {
+    "type": "/",
     "named": false
   },
   {
@@ -715,7 +928,31 @@
     "named": false
   },
   {
+    "type": "<<",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
     "type": ">",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": ">>",
+    "named": false
+  },
+  {
+    "type": "^",
     "named": false
   },
   {
@@ -795,6 +1032,10 @@
     "named": false
   },
   {
+    "type": "escape_sequence",
+    "named": true
+  },
+  {
     "type": "except",
     "named": false
   },
@@ -807,6 +1048,10 @@
     "named": false
   },
   {
+    "type": "false",
+    "named": true
+  },
+  {
     "type": "float32",
     "named": false
   },
@@ -816,6 +1061,10 @@
   },
   {
     "type": "function",
+    "named": false
+  },
+  {
+    "type": "global",
     "named": false
   },
   {
@@ -857,6 +1106,10 @@
   {
     "type": "multi",
     "named": false
+  },
+  {
+    "type": "null",
+    "named": true
   },
   {
     "type": "on",
@@ -903,7 +1156,11 @@
     "named": false
   },
   {
-    "type": "str",
+    "type": "string_fragment",
+    "named": true
+  },
+  {
+    "type": "true",
     "named": true
   },
   {
@@ -924,6 +1181,14 @@
   },
   {
     "type": "{",
+    "named": false
+  },
+  {
+    "type": "|",
+    "named": false
+  },
+  {
+    "type": "||",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -65,7 +65,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "expression",
@@ -371,6 +371,10 @@
           "named": true
         },
         {
+          "type": "number",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -460,10 +464,6 @@
         },
         {
           "type": "returnspec",
-          "named": true
-        },
-        {
-          "type": "uselang",
           "named": true
         },
         {
@@ -829,12 +829,12 @@
     }
   },
   {
-    "type": "uselang",
+    "type": "using",
     "named": true,
     "fields": {
       "language": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "identifier",
@@ -842,18 +842,17 @@
           }
         ]
       }
-    }
-  },
-  {
-    "type": "using",
-    "named": true,
-    "fields": {},
+    },
     "children": {
       "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "expression",
+          "type": "edgeql_fragment",
+          "named": true
+        },
+        {
+          "type": "string",
           "named": true
         }
       ]
@@ -1024,8 +1023,8 @@
     "named": false
   },
   {
-    "type": "edgedb",
-    "named": false
+    "type": "edgeql_fragment",
+    "named": true
   },
   {
     "type": "enum",
@@ -1109,6 +1108,10 @@
   },
   {
     "type": "null",
+    "named": true
+  },
+  {
+    "type": "number",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -14,15 +14,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 394
+#define STATE_COUNT 426
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 109
+#define SYMBOL_COUNT 133
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 67
+#define TOKEN_COUNT 86
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 3
+#define FIELD_COUNT 6
 #define MAX_ALIAS_SEQUENCE_LENGTH 15
-#define PRODUCTION_ID_COUNT 9
+#define PRODUCTION_ID_COUNT 10
 
 enum {
   anon_sym_module = 1,
@@ -58,81 +58,105 @@ enum {
   anon_sym_inheritable = 31,
   anon_sym_COLON = 32,
   anon_sym_setof = 33,
-  sym_str = 34,
-  anon_sym_str = 35,
-  anon_sym_bool = 36,
-  anon_sym_int16 = 37,
-  anon_sym_int32 = 38,
-  anon_sym_int64 = 39,
-  anon_sym_float32 = 40,
-  anon_sym_float64 = 41,
-  anon_sym_bigint = 42,
-  anon_sym_decimal = 43,
-  anon_sym_json = 44,
-  anon_sym_uuid = 45,
-  anon_sym_bytes = 46,
-  anon_sym_datetime = 47,
-  anon_sym_duration = 48,
-  anon_sym_cal_COLON_COLONlocal_datetime = 49,
-  anon_sym_cal_COLON_COLONlocal_date = 50,
-  anon_sym_cal_COLON_COLONlocal_time = 51,
-  anon_sym_cal_COLON_COLONrelative_duration = 52,
-  anon_sym_sequence = 53,
-  anon_sym_anytype = 54,
-  anon_sym_array = 55,
-  anon_sym_LT = 56,
-  anon_sym_GT = 57,
-  anon_sym_tuple = 58,
-  anon_sym_scalartype = 59,
-  anon_sym_enum = 60,
-  sym_identifier = 61,
-  sym_true = 62,
-  sym_false = 63,
-  sym_null = 64,
-  sym_comment = 65,
-  sym__whitespace = 66,
-  sym_source_file = 67,
-  sym_module = 68,
-  sym_schema_declarations = 69,
-  sym_object_type = 70,
-  sym_declarations = 71,
-  sym_scalar_type_def = 72,
-  sym_link = 73,
-  sym_property = 74,
-  sym_annotation = 75,
-  sym_constraint = 76,
-  sym_index = 77,
-  sym_alias = 78,
-  sym_function = 79,
-  sym_extending = 80,
-  sym_using = 81,
-  sym_uselang = 82,
-  sym_on = 83,
-  sym_except = 84,
-  sym_computed = 85,
-  sym_modifier = 86,
-  sym_argspec = 87,
-  sym_returnspec = 88,
-  sym_expr = 89,
-  sym__scalar_type = 90,
-  sym_array = 91,
-  sym_tuple = 92,
-  sym__tuple = 93,
-  sym__named_tuple = 94,
-  sym_enum = 95,
-  sym_type = 96,
-  aux_sym_source_file_repeat1 = 97,
-  aux_sym_schema_declarations_repeat1 = 98,
-  aux_sym_declarations_repeat1 = 99,
-  aux_sym_scalar_type_def_repeat1 = 100,
-  aux_sym_annotation_repeat1 = 101,
-  aux_sym_constraint_repeat1 = 102,
-  aux_sym_function_repeat1 = 103,
-  aux_sym_extending_repeat1 = 104,
-  aux_sym_argspec_repeat1 = 105,
-  aux_sym__tuple_repeat1 = 106,
-  aux_sym__named_tuple_repeat1 = 107,
-  aux_sym_enum_repeat1 = 108,
+  anon_sym_global = 34,
+  anon_sym_AMP_AMP = 35,
+  anon_sym_PIPE_PIPE = 36,
+  anon_sym_GT_GT = 37,
+  anon_sym_LT_LT = 38,
+  anon_sym_AMP = 39,
+  anon_sym_CARET = 40,
+  anon_sym_PIPE = 41,
+  anon_sym_PLUS = 42,
+  anon_sym_DASH = 43,
+  anon_sym_STAR = 44,
+  anon_sym_SLASH = 45,
+  anon_sym_PERCENT = 46,
+  anon_sym_LT = 47,
+  anon_sym_LT_EQ = 48,
+  anon_sym_EQ = 49,
+  anon_sym_BANG_EQ = 50,
+  anon_sym_GT_EQ = 51,
+  anon_sym_GT = 52,
+  anon_sym_SQUOTE = 53,
+  sym_unescaped_single_string_fragment = 54,
+  sym_escape_sequence = 55,
+  anon_sym_str = 56,
+  anon_sym_bool = 57,
+  anon_sym_int16 = 58,
+  anon_sym_int32 = 59,
+  anon_sym_int64 = 60,
+  anon_sym_float32 = 61,
+  anon_sym_float64 = 62,
+  anon_sym_bigint = 63,
+  anon_sym_decimal = 64,
+  anon_sym_json = 65,
+  anon_sym_uuid = 66,
+  anon_sym_bytes = 67,
+  anon_sym_datetime = 68,
+  anon_sym_duration = 69,
+  anon_sym_cal_COLON_COLONlocal_datetime = 70,
+  anon_sym_cal_COLON_COLONlocal_date = 71,
+  anon_sym_cal_COLON_COLONlocal_time = 72,
+  anon_sym_cal_COLON_COLONrelative_duration = 73,
+  anon_sym_sequence = 74,
+  anon_sym_anytype = 75,
+  anon_sym_array = 76,
+  anon_sym_tuple = 77,
+  anon_sym_scalartype = 78,
+  anon_sym_enum = 79,
+  sym_identifier = 80,
+  sym_true = 81,
+  sym_false = 82,
+  sym_null = 83,
+  sym_comment = 84,
+  sym__whitespace = 85,
+  sym_source_file = 86,
+  sym_module = 87,
+  sym_schema_declarations = 88,
+  sym_object_type = 89,
+  sym_declarations = 90,
+  sym_scalar_type_def = 91,
+  sym_link = 92,
+  sym_property = 93,
+  sym_annotation = 94,
+  sym_constraint = 95,
+  sym_index = 96,
+  sym_alias = 97,
+  sym_function = 98,
+  sym_extending = 99,
+  sym_using = 100,
+  sym_uselang = 101,
+  sym_on = 102,
+  sym_except = 103,
+  sym_computed = 104,
+  sym_modifier = 105,
+  sym_argspec = 106,
+  sym_returnspec = 107,
+  sym_expression = 108,
+  sym_fncall = 109,
+  sym_binary_expression = 110,
+  sym_string = 111,
+  sym__scalar_type = 112,
+  sym_array = 113,
+  sym_tuple = 114,
+  sym__tuple = 115,
+  sym__named_tuple = 116,
+  sym_enum = 117,
+  sym_type = 118,
+  aux_sym_source_file_repeat1 = 119,
+  aux_sym_schema_declarations_repeat1 = 120,
+  aux_sym_declarations_repeat1 = 121,
+  aux_sym_scalar_type_def_repeat1 = 122,
+  aux_sym_annotation_repeat1 = 123,
+  aux_sym_constraint_repeat1 = 124,
+  aux_sym_function_repeat1 = 125,
+  aux_sym_extending_repeat1 = 126,
+  aux_sym_argspec_repeat1 = 127,
+  aux_sym_fncall_repeat1 = 128,
+  aux_sym_string_repeat1 = 129,
+  aux_sym__tuple_repeat1 = 130,
+  aux_sym__named_tuple_repeat1 = 131,
+  aux_sym_enum_repeat1 = 132,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -170,7 +194,28 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_inheritable] = "inheritable",
   [anon_sym_COLON] = ":",
   [anon_sym_setof] = "set of",
-  [sym_str] = "str",
+  [anon_sym_global] = "global",
+  [anon_sym_AMP_AMP] = "&&",
+  [anon_sym_PIPE_PIPE] = "||",
+  [anon_sym_GT_GT] = ">>",
+  [anon_sym_LT_LT] = "<<",
+  [anon_sym_AMP] = "&",
+  [anon_sym_CARET] = "^",
+  [anon_sym_PIPE] = "|",
+  [anon_sym_PLUS] = "+",
+  [anon_sym_DASH] = "-",
+  [anon_sym_STAR] = "*",
+  [anon_sym_SLASH] = "/",
+  [anon_sym_PERCENT] = "%",
+  [anon_sym_LT] = "<",
+  [anon_sym_LT_EQ] = "<=",
+  [anon_sym_EQ] = "=",
+  [anon_sym_BANG_EQ] = "!=",
+  [anon_sym_GT_EQ] = ">=",
+  [anon_sym_GT] = ">",
+  [anon_sym_SQUOTE] = "'",
+  [sym_unescaped_single_string_fragment] = "string_fragment",
+  [sym_escape_sequence] = "escape_sequence",
   [anon_sym_str] = "str",
   [anon_sym_bool] = "bool",
   [anon_sym_int16] = "int16",
@@ -192,8 +237,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_sequence] = "sequence",
   [anon_sym_anytype] = "anytype",
   [anon_sym_array] = "array",
-  [anon_sym_LT] = "<",
-  [anon_sym_GT] = ">",
   [anon_sym_tuple] = "tuple",
   [anon_sym_scalartype] = "scalar type",
   [anon_sym_enum] = "enum",
@@ -225,7 +268,10 @@ static const char * const ts_symbol_names[] = {
   [sym_modifier] = "modifier",
   [sym_argspec] = "argspec",
   [sym_returnspec] = "returnspec",
-  [sym_expr] = "expr",
+  [sym_expression] = "expression",
+  [sym_fncall] = "fncall",
+  [sym_binary_expression] = "binary_expression",
+  [sym_string] = "string",
   [sym__scalar_type] = "_scalar_type",
   [sym_array] = "array",
   [sym_tuple] = "tuple",
@@ -242,6 +288,8 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_function_repeat1] = "function_repeat1",
   [aux_sym_extending_repeat1] = "extending_repeat1",
   [aux_sym_argspec_repeat1] = "argspec_repeat1",
+  [aux_sym_fncall_repeat1] = "fncall_repeat1",
+  [aux_sym_string_repeat1] = "string_repeat1",
   [aux_sym__tuple_repeat1] = "_tuple_repeat1",
   [aux_sym__named_tuple_repeat1] = "_named_tuple_repeat1",
   [aux_sym_enum_repeat1] = "enum_repeat1",
@@ -282,7 +330,28 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_inheritable] = anon_sym_inheritable,
   [anon_sym_COLON] = anon_sym_COLON,
   [anon_sym_setof] = anon_sym_setof,
-  [sym_str] = sym_str,
+  [anon_sym_global] = anon_sym_global,
+  [anon_sym_AMP_AMP] = anon_sym_AMP_AMP,
+  [anon_sym_PIPE_PIPE] = anon_sym_PIPE_PIPE,
+  [anon_sym_GT_GT] = anon_sym_GT_GT,
+  [anon_sym_LT_LT] = anon_sym_LT_LT,
+  [anon_sym_AMP] = anon_sym_AMP,
+  [anon_sym_CARET] = anon_sym_CARET,
+  [anon_sym_PIPE] = anon_sym_PIPE,
+  [anon_sym_PLUS] = anon_sym_PLUS,
+  [anon_sym_DASH] = anon_sym_DASH,
+  [anon_sym_STAR] = anon_sym_STAR,
+  [anon_sym_SLASH] = anon_sym_SLASH,
+  [anon_sym_PERCENT] = anon_sym_PERCENT,
+  [anon_sym_LT] = anon_sym_LT,
+  [anon_sym_LT_EQ] = anon_sym_LT_EQ,
+  [anon_sym_EQ] = anon_sym_EQ,
+  [anon_sym_BANG_EQ] = anon_sym_BANG_EQ,
+  [anon_sym_GT_EQ] = anon_sym_GT_EQ,
+  [anon_sym_GT] = anon_sym_GT,
+  [anon_sym_SQUOTE] = anon_sym_SQUOTE,
+  [sym_unescaped_single_string_fragment] = sym_unescaped_single_string_fragment,
+  [sym_escape_sequence] = sym_escape_sequence,
   [anon_sym_str] = anon_sym_str,
   [anon_sym_bool] = anon_sym_bool,
   [anon_sym_int16] = anon_sym_int16,
@@ -304,8 +373,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_sequence] = anon_sym_sequence,
   [anon_sym_anytype] = anon_sym_anytype,
   [anon_sym_array] = anon_sym_array,
-  [anon_sym_LT] = anon_sym_LT,
-  [anon_sym_GT] = anon_sym_GT,
   [anon_sym_tuple] = anon_sym_tuple,
   [anon_sym_scalartype] = anon_sym_scalartype,
   [anon_sym_enum] = anon_sym_enum,
@@ -337,7 +404,10 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_modifier] = sym_modifier,
   [sym_argspec] = sym_argspec,
   [sym_returnspec] = sym_returnspec,
-  [sym_expr] = sym_expr,
+  [sym_expression] = sym_expression,
+  [sym_fncall] = sym_fncall,
+  [sym_binary_expression] = sym_binary_expression,
+  [sym_string] = sym_string,
   [sym__scalar_type] = sym__scalar_type,
   [sym_array] = sym_array,
   [sym_tuple] = sym_tuple,
@@ -354,6 +424,8 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_function_repeat1] = aux_sym_function_repeat1,
   [aux_sym_extending_repeat1] = aux_sym_extending_repeat1,
   [aux_sym_argspec_repeat1] = aux_sym_argspec_repeat1,
+  [aux_sym_fncall_repeat1] = aux_sym_fncall_repeat1,
+  [aux_sym_string_repeat1] = aux_sym_string_repeat1,
   [aux_sym__tuple_repeat1] = aux_sym__tuple_repeat1,
   [aux_sym__named_tuple_repeat1] = aux_sym__named_tuple_repeat1,
   [aux_sym_enum_repeat1] = aux_sym_enum_repeat1,
@@ -496,7 +568,91 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [sym_str] = {
+  [anon_sym_global] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AMP_AMP] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PIPE_PIPE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_GT_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LT_LT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AMP] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_CARET] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PIPE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PLUS] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_STAR] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_SLASH] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PERCENT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LT_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_BANG_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_GT_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_SQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_unescaped_single_string_fragment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_escape_sequence] = {
     .visible = true,
     .named = true,
   },
@@ -581,14 +737,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_array] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_LT] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_GT] = {
     .visible = true,
     .named = false,
   },
@@ -716,7 +864,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_expr] = {
+  [sym_expression] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_fncall] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_binary_expression] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_string] = {
     .visible = true,
     .named = true,
   },
@@ -784,6 +944,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_fncall_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_string_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym__tuple_repeat1] = {
     .visible = false,
     .named = false,
@@ -800,14 +968,20 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
 
 enum {
   field_language = 1,
-  field_name = 2,
-  field_supertype = 3,
+  field_left = 2,
+  field_name = 3,
+  field_operator = 4,
+  field_right = 5,
+  field_supertype = 6,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_language] = "language",
+  [field_left] = "left",
   [field_name] = "name",
+  [field_operator] = "operator",
+  [field_right] = "right",
   [field_supertype] = "supertype",
 };
 
@@ -819,7 +993,8 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [5] = {.index = 4, .length = 2},
   [6] = {.index = 6, .length = 2},
   [7] = {.index = 8, .length = 1},
-  [8] = {.index = 9, .length = 1},
+  [8] = {.index = 9, .length = 3},
+  [9] = {.index = 12, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -840,6 +1015,10 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
   [8] =
     {field_name, 0},
   [9] =
+    {field_left, 0},
+    {field_operator, 1},
+    {field_right, 2},
+  [12] =
     {field_language, 1},
 };
 
@@ -949,9 +1128,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [94] = 94,
   [95] = 95,
   [96] = 96,
-  [97] = 97,
+  [97] = 89,
   [98] = 98,
-  [99] = 99,
+  [99] = 98,
   [100] = 100,
   [101] = 101,
   [102] = 102,
@@ -1035,9 +1214,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [180] = 180,
   [181] = 181,
   [182] = 182,
-  [183] = 182,
+  [183] = 183,
   [184] = 184,
-  [185] = 181,
+  [185] = 185,
   [186] = 186,
   [187] = 187,
   [188] = 188,
@@ -1046,30 +1225,30 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [191] = 191,
   [192] = 192,
   [193] = 193,
-  [194] = 193,
+  [194] = 194,
   [195] = 195,
   [196] = 196,
   [197] = 197,
-  [198] = 196,
+  [198] = 198,
   [199] = 199,
   [200] = 200,
   [201] = 201,
   [202] = 202,
   [203] = 203,
   [204] = 204,
-  [205] = 75,
-  [206] = 64,
-  [207] = 69,
+  [205] = 205,
+  [206] = 206,
+  [207] = 207,
   [208] = 208,
-  [209] = 83,
-  [210] = 98,
-  [211] = 68,
+  [209] = 209,
+  [210] = 210,
+  [211] = 211,
   [212] = 212,
-  [213] = 213,
+  [213] = 212,
   [214] = 214,
   [215] = 215,
-  [216] = 216,
-  [217] = 214,
+  [216] = 214,
+  [217] = 217,
   [218] = 218,
   [219] = 219,
   [220] = 220,
@@ -1079,8 +1258,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [224] = 224,
   [225] = 225,
   [226] = 226,
-  [227] = 227,
-  [228] = 228,
+  [227] = 226,
+  [228] = 224,
   [229] = 229,
   [230] = 230,
   [231] = 231,
@@ -1089,7 +1268,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [234] = 234,
   [235] = 235,
   [236] = 236,
-  [237] = 237,
+  [237] = 113,
   [238] = 238,
   [239] = 239,
   [240] = 240,
@@ -1104,37 +1283,37 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [249] = 249,
   [250] = 250,
   [251] = 251,
-  [252] = 252,
+  [252] = 119,
   [253] = 253,
-  [254] = 254,
+  [254] = 240,
   [255] = 255,
   [256] = 256,
   [257] = 257,
   [258] = 258,
   [259] = 259,
-  [260] = 260,
-  [261] = 261,
+  [260] = 109,
+  [261] = 134,
   [262] = 262,
-  [263] = 263,
+  [263] = 116,
   [264] = 264,
   [265] = 265,
   [266] = 266,
   [267] = 267,
   [268] = 268,
   [269] = 269,
-  [270] = 270,
+  [270] = 249,
   [271] = 271,
   [272] = 272,
   [273] = 273,
   [274] = 274,
-  [275] = 272,
+  [275] = 275,
   [276] = 276,
-  [277] = 277,
+  [277] = 132,
   [278] = 278,
   [279] = 279,
   [280] = 280,
-  [281] = 273,
-  [282] = 282,
+  [281] = 281,
+  [282] = 280,
   [283] = 283,
   [284] = 284,
   [285] = 285,
@@ -1238,194 +1417,341 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [383] = 383,
   [384] = 384,
   [385] = 385,
-  [386] = 336,
+  [386] = 386,
   [387] = 387,
-  [388] = 385,
-  [389] = 334,
-  [390] = 318,
+  [388] = 388,
+  [389] = 389,
+  [390] = 390,
   [391] = 391,
   [392] = 392,
   [393] = 393,
+  [394] = 394,
+  [395] = 395,
+  [396] = 396,
+  [397] = 397,
+  [398] = 398,
+  [399] = 399,
+  [400] = 400,
+  [401] = 401,
+  [402] = 402,
+  [403] = 403,
+  [404] = 404,
+  [405] = 405,
+  [406] = 406,
+  [407] = 407,
+  [408] = 408,
+  [409] = 409,
+  [410] = 410,
+  [411] = 411,
+  [412] = 412,
+  [413] = 413,
+  [414] = 414,
+  [415] = 415,
+  [416] = 416,
+  [417] = 417,
+  [418] = 418,
+  [419] = 419,
+  [420] = 420,
+  [421] = 360,
+  [422] = 385,
+  [423] = 423,
+  [424] = 424,
+  [425] = 425,
 };
+
+static inline bool sym_identifier_character_set_1(int32_t c) {
+  return (c < 160
+    ? (c < '['
+      ? (c < 0
+        ? c == 0
+        : (c <= '"' || (c >= '%' && c <= '@')))
+      : (c <= '^' || (c < '{'
+        ? c == '`'
+        : c <= '~')))
+    : (c <= 160 || (c < 8287
+      ? (c < 8192
+        ? c == 5760
+        : (c <= 8203 || c == 8239))
+      : (c <= 8288 || (c < 65279
+        ? c == 12288
+        : c <= 65279)))));
+}
+
+static inline bool sym_identifier_character_set_2(int32_t c) {
+  return (c < 160
+    ? (c < '['
+      ? (c < 0
+        ? c == 0
+        : (c <= '"' || (c >= '%' && c <= '@')))
+      : (c <= '^' || (c < '|'
+        ? c == '`'
+        : c <= '~')))
+    : (c <= 160 || (c < 8287
+      ? (c < 8192
+        ? c == 5760
+        : (c <= 8203 || c == 8239))
+      : (c <= 8288 || (c < 65279
+        ? c == 12288
+        : c <= 65279)))));
+}
+
+static inline bool sym_identifier_character_set_3(int32_t c) {
+  return (c < 160
+    ? (c < '['
+      ? (c < 0
+        ? c == 0
+        : (c <= '#' || (c >= '%' && c <= '@')))
+      : (c <= '^' || (c < '{'
+        ? c == '`'
+        : c <= '~')))
+    : (c <= 160 || (c < 8287
+      ? (c < 8192
+        ? c == 5760
+        : (c <= 8203 || c == 8239))
+      : (c <= 8288 || (c < 65279
+        ? c == 12288
+        : c <= 65279)))));
+}
+
+static inline bool sym_identifier_character_set_4(int32_t c) {
+  return (c < 160
+    ? (c < ':'
+      ? (c < 0
+        ? c == 0
+        : (c <= '#' || (c >= '%' && c <= '/')))
+      : (c <= '@' || (c < '`'
+        ? (c >= '[' && c <= '^')
+        : (c <= '`' || (c >= '{' && c <= '~')))))
+    : (c <= 160 || (c < 8287
+      ? (c < 8192
+        ? c == 5760
+        : (c <= 8203 || c == 8239))
+      : (c <= 8288 || (c < 65279
+        ? c == 12288
+        : c <= 65279)))));
+}
+
+static inline bool sym_identifier_character_set_5(int32_t c) {
+  return (c < 160
+    ? (c < ';'
+      ? (c < 0
+        ? c == 0
+        : (c <= '#' || (c >= '%' && c <= '/')))
+      : (c <= '@' || (c < '`'
+        ? (c >= '[' && c <= '^')
+        : (c <= '`' || (c >= '{' && c <= '~')))))
+    : (c <= 160 || (c < 8287
+      ? (c < 8192
+        ? c == 5760
+        : (c <= 8203 || c == 8239))
+      : (c <= 8288 || (c < 65279
+        ? c == 12288
+        : c <= 65279)))));
+}
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(258);
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == '\'') ADVANCE(8);
-      if (lookahead == '(') ADVANCE(277);
-      if (lookahead == ')') ADVANCE(278);
-      if (lookahead == ',') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(19);
-      if (lookahead == ':') ADVANCE(300);
-      if (lookahead == ';') ADVANCE(267);
-      if (lookahead == '<') ADVANCE(341);
-      if (lookahead == '>') ADVANCE(342);
-      if (lookahead == 'a') ADVANCE(43);
-      if (lookahead == 'b') ADVANCE(103);
-      if (lookahead == 'c') ADVANCE(22);
-      if (lookahead == 'd') ADVANCE(35);
-      if (lookahead == 'e') ADVANCE(58);
-      if (lookahead == 'f') ADVANCE(23);
-      if (lookahead == 'i') ADVANCE(148);
-      if (lookahead == 'j') ADVANCE(211);
-      if (lookahead == 'l') ADVANCE(110);
-      if (lookahead == 'm') ADVANCE(171);
-      if (lookahead == 'n') ADVANCE(244);
-      if (lookahead == 'o') ADVANCE(149);
-      if (lookahead == 'p') ADVANCE(200);
-      if (lookahead == 'r') ADVANCE(67);
-      if (lookahead == 's') ADVANCE(46);
-      if (lookahead == 't') ADVANCE(198);
-      if (lookahead == 'u') ADVANCE(215);
-      if (lookahead == '{') ADVANCE(260);
-      if (lookahead == '}') ADVANCE(261);
+      if (eof) ADVANCE(254);
+      if (lookahead == '!') ADVANCE(329);
+      if (lookahead == '#') ADVANCE(317);
+      if (lookahead == '%') ADVANCE(494);
+      if (lookahead == '&') ADVANCE(319);
+      if (lookahead == '\'') ADVANCE(316);
+      if (lookahead == '(') ADVANCE(494);
+      if (lookahead == ')') ADVANCE(494);
+      if (lookahead == '*') ADVANCE(494);
+      if (lookahead == '+') ADVANCE(494);
+      if (lookahead == ',') ADVANCE(494);
+      if (lookahead == '-') ADVANCE(330);
+      if (lookahead == '/') ADVANCE(494);
+      if (lookahead == ':') ADVANCE(329);
+      if (lookahead == ';') ADVANCE(494);
+      if (lookahead == '<') ADVANCE(327);
+      if (lookahead == '=') ADVANCE(494);
+      if (lookahead == '>') ADVANCE(328);
+      if (lookahead == '\\') ADVANCE(225);
+      if (lookahead == '^') ADVANCE(494);
+      if (lookahead == 'a') ADVANCE(351);
+      if (lookahead == 'b') ADVANCE(391);
+      if (lookahead == 'c') ADVANCE(333);
+      if (lookahead == 'd') ADVANCE(345);
+      if (lookahead == 'e') ADVANCE(362);
+      if (lookahead == 'f') ADVANCE(335);
+      if (lookahead == 'g') ADVANCE(409);
+      if (lookahead == 'i') ADVANCE(422);
+      if (lookahead == 'j') ADVANCE(463);
+      if (lookahead == 'l') ADVANCE(397);
+      if (lookahead == 'm') ADVANCE(433);
+      if (lookahead == 'n') ADVANCE(483);
+      if (lookahead == 'o') ADVANCE(420);
+      if (lookahead == 'p') ADVANCE(454);
+      if (lookahead == 'r') ADVANCE(371);
+      if (lookahead == 's') ADVANCE(354);
+      if (lookahead == 't') ADVANCE(451);
+      if (lookahead == 'u') ADVANCE(465);
+      if (lookahead == '{') ADVANCE(494);
+      if (lookahead == '|') ADVANCE(493);
+      if (lookahead == '}') ADVANCE(494);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
+          lookahead == ' ') ADVANCE(494);
+      if (lookahead != 0) ADVANCE(494);
       END_STATE();
     case 1:
-      if (lookahead == ' ') ADVANCE(172);
+      if (lookahead == '#') ADVANCE(317);
+      if (lookahead == '\'') ADVANCE(316);
+      if (lookahead == '\\') ADVANCE(225);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(494);
+      if (lookahead != 0) ADVANCE(494);
       END_STATE();
     case 2:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == '\'') ADVANCE(8);
-      if (lookahead == '(') ADVANCE(277);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '\'') ADVANCE(316);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == ')') ADVANCE(274);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'f') ADVANCE(558);
+      if (lookahead == 'g') ADVANCE(619);
+      if (lookahead == 'n') ADVANCE(689);
+      if (lookahead == 't') ADVANCE(662);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == ')') ADVANCE(278);
-      if (lookahead == ',') ADVANCE(282);
-      if (lookahead == ':') ADVANCE(299);
-      if (lookahead == '>') ADVANCE(342);
-      if (lookahead == 'a') ADVANCE(426);
-      if (lookahead == 'b') ADVANCE(400);
-      if (lookahead == 'c') ADVANCE(358);
-      if (lookahead == 'd') ADVANCE(367);
-      if (lookahead == 'f') ADVANCE(417);
-      if (lookahead == 'i') ADVANCE(432);
-      if (lookahead == 'j') ADVANCE(462);
-      if (lookahead == 'o') ADVANCE(447);
-      if (lookahead == 's') ADVANCE(380);
-      if (lookahead == 't') ADVANCE(481);
-      if (lookahead == 'u') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == '\\') ADVANCE(231);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == ',') ADVANCE(282);
-      if (lookahead == '-') ADVANCE(19);
-      if (lookahead == ':') ADVANCE(18);
-      if (lookahead == ';') ADVANCE(267);
-      if (lookahead == '>') ADVANCE(342);
-      if (lookahead == 'a') ADVANCE(44);
-      if (lookahead == 'c') ADVANCE(173);
-      if (lookahead == 'e') ADVANCE(252);
-      if (lookahead == 'f') ADVANCE(242);
-      if (lookahead == 'i') ADVANCE(158);
-      if (lookahead == 'l') ADVANCE(110);
-      if (lookahead == 'm') ADVANCE(243);
-      if (lookahead == 'o') ADVANCE(187);
-      if (lookahead == 'p') ADVANCE(200);
-      if (lookahead == 'r') ADVANCE(67);
-      if (lookahead == 's') ADVANCE(47);
-      if (lookahead == 't') ADVANCE(255);
-      if (lookahead == 'u') ADVANCE(214);
-      if (lookahead == '{') ADVANCE(260);
-      if (lookahead == '}') ADVANCE(261);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == ',') ADVANCE(277);
+      if (lookahead == '-') ADVANCE(20);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(294);
+      if (lookahead == '>') ADVANCE(314);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(627);
+      if (lookahead == 'b') ADVANCE(596);
+      if (lookahead == 'c') ADVANCE(549);
+      if (lookahead == 'd') ADVANCE(560);
+      if (lookahead == 'f') ADVANCE(615);
+      if (lookahead == 'i') ADVANCE(633);
+      if (lookahead == 'j') ADVANCE(665);
+      if (lookahead == 'o') ADVANCE(649);
+      if (lookahead == 's') ADVANCE(574);
+      if (lookahead == 't') ADVANCE(685);
+      if (lookahead == 'u') ADVANCE(684);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == ':') ADVANCE(18);
-      if (lookahead == 'a') ADVANCE(426);
-      if (lookahead == 'b') ADVANCE(400);
-      if (lookahead == 'c') ADVANCE(358);
-      if (lookahead == 'd') ADVANCE(367);
-      if (lookahead == 'f') ADVANCE(417);
-      if (lookahead == 'i') ADVANCE(432);
-      if (lookahead == 'j') ADVANCE(462);
-      if (lookahead == 's') ADVANCE(375);
-      if (lookahead == 't') ADVANCE(481);
-      if (lookahead == 'u') ADVANCE(480);
-      if (lookahead == '{') ADVANCE(260);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == ',') ADVANCE(277);
+      if (lookahead == '-') ADVANCE(20);
+      if (lookahead == ':') ADVANCE(19);
+      if (lookahead == ';') ADVANCE(263);
+      if (lookahead == '>') ADVANCE(314);
+      if (lookahead == 'a') ADVANCE(44);
+      if (lookahead == 'c') ADVANCE(162);
+      if (lookahead == 'e') ADVANCE(236);
+      if (lookahead == 'f') ADVANCE(228);
+      if (lookahead == 'i') ADVANCE(147);
+      if (lookahead == 'l') ADVANCE(105);
+      if (lookahead == 'm') ADVANCE(227);
+      if (lookahead == 'o') ADVANCE(175);
+      if (lookahead == 'p') ADVANCE(186);
+      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == 's') ADVANCE(47);
+      if (lookahead == 't') ADVANCE(237);
+      if (lookahead == 'u') ADVANCE(198);
+      if (lookahead == '{') ADVANCE(256);
+      if (lookahead == '}') ADVANCE(257);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+          lookahead == ' ') ADVANCE(699);
       END_STATE();
     case 6:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == ';') ADVANCE(267);
-      if (lookahead == 'a') ADVANCE(370);
-      if (lookahead == 'i') ADVANCE(429);
-      if (lookahead == 'm') ADVANCE(483);
-      if (lookahead == 'o') ADVANCE(446);
-      if (lookahead == 'r') ADVANCE(394);
-      if (lookahead == 's') ADVANCE(409);
-      if (lookahead == 'u') ADVANCE(464);
-      if (lookahead == '{') ADVANCE(260);
-      if (lookahead == '}') ADVANCE(261);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(19);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(627);
+      if (lookahead == 'b') ADVANCE(596);
+      if (lookahead == 'c') ADVANCE(549);
+      if (lookahead == 'd') ADVANCE(560);
+      if (lookahead == 'f') ADVANCE(615);
+      if (lookahead == 'i') ADVANCE(633);
+      if (lookahead == 'j') ADVANCE(665);
+      if (lookahead == 's') ADVANCE(569);
+      if (lookahead == 't') ADVANCE(685);
+      if (lookahead == 'u') ADVANCE(684);
+      if (lookahead == '{') ADVANCE(256);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_2(lookahead)) ADVANCE(694);
       END_STATE();
     case 7:
-      if (lookahead == '#') ADVANCE(492);
-      if (lookahead == 'a') ADVANCE(426);
-      if (lookahead == 'b') ADVANCE(400);
-      if (lookahead == 'c') ADVANCE(358);
-      if (lookahead == 'd') ADVANCE(367);
-      if (lookahead == 'f') ADVANCE(417);
-      if (lookahead == 'i') ADVANCE(432);
-      if (lookahead == 'j') ADVANCE(462);
-      if (lookahead == 's') ADVANCE(385);
-      if (lookahead == 't') ADVANCE(481);
-      if (lookahead == 'u') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ';') ADVANCE(263);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(563);
+      if (lookahead == 'i') ADVANCE(630);
+      if (lookahead == 'm') ADVANCE(687);
+      if (lookahead == 'o') ADVANCE(648);
+      if (lookahead == 'r') ADVANCE(590);
+      if (lookahead == 's') ADVANCE(605);
+      if (lookahead == 'u') ADVANCE(668);
+      if (lookahead == '{') ADVANCE(256);
+      if (lookahead == '}') ADVANCE(257);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(493);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_2(lookahead)) ADVANCE(694);
       END_STATE();
     case 8:
-      if (lookahead == '\'') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(8);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(627);
+      if (lookahead == 'b') ADVANCE(596);
+      if (lookahead == 'c') ADVANCE(549);
+      if (lookahead == 'd') ADVANCE(560);
+      if (lookahead == 'f') ADVANCE(615);
+      if (lookahead == 'i') ADVANCE(633);
+      if (lookahead == 'j') ADVANCE(665);
+      if (lookahead == 's') ADVANCE(579);
+      if (lookahead == 't') ADVANCE(685);
+      if (lookahead == 'u') ADVANCE(684);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(699);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
       END_STATE();
     case 9:
       if (lookahead == '1') ADVANCE(15);
@@ -1433,2329 +1759,3477 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '6') ADVANCE(13);
       END_STATE();
     case 10:
-      if (lookahead == '2') ADVANCE(309);
+      if (lookahead == '2') ADVANCE(504);
       END_STATE();
     case 11:
-      if (lookahead == '2') ADVANCE(313);
+      if (lookahead == '2') ADVANCE(508);
       END_STATE();
     case 12:
       if (lookahead == '3') ADVANCE(11);
       if (lookahead == '6') ADVANCE(14);
       END_STATE();
     case 13:
-      if (lookahead == '4') ADVANCE(311);
+      if (lookahead == '4') ADVANCE(506);
       END_STATE();
     case 14:
-      if (lookahead == '4') ADVANCE(315);
+      if (lookahead == '4') ADVANCE(510);
       END_STATE();
     case 15:
-      if (lookahead == '6') ADVANCE(307);
+      if (lookahead == '6') ADVANCE(502);
       END_STATE();
     case 16:
-      if (lookahead == ':') ADVANCE(135);
+      if (lookahead == ':') ADVANCE(127);
       END_STATE();
     case 17:
       if (lookahead == ':') ADVANCE(16);
       END_STATE();
     case 18:
-      if (lookahead == '=') ADVANCE(266);
+      if (lookahead == '=') ADVANCE(312);
       END_STATE();
     case 19:
-      if (lookahead == '>') ADVANCE(265);
+      if (lookahead == '=') ADVANCE(262);
       END_STATE();
     case 20:
-      if (lookahead == '_') ADVANCE(62);
+      if (lookahead == '>') ADVANCE(261);
       END_STATE();
     case 21:
-      if (lookahead == '_') ADVANCE(59);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_3(lookahead)) ADVANCE(694);
       END_STATE();
     case 22:
-      if (lookahead == 'a') ADVANCE(126);
-      if (lookahead == 'o') ADVANCE(170);
+      if (lookahead == '_') ADVANCE(63);
       END_STATE();
     case 23:
-      if (lookahead == 'a') ADVANCE(132);
-      if (lookahead == 'l') ADVANCE(178);
-      if (lookahead == 'u') ADVANCE(159);
+      if (lookahead == '_') ADVANCE(60);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(253);
+      if (lookahead == 'a') ADVANCE(120);
+      if (lookahead == 'o') ADVANCE(159);
       END_STATE();
     case 25:
       if (lookahead == 'a') ADVANCE(45);
       END_STATE();
     case 26:
-      if (lookahead == 'a') ADVANCE(50);
+      if (lookahead == 'a') ADVANCE(194);
       END_STATE();
     case 27:
-      if (lookahead == 'a') ADVANCE(209);
+      if (lookahead == 'a') ADVANCE(50);
       END_STATE();
     case 28:
-      if (lookahead == 'a') ADVANCE(63);
+      if (lookahead == 'a') ADVANCE(126);
       END_STATE();
     case 29:
-      if (lookahead == 'a') ADVANCE(218);
+      if (lookahead == 'a') ADVANCE(64);
       END_STATE();
     case 30:
-      if (lookahead == 'a') ADVANCE(134);
+      if (lookahead == 'a') ADVANCE(201);
       END_STATE();
     case 31:
-      if (lookahead == 'a') ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(122);
       END_STATE();
     case 32:
-      if (lookahead == 'a') ADVANCE(129);
+      if (lookahead == 'a') ADVANCE(184);
       END_STATE();
     case 33:
-      if (lookahead == 'a') ADVANCE(130);
+      if (lookahead == 'a') ADVANCE(123);
       END_STATE();
     case 34:
-      if (lookahead == 'a') ADVANCE(131);
+      if (lookahead == 'a') ADVANCE(124);
       END_STATE();
     case 35:
-      if (lookahead == 'a') ADVANCE(225);
+      if (lookahead == 'a') ADVANCE(208);
       if (lookahead == 'e') ADVANCE(48);
-      if (lookahead == 'u') ADVANCE(201);
+      if (lookahead == 'u') ADVANCE(185);
       END_STATE();
     case 36:
-      if (lookahead == 'a') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(215);
       END_STATE();
     case 37:
-      if (lookahead == 'a') ADVANCE(229);
+      if (lookahead == 'a') ADVANCE(214);
       END_STATE();
     case 38:
-      if (lookahead == 'a') ADVANCE(116);
+      if (lookahead == 'a') ADVANCE(111);
       END_STATE();
     case 39:
-      if (lookahead == 'a') ADVANCE(236);
+      if (lookahead == 'a') ADVANCE(219);
       END_STATE();
     case 40:
-      if (lookahead == 'a') ADVANCE(238);
+      if (lookahead == 'a') ADVANCE(222);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(239);
+      if (lookahead == 'a') ADVANCE(223);
       END_STATE();
     case 42:
-      if (lookahead == 'b') ADVANCE(279);
+      if (lookahead == 'b') ADVANCE(275);
       END_STATE();
     case 43:
-      if (lookahead == 'b') ADVANCE(212);
-      if (lookahead == 'l') ADVANCE(107);
-      if (lookahead == 'n') ADVANCE(165);
-      if (lookahead == 'r') ADVANCE(199);
+      if (lookahead == 'b') ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(102);
+      if (lookahead == 'n') ADVANCE(155);
       END_STATE();
     case 44:
-      if (lookahead == 'b') ADVANCE(212);
-      if (lookahead == 'l') ADVANCE(107);
-      if (lookahead == 'n') ADVANCE(164);
+      if (lookahead == 'b') ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(102);
+      if (lookahead == 'n') ADVANCE(154);
       END_STATE();
     case 45:
-      if (lookahead == 'b') ADVANCE(139);
+      if (lookahead == 'b') ADVANCE(130);
       END_STATE();
     case 46:
-      if (lookahead == 'c') ADVANCE(30);
-      if (lookahead == 'e') ADVANCE(195);
-      if (lookahead == 'i') ADVANCE(160);
-      if (lookahead == 't') ADVANCE(196);
+      if (lookahead == 'c') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(182);
+      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 't') ADVANCE(183);
       END_STATE();
     case 47:
-      if (lookahead == 'c') ADVANCE(30);
-      if (lookahead == 'i') ADVANCE(160);
+      if (lookahead == 'c') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(149);
       END_STATE();
     case 48:
-      if (lookahead == 'c') ADVANCE(108);
+      if (lookahead == 'c') ADVANCE(103);
       END_STATE();
     case 49:
-      if (lookahead == 'c') ADVANCE(86);
-      if (lookahead == 't') ADVANCE(92);
+      if (lookahead == 'c') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(89);
       END_STATE();
     case 50:
-      if (lookahead == 'c') ADVANCE(221);
+      if (lookahead == 'c') ADVANCE(204);
       END_STATE();
     case 51:
-      if (lookahead == 'c') ADVANCE(77);
+      if (lookahead == 'c') ADVANCE(73);
       END_STATE();
     case 52:
       if (lookahead == 'c') ADVANCE(34);
       END_STATE();
     case 53:
-      if (lookahead == 'c') ADVANCE(237);
+      if (lookahead == 'c') ADVANCE(221);
       END_STATE();
     case 54:
-      if (lookahead == 'd') ADVANCE(323);
+      if (lookahead == 'd') ADVANCE(518);
       END_STATE();
     case 55:
       if (lookahead == 'd') ADVANCE(42);
       END_STATE();
     case 56:
-      if (lookahead == 'd') ADVANCE(289);
+      if (lookahead == 'd') ADVANCE(284);
       END_STATE();
     case 57:
-      if (lookahead == 'd') ADVANCE(287);
+      if (lookahead == 'd') ADVANCE(282);
       END_STATE();
     case 58:
-      if (lookahead == 'd') ADVANCE(100);
-      if (lookahead == 'n') ADVANCE(241);
+      if (lookahead == 'd') ADVANCE(95);
+      if (lookahead == 'n') ADVANCE(226);
       if (lookahead == 'x') ADVANCE(49);
       END_STATE();
     case 59:
-      if (lookahead == 'd') ADVANCE(249);
+      if (lookahead == 'd') ADVANCE(229);
       END_STATE();
     case 60:
-      if (lookahead == 'd') ADVANCE(68);
-      if (lookahead == 'h') ADVANCE(88);
+      if (lookahead == 'd') ADVANCE(233);
       END_STATE();
     case 61:
-      if (lookahead == 'd') ADVANCE(68);
-      if (lookahead == 'h') ADVANCE(88);
-      if (lookahead == 't') ADVANCE(9);
+      if (lookahead == 'd') ADVANCE(67);
+      if (lookahead == 'h') ADVANCE(84);
       END_STATE();
     case 62:
-      if (lookahead == 'd') ADVANCE(36);
-      if (lookahead == 't') ADVANCE(118);
+      if (lookahead == 'd') ADVANCE(67);
+      if (lookahead == 'h') ADVANCE(84);
+      if (lookahead == 't') ADVANCE(9);
       END_STATE();
     case 63:
-      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == 'd') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(113);
       END_STATE();
     case 64:
-      if (lookahead == 'd') ADVANCE(248);
+      if (lookahead == 'd') ADVANCE(87);
       END_STATE();
     case 65:
-      if (lookahead == 'd') ADVANCE(115);
+      if (lookahead == 'd') ADVANCE(110);
       END_STATE();
     case 66:
-      if (lookahead == 'd') ADVANCE(115);
-      if (lookahead == 's') ADVANCE(122);
+      if (lookahead == 'e') ADVANCE(181);
       END_STATE();
     case 67:
-      if (lookahead == 'e') ADVANCE(194);
+      if (lookahead == 'e') ADVANCE(235);
       END_STATE();
     case 68:
-      if (lookahead == 'e') ADVANCE(251);
+      if (lookahead == 'e') ADVANCE(258);
       END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(489);
+      if (lookahead == 'e') ADVANCE(255);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(262);
+      if (lookahead == 'e') ADVANCE(288);
       END_STATE();
     case 71:
-      if (lookahead == 'e') ADVANCE(490);
+      if (lookahead == 'e') ADVANCE(532);
       END_STATE();
     case 72:
-      if (lookahead == 'e') ADVANCE(343);
+      if (lookahead == 'e') ADVANCE(522);
       END_STATE();
     case 73:
-      if (lookahead == 'e') ADVANCE(259);
+      if (lookahead == 'e') ADVANCE(530);
       END_STATE();
     case 74:
-      if (lookahead == 'e') ADVANCE(293);
+      if (lookahead == 'e') ADVANCE(292);
       END_STATE();
     case 75:
-      if (lookahead == 'e') ADVANCE(337);
+      if (lookahead == 'e') ADVANCE(527);
       END_STATE();
     case 76:
-      if (lookahead == 'e') ADVANCE(327);
+      if (lookahead == 'e') ADVANCE(528);
       END_STATE();
     case 77:
-      if (lookahead == 'e') ADVANCE(335);
+      if (lookahead == 'e') ADVANCE(526);
       END_STATE();
     case 78:
-      if (lookahead == 'e') ADVANCE(297);
+      if (lookahead == 'e') ADVANCE(536);
       END_STATE();
     case 79:
-      if (lookahead == 'e') ADVANCE(332);
+      if (lookahead == 'e') ADVANCE(176);
       END_STATE();
     case 80:
-      if (lookahead == 'e') ADVANCE(333);
+      if (lookahead == 'e') ADVANCE(23);
       END_STATE();
     case 81:
-      if (lookahead == 'e') ADVANCE(331);
-      END_STATE();
-    case 82:
-      if (lookahead == 'e') ADVANCE(345);
-      END_STATE();
-    case 83:
-      if (lookahead == 'e') ADVANCE(21);
-      END_STATE();
-    case 84:
       if (lookahead == 'e') ADVANCE(55);
       END_STATE();
+    case 82:
+      if (lookahead == 'e') ADVANCE(195);
+      END_STATE();
+    case 83:
+      if (lookahead == 'e') ADVANCE(187);
+      END_STATE();
+    case 84:
+      if (lookahead == 'e') ADVANCE(190);
+      END_STATE();
     case 85:
-      if (lookahead == 'e') ADVANCE(205);
+      if (lookahead == 'e') ADVANCE(191);
       END_STATE();
     case 86:
-      if (lookahead == 'e') ADVANCE(188);
-      END_STATE();
-    case 87:
-      if (lookahead == 'e') ADVANCE(210);
-      END_STATE();
-    case 88:
-      if (lookahead == 'e') ADVANCE(204);
-      END_STATE();
-    case 89:
       if (lookahead == 'e') ADVANCE(56);
       END_STATE();
-    case 90:
-      if (lookahead == 'e') ADVANCE(206);
-      END_STATE();
-    case 91:
+    case 87:
       if (lookahead == 'e') ADVANCE(57);
       END_STATE();
-    case 92:
+    case 88:
+      if (lookahead == 'e') ADVANCE(133);
+      END_STATE();
+    case 89:
       if (lookahead == 'e') ADVANCE(152);
       END_STATE();
+    case 90:
+      if (lookahead == 'e') ADVANCE(151);
+      END_STATE();
+    case 91:
+      if (lookahead == 'e') ADVANCE(212);
+      END_STATE();
+    case 92:
+      if (lookahead == 'f') ADVANCE(295);
+      END_STATE();
     case 93:
-      if (lookahead == 'e') ADVANCE(162);
+      if (lookahead == 'g') ADVANCE(270);
       END_STATE();
     case 94:
-      if (lookahead == 'e') ADVANCE(142);
+      if (lookahead == 'g') ADVANCE(276);
       END_STATE();
     case 95:
-      if (lookahead == 'e') ADVANCE(167);
+      if (lookahead == 'g') ADVANCE(81);
       END_STATE();
     case 96:
-      if (lookahead == 'e') ADVANCE(228);
+      if (lookahead == 'g') ADVANCE(129);
       END_STATE();
     case 97:
-      if (lookahead == 'f') ADVANCE(301);
+      if (lookahead == 'g') ADVANCE(108);
       END_STATE();
     case 98:
-      if (lookahead == 'g') ADVANCE(274);
+      if (lookahead == 'i') ADVANCE(97);
+      if (lookahead == 'o') ADVANCE(163);
+      if (lookahead == 'y') ADVANCE(207);
       END_STATE();
     case 99:
-      if (lookahead == 'g') ADVANCE(281);
+      if (lookahead == 'i') ADVANCE(290);
       END_STATE();
     case 100:
-      if (lookahead == 'g') ADVANCE(84);
+      if (lookahead == 'i') ADVANCE(234);
       END_STATE();
     case 101:
-      if (lookahead == 'g') ADVANCE(113);
-      END_STATE();
-    case 102:
-      if (lookahead == 'g') ADVANCE(138);
-      END_STATE();
-    case 103:
-      if (lookahead == 'i') ADVANCE(101);
-      if (lookahead == 'o') ADVANCE(176);
-      if (lookahead == 'y') ADVANCE(223);
-      END_STATE();
-    case 104:
-      if (lookahead == 'i') ADVANCE(295);
-      END_STATE();
-    case 105:
-      if (lookahead == 'i') ADVANCE(250);
-      END_STATE();
-    case 106:
       if (lookahead == 'i') ADVANCE(54);
       END_STATE();
-    case 107:
-      if (lookahead == 'i') ADVANCE(27);
+    case 102:
+      if (lookahead == 'i') ADVANCE(26);
       END_STATE();
-    case 108:
-      if (lookahead == 'i') ADVANCE(147);
+    case 103:
+      if (lookahead == 'i') ADVANCE(138);
       END_STATE();
-    case 109:
-      if (lookahead == 'i') ADVANCE(144);
+    case 104:
+      if (lookahead == 'i') ADVANCE(135);
       END_STATE();
-    case 110:
+    case 105:
+      if (lookahead == 'i') ADVANCE(141);
+      END_STATE();
+    case 106:
       if (lookahead == 'i') ADVANCE(150);
       END_STATE();
+    case 107:
+      if (lookahead == 'i') ADVANCE(192);
+      END_STATE();
+    case 108:
+      if (lookahead == 'i') ADVANCE(156);
+      END_STATE();
+    case 109:
+      if (lookahead == 'i') ADVANCE(213);
+      END_STATE();
+    case 110:
+      if (lookahead == 'i') ADVANCE(153);
+      END_STATE();
     case 111:
-      if (lookahead == 'i') ADVANCE(161);
+      if (lookahead == 'i') ADVANCE(157);
       END_STATE();
     case 112:
-      if (lookahead == 'i') ADVANCE(207);
+      if (lookahead == 'i') ADVANCE(169);
       END_STATE();
     case 113:
-      if (lookahead == 'i') ADVANCE(166);
+      if (lookahead == 'i') ADVANCE(136);
       END_STATE();
     case 114:
-      if (lookahead == 'i') ADVANCE(230);
+      if (lookahead == 'i') ADVANCE(170);
       END_STATE();
     case 115:
-      if (lookahead == 'i') ADVANCE(163);
+      if (lookahead == 'i') ADVANCE(137);
       END_STATE();
     case 116:
-      if (lookahead == 'i') ADVANCE(168);
+      if (lookahead == 'i') ADVANCE(171);
       END_STATE();
     case 117:
-      if (lookahead == 'i') ADVANCE(181);
+      if (lookahead == 'i') ADVANCE(172);
       END_STATE();
     case 118:
-      if (lookahead == 'i') ADVANCE(145);
+      if (lookahead == 'i') ADVANCE(173);
       END_STATE();
     case 119:
-      if (lookahead == 'i') ADVANCE(182);
+      if (lookahead == 'k') ADVANCE(260);
       END_STATE();
     case 120:
-      if (lookahead == 'i') ADVANCE(146);
-      END_STATE();
-    case 121:
-      if (lookahead == 'i') ADVANCE(183);
-      END_STATE();
-    case 122:
-      if (lookahead == 'i') ADVANCE(184);
-      END_STATE();
-    case 123:
-      if (lookahead == 'i') ADVANCE(185);
-      END_STATE();
-    case 124:
-      if (lookahead == 'i') ADVANCE(186);
-      END_STATE();
-    case 125:
-      if (lookahead == 'k') ADVANCE(264);
-      END_STATE();
-    case 126:
       if (lookahead == 'l') ADVANCE(17);
       END_STATE();
+    case 121:
+      if (lookahead == 'l') ADVANCE(500);
+      END_STATE();
+    case 122:
+      if (lookahead == 'l') ADVANCE(514);
+      END_STATE();
+    case 123:
+      if (lookahead == 'l') ADVANCE(286);
+      END_STATE();
+    case 124:
+      if (lookahead == 'l') ADVANCE(22);
+      END_STATE();
+    case 125:
+      if (lookahead == 'l') ADVANCE(164);
+      if (lookahead == 'u') ADVANCE(148);
+      END_STATE();
+    case 126:
+      if (lookahead == 'l') ADVANCE(32);
+      END_STATE();
     case 127:
-      if (lookahead == 'l') ADVANCE(305);
+      if (lookahead == 'l') ADVANCE(166);
+      if (lookahead == 'r') ADVANCE(88);
       END_STATE();
     case 128:
-      if (lookahead == 'l') ADVANCE(491);
+      if (lookahead == 'l') ADVANCE(69);
       END_STATE();
     case 129:
-      if (lookahead == 'l') ADVANCE(319);
+      if (lookahead == 'l') ADVANCE(70);
       END_STATE();
     case 130:
-      if (lookahead == 'l') ADVANCE(291);
-      END_STATE();
-    case 131:
-      if (lookahead == 'l') ADVANCE(20);
-      END_STATE();
-    case 132:
-      if (lookahead == 'l') ADVANCE(213);
-      END_STATE();
-    case 133:
-      if (lookahead == 'l') ADVANCE(128);
-      END_STATE();
-    case 134:
-      if (lookahead == 'l') ADVANCE(31);
-      END_STATE();
-    case 135:
-      if (lookahead == 'l') ADVANCE(177);
-      if (lookahead == 'r') ADVANCE(94);
-      END_STATE();
-    case 136:
-      if (lookahead == 'l') ADVANCE(72);
-      END_STATE();
-    case 137:
-      if (lookahead == 'l') ADVANCE(73);
-      END_STATE();
-    case 138:
       if (lookahead == 'l') ADVANCE(74);
       END_STATE();
-    case 139:
-      if (lookahead == 'l') ADVANCE(78);
+    case 131:
+      if (lookahead == 'l') ADVANCE(168);
       END_STATE();
-    case 140:
-      if (lookahead == 'l') ADVANCE(180);
+    case 132:
+      if (lookahead == 'l') ADVANCE(210);
       END_STATE();
-    case 141:
-      if (lookahead == 'l') ADVANCE(227);
-      END_STATE();
-    case 142:
+    case 133:
       if (lookahead == 'l') ADVANCE(37);
       END_STATE();
-    case 143:
-      if (lookahead == 'm') ADVANCE(346);
+    case 134:
+      if (lookahead == 'm') ADVANCE(537);
       END_STATE();
-    case 144:
+    case 135:
+      if (lookahead == 'm') ADVANCE(72);
+      END_STATE();
+    case 136:
       if (lookahead == 'm') ADVANCE(76);
       END_STATE();
-    case 145:
-      if (lookahead == 'm') ADVANCE(80);
+    case 137:
+      if (lookahead == 'm') ADVANCE(77);
       END_STATE();
-    case 146:
-      if (lookahead == 'm') ADVANCE(81);
+    case 138:
+      if (lookahead == 'm') ADVANCE(31);
       END_STATE();
-    case 147:
-      if (lookahead == 'm') ADVANCE(32);
+    case 139:
+      if (lookahead == 'n') ADVANCE(62);
       END_STATE();
-    case 148:
-      if (lookahead == 'n') ADVANCE(61);
-      END_STATE();
-    case 149:
-      if (lookahead == 'n') ADVANCE(283);
-      if (lookahead == 'p') ADVANCE(226);
-      if (lookahead == 'v') ADVANCE(85);
-      END_STATE();
-    case 150:
-      if (lookahead == 'n') ADVANCE(125);
-      END_STATE();
-    case 151:
-      if (lookahead == 'n') ADVANCE(321);
-      END_STATE();
-    case 152:
-      if (lookahead == 'n') ADVANCE(66);
-      END_STATE();
-    case 153:
-      if (lookahead == 'n') ADVANCE(329);
-      END_STATE();
-    case 154:
-      if (lookahead == 'n') ADVANCE(276);
-      END_STATE();
-    case 155:
-      if (lookahead == 'n') ADVANCE(280);
-      END_STATE();
-    case 156:
-      if (lookahead == 'n') ADVANCE(269);
-      END_STATE();
-    case 157:
-      if (lookahead == 'n') ADVANCE(334);
-      END_STATE();
-    case 158:
-      if (lookahead == 'n') ADVANCE(60);
-      END_STATE();
-    case 159:
-      if (lookahead == 'n') ADVANCE(53);
-      END_STATE();
-    case 160:
-      if (lookahead == 'n') ADVANCE(102);
-      END_STATE();
-    case 161:
-      if (lookahead == 'n') ADVANCE(98);
-      END_STATE();
-    case 162:
-      if (lookahead == 'n') ADVANCE(51);
-      END_STATE();
-    case 163:
-      if (lookahead == 'n') ADVANCE(99);
-      END_STATE();
-    case 164:
-      if (lookahead == 'n') ADVANCE(175);
-      END_STATE();
-    case 165:
-      if (lookahead == 'n') ADVANCE(175);
-      if (lookahead == 'y') ADVANCE(217);
-      END_STATE();
-    case 166:
-      if (lookahead == 'n') ADVANCE(219);
-      END_STATE();
-    case 167:
-      if (lookahead == 'n') ADVANCE(65);
-      END_STATE();
-    case 168:
-      if (lookahead == 'n') ADVANCE(222);
-      END_STATE();
-    case 169:
-      if (lookahead == 'n') ADVANCE(33);
-      END_STATE();
-    case 170:
-      if (lookahead == 'n') ADVANCE(216);
-      END_STATE();
-    case 171:
-      if (lookahead == 'o') ADVANCE(64);
-      if (lookahead == 'u') ADVANCE(141);
-      END_STATE();
-    case 172:
-      if (lookahead == 'o') ADVANCE(97);
-      END_STATE();
-    case 173:
-      if (lookahead == 'o') ADVANCE(170);
-      END_STATE();
-    case 174:
-      if (lookahead == 'o') ADVANCE(193);
-      END_STATE();
-    case 175:
-      if (lookahead == 'o') ADVANCE(240);
-      END_STATE();
-    case 176:
-      if (lookahead == 'o') ADVANCE(127);
-      END_STATE();
-    case 177:
-      if (lookahead == 'o') ADVANCE(52);
-      END_STATE();
-    case 178:
-      if (lookahead == 'o') ADVANCE(29);
-      END_STATE();
-    case 179:
-      if (lookahead == 'o') ADVANCE(151);
-      END_STATE();
-    case 180:
-      if (lookahead == 'o') ADVANCE(28);
-      END_STATE();
-    case 181:
-      if (lookahead == 'o') ADVANCE(169);
-      END_STATE();
-    case 182:
-      if (lookahead == 'o') ADVANCE(153);
-      END_STATE();
-    case 183:
-      if (lookahead == 'o') ADVANCE(154);
-      END_STATE();
-    case 184:
-      if (lookahead == 'o') ADVANCE(155);
-      END_STATE();
-    case 185:
-      if (lookahead == 'o') ADVANCE(156);
-      END_STATE();
-    case 186:
-      if (lookahead == 'o') ADVANCE(157);
-      END_STATE();
-    case 187:
-      if (lookahead == 'p') ADVANCE(226);
-      if (lookahead == 'v') ADVANCE(85);
-      END_STATE();
-    case 188:
-      if (lookahead == 'p') ADVANCE(220);
-      END_STATE();
-    case 189:
-      if (lookahead == 'p') ADVANCE(136);
-      END_STATE();
-    case 190:
-      if (lookahead == 'p') ADVANCE(70);
-      END_STATE();
-    case 191:
-      if (lookahead == 'p') ADVANCE(75);
-      END_STATE();
-    case 192:
-      if (lookahead == 'p') ADVANCE(82);
-      END_STATE();
-    case 193:
-      if (lookahead == 'p') ADVANCE(90);
-      END_STATE();
-    case 194:
-      if (lookahead == 'q') ADVANCE(245);
-      END_STATE();
-    case 195:
-      if (lookahead == 'q') ADVANCE(247);
-      if (lookahead == 't') ADVANCE(1);
-      END_STATE();
-    case 196:
-      if (lookahead == 'r') ADVANCE(303);
-      END_STATE();
-    case 197:
-      if (lookahead == 'r') ADVANCE(263);
-      END_STATE();
-    case 198:
-      if (lookahead == 'r') ADVANCE(246);
-      if (lookahead == 'u') ADVANCE(189);
-      if (lookahead == 'y') ADVANCE(190);
-      END_STATE();
-    case 199:
-      if (lookahead == 'r') ADVANCE(24);
-      END_STATE();
-    case 200:
-      if (lookahead == 'r') ADVANCE(174);
-      END_STATE();
-    case 201:
-      if (lookahead == 'r') ADVANCE(39);
-      END_STATE();
-    case 202:
-      if (lookahead == 'r') ADVANCE(26);
-      END_STATE();
-    case 203:
-      if (lookahead == 'r') ADVANCE(38);
-      END_STATE();
-    case 204:
-      if (lookahead == 'r') ADVANCE(114);
-      END_STATE();
-    case 205:
-      if (lookahead == 'r') ADVANCE(140);
-      END_STATE();
-    case 206:
-      if (lookahead == 'r') ADVANCE(224);
-      END_STATE();
-    case 207:
-      if (lookahead == 'r') ADVANCE(89);
-      END_STATE();
-    case 208:
-      if (lookahead == 'r') ADVANCE(41);
-      END_STATE();
-    case 209:
-      if (lookahead == 's') ADVANCE(273);
-      END_STATE();
-    case 210:
-      if (lookahead == 's') ADVANCE(325);
-      END_STATE();
-    case 211:
-      if (lookahead == 's') ADVANCE(179);
-      END_STATE();
-    case 212:
-      if (lookahead == 's') ADVANCE(232);
-      END_STATE();
-    case 213:
-      if (lookahead == 's') ADVANCE(71);
-      END_STATE();
-    case 214:
-      if (lookahead == 's') ADVANCE(111);
-      END_STATE();
-    case 215:
-      if (lookahead == 's') ADVANCE(111);
-      if (lookahead == 'u') ADVANCE(106);
-      END_STATE();
-    case 216:
-      if (lookahead == 's') ADVANCE(234);
-      END_STATE();
-    case 217:
-      if (lookahead == 't') ADVANCE(256);
-      END_STATE();
-    case 218:
-      if (lookahead == 't') ADVANCE(12);
-      END_STATE();
-    case 219:
-      if (lookahead == 't') ADVANCE(317);
-      END_STATE();
-    case 220:
-      if (lookahead == 't') ADVANCE(284);
-      END_STATE();
-    case 221:
-      if (lookahead == 't') ADVANCE(285);
-      END_STATE();
-    case 222:
-      if (lookahead == 't') ADVANCE(271);
-      END_STATE();
-    case 223:
-      if (lookahead == 't') ADVANCE(87);
-      END_STATE();
-    case 224:
-      if (lookahead == 't') ADVANCE(254);
-      END_STATE();
-    case 225:
-      if (lookahead == 't') ADVANCE(96);
-      END_STATE();
-    case 226:
-      if (lookahead == 't') ADVANCE(117);
-      END_STATE();
-    case 227:
-      if (lookahead == 't') ADVANCE(104);
-      END_STATE();
-    case 228:
-      if (lookahead == 't') ADVANCE(109);
-      END_STATE();
-    case 229:
-      if (lookahead == 't') ADVANCE(105);
-      END_STATE();
-    case 230:
-      if (lookahead == 't') ADVANCE(25);
-      END_STATE();
-    case 231:
-      if (lookahead == 't') ADVANCE(79);
-      END_STATE();
-    case 232:
-      if (lookahead == 't') ADVANCE(202);
-      END_STATE();
-    case 233:
-      if (lookahead == 't') ADVANCE(95);
-      END_STATE();
-    case 234:
-      if (lookahead == 't') ADVANCE(203);
-      END_STATE();
-    case 235:
-      if (lookahead == 't') ADVANCE(257);
-      END_STATE();
-    case 236:
-      if (lookahead == 't') ADVANCE(119);
-      END_STATE();
-    case 237:
-      if (lookahead == 't') ADVANCE(121);
-      END_STATE();
-    case 238:
-      if (lookahead == 't') ADVANCE(123);
-      END_STATE();
-    case 239:
-      if (lookahead == 't') ADVANCE(124);
-      END_STATE();
-    case 240:
-      if (lookahead == 't') ADVANCE(40);
-      END_STATE();
-    case 241:
-      if (lookahead == 'u') ADVANCE(143);
-      END_STATE();
-    case 242:
-      if (lookahead == 'u') ADVANCE(159);
-      END_STATE();
-    case 243:
-      if (lookahead == 'u') ADVANCE(141);
-      END_STATE();
-    case 244:
-      if (lookahead == 'u') ADVANCE(133);
-      END_STATE();
-    case 245:
-      if (lookahead == 'u') ADVANCE(112);
-      END_STATE();
-    case 246:
-      if (lookahead == 'u') ADVANCE(69);
-      END_STATE();
-    case 247:
-      if (lookahead == 'u') ADVANCE(93);
-      END_STATE();
-    case 248:
-      if (lookahead == 'u') ADVANCE(137);
-      END_STATE();
-    case 249:
-      if (lookahead == 'u') ADVANCE(208);
-      END_STATE();
-    case 250:
+    case 140:
+      if (lookahead == 'n') ADVANCE(278);
+      if (lookahead == 'p') ADVANCE(209);
       if (lookahead == 'v') ADVANCE(83);
       END_STATE();
+    case 141:
+      if (lookahead == 'n') ADVANCE(119);
+      END_STATE();
+    case 142:
+      if (lookahead == 'n') ADVANCE(516);
+      END_STATE();
+    case 143:
+      if (lookahead == 'n') ADVANCE(524);
+      END_STATE();
+    case 144:
+      if (lookahead == 'n') ADVANCE(272);
+      END_STATE();
+    case 145:
+      if (lookahead == 'n') ADVANCE(265);
+      END_STATE();
+    case 146:
+      if (lookahead == 'n') ADVANCE(529);
+      END_STATE();
+    case 147:
+      if (lookahead == 'n') ADVANCE(61);
+      END_STATE();
+    case 148:
+      if (lookahead == 'n') ADVANCE(53);
+      END_STATE();
+    case 149:
+      if (lookahead == 'n') ADVANCE(96);
+      END_STATE();
+    case 150:
+      if (lookahead == 'n') ADVANCE(93);
+      END_STATE();
+    case 151:
+      if (lookahead == 'n') ADVANCE(51);
+      END_STATE();
+    case 152:
+      if (lookahead == 'n') ADVANCE(65);
+      END_STATE();
+    case 153:
+      if (lookahead == 'n') ADVANCE(94);
+      END_STATE();
+    case 154:
+      if (lookahead == 'n') ADVANCE(165);
+      END_STATE();
+    case 155:
+      if (lookahead == 'n') ADVANCE(165);
+      if (lookahead == 'y') ADVANCE(218);
+      END_STATE();
+    case 156:
+      if (lookahead == 'n') ADVANCE(202);
+      END_STATE();
+    case 157:
+      if (lookahead == 'n') ADVANCE(205);
+      END_STATE();
+    case 158:
+      if (lookahead == 'n') ADVANCE(33);
+      END_STATE();
+    case 159:
+      if (lookahead == 'n') ADVANCE(200);
+      END_STATE();
+    case 160:
+      if (lookahead == 'o') ADVANCE(59);
+      if (lookahead == 'u') ADVANCE(132);
+      END_STATE();
+    case 161:
+      if (lookahead == 'o') ADVANCE(92);
+      END_STATE();
+    case 162:
+      if (lookahead == 'o') ADVANCE(159);
+      END_STATE();
+    case 163:
+      if (lookahead == 'o') ADVANCE(121);
+      END_STATE();
+    case 164:
+      if (lookahead == 'o') ADVANCE(30);
+      END_STATE();
+    case 165:
+      if (lookahead == 'o') ADVANCE(224);
+      END_STATE();
+    case 166:
+      if (lookahead == 'o') ADVANCE(52);
+      END_STATE();
+    case 167:
+      if (lookahead == 'o') ADVANCE(142);
+      END_STATE();
+    case 168:
+      if (lookahead == 'o') ADVANCE(29);
+      END_STATE();
+    case 169:
+      if (lookahead == 'o') ADVANCE(158);
+      END_STATE();
+    case 170:
+      if (lookahead == 'o') ADVANCE(143);
+      END_STATE();
+    case 171:
+      if (lookahead == 'o') ADVANCE(144);
+      END_STATE();
+    case 172:
+      if (lookahead == 'o') ADVANCE(145);
+      END_STATE();
+    case 173:
+      if (lookahead == 'o') ADVANCE(146);
+      END_STATE();
+    case 174:
+      if (lookahead == 'o') ADVANCE(180);
+      END_STATE();
+    case 175:
+      if (lookahead == 'p') ADVANCE(209);
+      if (lookahead == 'v') ADVANCE(83);
+      END_STATE();
+    case 176:
+      if (lookahead == 'p') ADVANCE(203);
+      END_STATE();
+    case 177:
+      if (lookahead == 'p') ADVANCE(68);
+      END_STATE();
+    case 178:
+      if (lookahead == 'p') ADVANCE(71);
+      END_STATE();
+    case 179:
+      if (lookahead == 'p') ADVANCE(78);
+      END_STATE();
+    case 180:
+      if (lookahead == 'p') ADVANCE(85);
+      END_STATE();
+    case 181:
+      if (lookahead == 'q') ADVANCE(230);
+      END_STATE();
+    case 182:
+      if (lookahead == 'q') ADVANCE(232);
+      END_STATE();
+    case 183:
+      if (lookahead == 'r') ADVANCE(498);
+      END_STATE();
+    case 184:
+      if (lookahead == 'r') ADVANCE(259);
+      END_STATE();
+    case 185:
+      if (lookahead == 'r') ADVANCE(39);
+      END_STATE();
+    case 186:
+      if (lookahead == 'r') ADVANCE(174);
+      END_STATE();
+    case 187:
+      if (lookahead == 'r') ADVANCE(131);
+      END_STATE();
+    case 188:
+      if (lookahead == 'r') ADVANCE(27);
+      END_STATE();
+    case 189:
+      if (lookahead == 'r') ADVANCE(38);
+      END_STATE();
+    case 190:
+      if (lookahead == 'r') ADVANCE(109);
+      END_STATE();
+    case 191:
+      if (lookahead == 'r') ADVANCE(206);
+      END_STATE();
+    case 192:
+      if (lookahead == 'r') ADVANCE(86);
+      END_STATE();
+    case 193:
+      if (lookahead == 'r') ADVANCE(41);
+      END_STATE();
+    case 194:
+      if (lookahead == 's') ADVANCE(269);
+      END_STATE();
+    case 195:
+      if (lookahead == 's') ADVANCE(520);
+      END_STATE();
+    case 196:
+      if (lookahead == 's') ADVANCE(167);
+      END_STATE();
+    case 197:
+      if (lookahead == 's') ADVANCE(216);
+      END_STATE();
+    case 198:
+      if (lookahead == 's') ADVANCE(106);
+      END_STATE();
+    case 199:
+      if (lookahead == 's') ADVANCE(106);
+      if (lookahead == 'u') ADVANCE(101);
+      END_STATE();
+    case 200:
+      if (lookahead == 's') ADVANCE(217);
+      END_STATE();
+    case 201:
+      if (lookahead == 't') ADVANCE(12);
+      END_STATE();
+    case 202:
+      if (lookahead == 't') ADVANCE(512);
+      END_STATE();
+    case 203:
+      if (lookahead == 't') ADVANCE(279);
+      END_STATE();
+    case 204:
+      if (lookahead == 't') ADVANCE(280);
+      END_STATE();
+    case 205:
+      if (lookahead == 't') ADVANCE(267);
+      END_STATE();
+    case 206:
+      if (lookahead == 't') ADVANCE(238);
+      END_STATE();
+    case 207:
+      if (lookahead == 't') ADVANCE(82);
+      END_STATE();
+    case 208:
+      if (lookahead == 't') ADVANCE(91);
+      END_STATE();
+    case 209:
+      if (lookahead == 't') ADVANCE(112);
+      END_STATE();
+    case 210:
+      if (lookahead == 't') ADVANCE(99);
+      END_STATE();
+    case 211:
+      if (lookahead == 't') ADVANCE(89);
+      END_STATE();
+    case 212:
+      if (lookahead == 't') ADVANCE(104);
+      END_STATE();
+    case 213:
+      if (lookahead == 't') ADVANCE(25);
+      END_STATE();
+    case 214:
+      if (lookahead == 't') ADVANCE(100);
+      END_STATE();
+    case 215:
+      if (lookahead == 't') ADVANCE(75);
+      END_STATE();
+    case 216:
+      if (lookahead == 't') ADVANCE(188);
+      END_STATE();
+    case 217:
+      if (lookahead == 't') ADVANCE(189);
+      END_STATE();
+    case 218:
+      if (lookahead == 't') ADVANCE(239);
+      END_STATE();
+    case 219:
+      if (lookahead == 't') ADVANCE(114);
+      END_STATE();
+    case 220:
+      if (lookahead == 't') ADVANCE(240);
+      END_STATE();
+    case 221:
+      if (lookahead == 't') ADVANCE(116);
+      END_STATE();
+    case 222:
+      if (lookahead == 't') ADVANCE(117);
+      END_STATE();
+    case 223:
+      if (lookahead == 't') ADVANCE(118);
+      END_STATE();
+    case 224:
+      if (lookahead == 't') ADVANCE(40);
+      END_STATE();
+    case 225:
+      if (lookahead == 'u') ADVANCE(241);
+      if (lookahead == 'x') ADVANCE(250);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(497);
+      if (lookahead != 0) ADVANCE(495);
+      END_STATE();
+    case 226:
+      if (lookahead == 'u') ADVANCE(134);
+      END_STATE();
+    case 227:
+      if (lookahead == 'u') ADVANCE(132);
+      END_STATE();
+    case 228:
+      if (lookahead == 'u') ADVANCE(148);
+      END_STATE();
+    case 229:
+      if (lookahead == 'u') ADVANCE(128);
+      END_STATE();
+    case 230:
+      if (lookahead == 'u') ADVANCE(107);
+      END_STATE();
+    case 231:
+      if (lookahead == 'u') ADVANCE(242);
+      END_STATE();
+    case 232:
+      if (lookahead == 'u') ADVANCE(90);
+      END_STATE();
+    case 233:
+      if (lookahead == 'u') ADVANCE(193);
+      END_STATE();
+    case 234:
+      if (lookahead == 'v') ADVANCE(80);
+      END_STATE();
+    case 235:
+      if (lookahead == 'x') ADVANCE(268);
+      END_STATE();
+    case 236:
+      if (lookahead == 'x') ADVANCE(211);
+      END_STATE();
+    case 237:
+      if (lookahead == 'y') ADVANCE(177);
+      END_STATE();
+    case 238:
+      if (lookahead == 'y') ADVANCE(264);
+      END_STATE();
+    case 239:
+      if (lookahead == 'y') ADVANCE(178);
+      END_STATE();
+    case 240:
+      if (lookahead == 'y') ADVANCE(179);
+      END_STATE();
+    case 241:
+      if (lookahead == '{') ADVANCE(247);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(245);
+      END_STATE();
+    case 242:
+      if (lookahead == '{') ADVANCE(249);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(252);
+      END_STATE();
+    case 243:
+      if (lookahead == '}') ADVANCE(495);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+      END_STATE();
+    case 244:
+      if (lookahead == '}') ADVANCE(694);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(244);
+      END_STATE();
+    case 245:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(250);
+      END_STATE();
+    case 246:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(495);
+      END_STATE();
+    case 247:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+      END_STATE();
+    case 248:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(694);
+      END_STATE();
+    case 249:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(244);
+      END_STATE();
+    case 250:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
+      END_STATE();
     case 251:
-      if (lookahead == 'x') ADVANCE(272);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
       END_STATE();
     case 252:
-      if (lookahead == 'x') ADVANCE(233);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(251);
       END_STATE();
     case 253:
-      if (lookahead == 'y') ADVANCE(339);
+      if (eof) ADVANCE(254);
+      if (lookahead == '!') ADVANCE(18);
+      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '%') ADVANCE(308);
+      if (lookahead == '&') ADVANCE(301);
+      if (lookahead == '(') ADVANCE(273);
+      if (lookahead == ')') ADVANCE(274);
+      if (lookahead == '*') ADVANCE(306);
+      if (lookahead == '+') ADVANCE(304);
+      if (lookahead == ',') ADVANCE(277);
+      if (lookahead == '-') ADVANCE(305);
+      if (lookahead == '/') ADVANCE(307);
+      if (lookahead == ':') ADVANCE(294);
+      if (lookahead == ';') ADVANCE(263);
+      if (lookahead == '<') ADVANCE(309);
+      if (lookahead == '=') ADVANCE(311);
+      if (lookahead == '>') ADVANCE(315);
+      if (lookahead == '^') ADVANCE(302);
+      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'b') ADVANCE(98);
+      if (lookahead == 'c') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(35);
+      if (lookahead == 'e') ADVANCE(58);
+      if (lookahead == 'f') ADVANCE(125);
+      if (lookahead == 'i') ADVANCE(139);
+      if (lookahead == 'j') ADVANCE(196);
+      if (lookahead == 'l') ADVANCE(105);
+      if (lookahead == 'm') ADVANCE(160);
+      if (lookahead == 'o') ADVANCE(140);
+      if (lookahead == 'p') ADVANCE(186);
+      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == 's') ADVANCE(46);
+      if (lookahead == 't') ADVANCE(237);
+      if (lookahead == 'u') ADVANCE(199);
+      if (lookahead == '{') ADVANCE(256);
+      if (lookahead == '|') ADVANCE(303);
+      if (lookahead == '}') ADVANCE(257);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(699);
       END_STATE();
     case 254:
-      if (lookahead == 'y') ADVANCE(268);
-      END_STATE();
-    case 255:
-      if (lookahead == 'y') ADVANCE(190);
-      END_STATE();
-    case 256:
-      if (lookahead == 'y') ADVANCE(191);
-      END_STATE();
-    case 257:
-      if (lookahead == 'y') ADVANCE(192);
-      END_STATE();
-    case 258:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 259:
+    case 255:
       ACCEPT_TOKEN(anon_sym_module);
       END_STATE();
-    case 260:
+    case 256:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 261:
+    case 257:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 262:
+    case 258:
       ACCEPT_TOKEN(anon_sym_type);
       END_STATE();
-    case 263:
+    case 259:
       ACCEPT_TOKEN(anon_sym_scalar);
       END_STATE();
-    case 264:
+    case 260:
       ACCEPT_TOKEN(anon_sym_link);
       END_STATE();
-    case 265:
+    case 261:
       ACCEPT_TOKEN(anon_sym_DASH_GT);
       END_STATE();
-    case 266:
+    case 262:
       ACCEPT_TOKEN(anon_sym_COLON_EQ);
       END_STATE();
-    case 267:
+    case 263:
       ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
-    case 268:
+    case 264:
       ACCEPT_TOKEN(anon_sym_property);
       END_STATE();
-    case 269:
+    case 265:
       ACCEPT_TOKEN(anon_sym_annotation);
       END_STATE();
-    case 270:
+    case 266:
       ACCEPT_TOKEN(anon_sym_annotation);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
-    case 271:
+    case 267:
       ACCEPT_TOKEN(anon_sym_constraint);
       END_STATE();
-    case 272:
+    case 268:
       ACCEPT_TOKEN(anon_sym_index);
       END_STATE();
-    case 273:
+    case 269:
       ACCEPT_TOKEN(anon_sym_alias);
       END_STATE();
-    case 274:
+    case 270:
       ACCEPT_TOKEN(anon_sym_using);
       END_STATE();
-    case 275:
+    case 271:
       ACCEPT_TOKEN(anon_sym_using);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
-    case 276:
+    case 272:
       ACCEPT_TOKEN(anon_sym_function);
       END_STATE();
-    case 277:
+    case 273:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 278:
+    case 274:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 279:
+    case 275:
       ACCEPT_TOKEN(anon_sym_edgedb);
       END_STATE();
-    case 280:
-      ACCEPT_TOKEN(anon_sym_extension);
-      END_STATE();
-    case 281:
+    case 276:
       ACCEPT_TOKEN(anon_sym_extending);
       END_STATE();
-    case 282:
+    case 277:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 283:
+    case 278:
       ACCEPT_TOKEN(anon_sym_on);
       END_STATE();
-    case 284:
+    case 279:
       ACCEPT_TOKEN(anon_sym_except);
       END_STATE();
-    case 285:
+    case 280:
       ACCEPT_TOKEN(anon_sym_abstract);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(anon_sym_abstract);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(anon_sym_overloaded);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(anon_sym_overloaded);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(anon_sym_required);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(anon_sym_required);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
     case 286:
-      ACCEPT_TOKEN(anon_sym_abstract);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_optional);
       END_STATE();
     case 287:
-      ACCEPT_TOKEN(anon_sym_overloaded);
+      ACCEPT_TOKEN(anon_sym_optional);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
     case 288:
-      ACCEPT_TOKEN(anon_sym_overloaded);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_single);
       END_STATE();
     case 289:
-      ACCEPT_TOKEN(anon_sym_required);
+      ACCEPT_TOKEN(anon_sym_single);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
     case 290:
-      ACCEPT_TOKEN(anon_sym_required);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_multi);
       END_STATE();
     case 291:
-      ACCEPT_TOKEN(anon_sym_optional);
+      ACCEPT_TOKEN(anon_sym_multi);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
     case 292:
-      ACCEPT_TOKEN(anon_sym_optional);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_inheritable);
       END_STATE();
     case 293:
-      ACCEPT_TOKEN(anon_sym_single);
+      ACCEPT_TOKEN(anon_sym_inheritable);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
       END_STATE();
     case 294:
-      ACCEPT_TOKEN(anon_sym_single);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(anon_sym_multi);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(anon_sym_multi);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(anon_sym_inheritable);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(anon_sym_inheritable);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      if (lookahead == '=') ADVANCE(266);
-      END_STATE();
-    case 301:
       ACCEPT_TOKEN(anon_sym_setof);
       END_STATE();
+    case 296:
+      ACCEPT_TOKEN(anon_sym_global);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(anon_sym_AMP_AMP);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(anon_sym_GT_GT);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(anon_sym_LT_LT);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(297);
+      END_STATE();
     case 302:
-      ACCEPT_TOKEN(sym_str);
-      if (lookahead == '\'') ADVANCE(302);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(8);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 303:
-      ACCEPT_TOKEN(anon_sym_str);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(298);
       END_STATE();
     case 304:
-      ACCEPT_TOKEN(anon_sym_str);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(anon_sym_bool);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 306:
-      ACCEPT_TOKEN(anon_sym_bool);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(anon_sym_int16);
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 308:
-      ACCEPT_TOKEN(anon_sym_int16);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 309:
-      ACCEPT_TOKEN(anon_sym_int32);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '<') ADVANCE(300);
+      if (lookahead == '=') ADVANCE(310);
       END_STATE();
     case 310:
-      ACCEPT_TOKEN(anon_sym_int32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
       END_STATE();
     case 311:
-      ACCEPT_TOKEN(anon_sym_int64);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 312:
-      ACCEPT_TOKEN(anon_sym_int64);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(anon_sym_float32);
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(anon_sym_float32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 315:
-      ACCEPT_TOKEN(anon_sym_float64);
-      END_STATE();
-    case 316:
-      ACCEPT_TOKEN(anon_sym_float64);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 317:
-      ACCEPT_TOKEN(anon_sym_bigint);
-      END_STATE();
-    case 318:
-      ACCEPT_TOKEN(anon_sym_bigint);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 319:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      END_STATE();
-    case 320:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 321:
-      ACCEPT_TOKEN(anon_sym_json);
-      END_STATE();
-    case 322:
-      ACCEPT_TOKEN(anon_sym_json);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 323:
-      ACCEPT_TOKEN(anon_sym_uuid);
-      END_STATE();
-    case 324:
-      ACCEPT_TOKEN(anon_sym_uuid);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 325:
-      ACCEPT_TOKEN(anon_sym_bytes);
-      END_STATE();
-    case 326:
-      ACCEPT_TOKEN(anon_sym_bytes);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 327:
-      ACCEPT_TOKEN(anon_sym_datetime);
-      END_STATE();
-    case 328:
-      ACCEPT_TOKEN(anon_sym_datetime);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 329:
-      ACCEPT_TOKEN(anon_sym_duration);
-      END_STATE();
-    case 330:
-      ACCEPT_TOKEN(anon_sym_duration);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 331:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
-      END_STATE();
-    case 332:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
-      if (lookahead == 't') ADVANCE(120);
-      END_STATE();
-    case 333:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
-      END_STATE();
-    case 334:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
-      END_STATE();
-    case 335:
-      ACCEPT_TOKEN(anon_sym_sequence);
-      END_STATE();
-    case 336:
-      ACCEPT_TOKEN(anon_sym_sequence);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 337:
-      ACCEPT_TOKEN(anon_sym_anytype);
-      END_STATE();
-    case 338:
-      ACCEPT_TOKEN(anon_sym_anytype);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 339:
-      ACCEPT_TOKEN(anon_sym_array);
-      END_STATE();
-    case 340:
-      ACCEPT_TOKEN(anon_sym_array);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
-      END_STATE();
-    case 341:
-      ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 342:
       ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
+    case 315:
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(313);
+      if (lookahead == '>') ADVANCE(299);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '\n') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(317);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == ' ') ADVANCE(435);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '&') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '1') ADVANCE(324);
+      if (lookahead == '3') ADVANCE(321);
+      if (lookahead == '6') ADVANCE(323);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '2') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '3') ADVANCE(321);
+      if (lookahead == '6') ADVANCE(323);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '4') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '6') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == ':') ADVANCE(412);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == ':') ADVANCE(325);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '<') ADVANCE(494);
+      if (lookahead == '=') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '=') ADVANCE(494);
+      if (lookahead == '>') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 329:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '=') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '>') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '_') ADVANCE(367);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 332:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '_') ADVANCE(364);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 333:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(406);
+      if (lookahead == 'o') ADVANCE(432);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(491);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(408);
+      if (lookahead == 'l') ADVANCE(439);
+      if (lookahead == 'u') ADVANCE(425);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(357);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(352);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(461);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(366);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(405);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 342:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(469);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
     case 343:
-      ACCEPT_TOKEN(anon_sym_tuple);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(411);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 344:
-      ACCEPT_TOKEN(anon_sym_tuple);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 345:
-      ACCEPT_TOKEN(anon_sym_scalartype);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(472);
+      if (lookahead == 'e') ADVANCE(355);
+      if (lookahead == 'u') ADVANCE(453);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 346:
-      ACCEPT_TOKEN(anon_sym_enum);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(472);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 347:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ' ') ADVANCE(172);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(401);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 348:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ' ') ADVANCE(235);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(477);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 349:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(355);
-      if (lookahead == '3') ADVANCE(350);
-      if (lookahead == '6') ADVANCE(353);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(479);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 350:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(310);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'b') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 351:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(314);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'b') ADVANCE(462);
+      if (lookahead == 'l') ADVANCE(394);
+      if (lookahead == 'n') ADVANCE(429);
+      if (lookahead == 'r') ADVANCE(452);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 352:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '3') ADVANCE(351);
-      if (lookahead == '6') ADVANCE(354);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'b') ADVANCE(413);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 353:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(312);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'b') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 354:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(316);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(343);
+      if (lookahead == 'e') ADVANCE(449);
+      if (lookahead == 'i') ADVANCE(426);
+      if (lookahead == 't') ADVANCE(450);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 355:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(308);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(395);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 356:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ':') ADVANCE(16);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(378);
+      if (lookahead == 't') ADVANCE(382);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 357:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(371);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(467);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 358:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(413);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 359:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(379);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(344);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 360:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(485);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'c') ADVANCE(479);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 361:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(455);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 362:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(374);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(387);
+      if (lookahead == 'n') ADVANCE(482);
+      if (lookahead == 'x') ADVANCE(356);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 363:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(415);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(350);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 364:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(467);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(487);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 365:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(416);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(372);
+      if (lookahead == 'h') ADVANCE(379);
+      if (lookahead == 't') ADVANCE(320);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 366:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(418);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(373);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 367:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(471);
-      if (lookahead == 'e') ADVANCE(372);
-      if (lookahead == 'u') ADVANCE(456);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(346);
+      if (lookahead == 't') ADVANCE(396);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 368:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(474);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(399);
+      if (lookahead == 's') ADVANCE(398);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 369:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(477);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'd') ADVANCE(485);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 370:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(463);
-      if (lookahead == 'n') ADVANCE(435);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 371:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(421);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(448);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 372:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(402);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(490);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 373:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(384);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(361);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 374:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(469);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(332);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 375:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(366);
-      if (lookahead == 'e') ADVANCE(451);
-      if (lookahead == 't') ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(363);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 376:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(324);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(461);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 377:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(290);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(460);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 378:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(288);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(444);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 379:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(392);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(457);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 380:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(450);
-      if (lookahead == 't') ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(458);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 381:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(344);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(416);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 382:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(338);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(424);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 383:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(328);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(428);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 384:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(336);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(476);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 385:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(451);
-      if (lookahead == 't') ADVANCE(453);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'f') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 386:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(294);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 387:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(298);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(375);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 388:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(461);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(413);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 389:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(377);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(401);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 390:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(433);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 391:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(460);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(389);
+      if (lookahead == 'o') ADVANCE(440);
+      if (lookahead == 'y') ADVANCE(471);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 392:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(378);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(489);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 393:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(458);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(361);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 394:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(452);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(339);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 395:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(473);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(419);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 396:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(275);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(418);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 397:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(412);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(423);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 398:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(420);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(441);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 399:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(393);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(427);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 400:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(397);
-      if (lookahead == 'o') ADVANCE(439);
-      if (lookahead == 'y') ADVANCE(465);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(459);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 401:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(376);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(430);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 402:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(425);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(478);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 403:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(296);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(443);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 404:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(424);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'k') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 405:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(440);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 406:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(441);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(326);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 407:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(459);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(331);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 408:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(444);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(464);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 409:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(431);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(434);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 410:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(434);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(405);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 411:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(475);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(336);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 412:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(436);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(438);
+      if (lookahead == 'r') ADVANCE(381);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 413:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(356);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 414:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(306);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(442);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 415:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(320);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(475);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 416:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(292);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'l') ADVANCE(348);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 417:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(445);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'm') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 418:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(361);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'm') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 419:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(381);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'm') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 420:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(386);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(494);
+      if (lookahead == 'p') ADVANCE(474);
+      if (lookahead == 'v') ADVANCE(377);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 421:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(387);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 422:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(442);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(365);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 423:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(476);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(404);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 424:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(383);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(368);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 425:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(363);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(360);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 426:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(487);
-      if (lookahead == 'r') ADVANCE(454);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(388);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 427:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(322);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(386);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 428:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(330);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(358);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 429:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(399);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(437);
+      if (lookahead == 'y') ADVANCE(468);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 430:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(270);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(467);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 431:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(398);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 432:
-      ACCEPT_TOKEN(sym_identifier);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'n') ADVANCE(466);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 433:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(373);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(369);
+      if (lookahead == 'u') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 434:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(396);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(353);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 435:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(443);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(385);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 436:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(468);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(447);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 437:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(365);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(473);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 438:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(427);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(359);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 439:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(414);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(342);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 440:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(437);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(405);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 441:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(428);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(421);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 442:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(359);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(340);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 443:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(479);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'o') ADVANCE(431);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 444:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(430);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'p') ADVANCE(467);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 445:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(364);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'p') ADVANCE(413);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 446:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(472);
-      if (lookahead == 'v') ADVANCE(391);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'p') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 447:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(472);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'p') ADVANCE(380);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 448:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(419);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'q') ADVANCE(484);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 449:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(382);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'q') ADVANCE(488);
+      if (lookahead == 't') ADVANCE(318);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 450:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'q') ADVANCE(482);
-      if (lookahead == 't') ADVANCE(347);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 451:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'q') ADVANCE(482);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(486);
+      if (lookahead == 'u') ADVANCE(445);
+      if (lookahead == 'y') ADVANCE(446);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 452:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'q') ADVANCE(484);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(334);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 453:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(304);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(349);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 454:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(360);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(436);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 455:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(348);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 456:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(368);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(347);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 457:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(362);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(402);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 458:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(411);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(470);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 459:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(389);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(373);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 460:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(422);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(414);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 461:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(326);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 462:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(438);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(480);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 463:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(478);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(441);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 464:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(410);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 465:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(388);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(399);
+      if (lookahead == 'u') ADVANCE(393);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 466:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(349);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 's') ADVANCE(481);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 467:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(352);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 468:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(318);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(492);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 469:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(286);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(322);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 470:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(486);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(491);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 471:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(395);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(376);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 472:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(405);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(384);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 473:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(404);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(349);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 474:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(406);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(403);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 475:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(357);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(390);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 476:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(403);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(396);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 477:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(408);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(392);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 478:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(457);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(338);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 479:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(369);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(398);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 480:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(401);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(455);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 481:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(448);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(456);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 482:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(390);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(417);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 483:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(423);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(410);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 484:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(407);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(400);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 485:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(340);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(413);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 486:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(449);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(370);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 487:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(470);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(453);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 488:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'u') ADVANCE(383);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 489:
-      ACCEPT_TOKEN(sym_true);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'v') ADVANCE(374);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 490:
-      ACCEPT_TOKEN(sym_false);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'x') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 491:
-      ACCEPT_TOKEN(sym_null);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'y') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 492:
-      ACCEPT_TOKEN(sym_comment);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'y') ADVANCE(446);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(492);
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
       END_STATE();
     case 493:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '|') ADVANCE(494);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 494:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(494);
+      END_STATE();
+    case 495:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      END_STATE();
+    case 496:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(495);
+      END_STATE();
+    case 497:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(496);
+      END_STATE();
+    case 498:
+      ACCEPT_TOKEN(anon_sym_str);
+      END_STATE();
+    case 499:
+      ACCEPT_TOKEN(anon_sym_str);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 500:
+      ACCEPT_TOKEN(anon_sym_bool);
+      END_STATE();
+    case 501:
+      ACCEPT_TOKEN(anon_sym_bool);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 502:
+      ACCEPT_TOKEN(anon_sym_int16);
+      END_STATE();
+    case 503:
+      ACCEPT_TOKEN(anon_sym_int16);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 504:
+      ACCEPT_TOKEN(anon_sym_int32);
+      END_STATE();
+    case 505:
+      ACCEPT_TOKEN(anon_sym_int32);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 506:
+      ACCEPT_TOKEN(anon_sym_int64);
+      END_STATE();
+    case 507:
+      ACCEPT_TOKEN(anon_sym_int64);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 508:
+      ACCEPT_TOKEN(anon_sym_float32);
+      END_STATE();
+    case 509:
+      ACCEPT_TOKEN(anon_sym_float32);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 510:
+      ACCEPT_TOKEN(anon_sym_float64);
+      END_STATE();
+    case 511:
+      ACCEPT_TOKEN(anon_sym_float64);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 512:
+      ACCEPT_TOKEN(anon_sym_bigint);
+      END_STATE();
+    case 513:
+      ACCEPT_TOKEN(anon_sym_bigint);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 514:
+      ACCEPT_TOKEN(anon_sym_decimal);
+      END_STATE();
+    case 515:
+      ACCEPT_TOKEN(anon_sym_decimal);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 516:
+      ACCEPT_TOKEN(anon_sym_json);
+      END_STATE();
+    case 517:
+      ACCEPT_TOKEN(anon_sym_json);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 518:
+      ACCEPT_TOKEN(anon_sym_uuid);
+      END_STATE();
+    case 519:
+      ACCEPT_TOKEN(anon_sym_uuid);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 520:
+      ACCEPT_TOKEN(anon_sym_bytes);
+      END_STATE();
+    case 521:
+      ACCEPT_TOKEN(anon_sym_bytes);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 522:
+      ACCEPT_TOKEN(anon_sym_datetime);
+      END_STATE();
+    case 523:
+      ACCEPT_TOKEN(anon_sym_datetime);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 524:
+      ACCEPT_TOKEN(anon_sym_duration);
+      END_STATE();
+    case 525:
+      ACCEPT_TOKEN(anon_sym_duration);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 526:
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
+      END_STATE();
+    case 527:
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
+      if (lookahead == 't') ADVANCE(115);
+      END_STATE();
+    case 528:
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
+      END_STATE();
+    case 529:
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
+      END_STATE();
+    case 530:
+      ACCEPT_TOKEN(anon_sym_sequence);
+      END_STATE();
+    case 531:
+      ACCEPT_TOKEN(anon_sym_sequence);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 532:
+      ACCEPT_TOKEN(anon_sym_anytype);
+      END_STATE();
+    case 533:
+      ACCEPT_TOKEN(anon_sym_anytype);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 534:
+      ACCEPT_TOKEN(anon_sym_array);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 535:
+      ACCEPT_TOKEN(anon_sym_tuple);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 536:
+      ACCEPT_TOKEN(anon_sym_scalartype);
+      END_STATE();
+    case 537:
+      ACCEPT_TOKEN(anon_sym_enum);
+      END_STATE();
+    case 538:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == ' ') ADVANCE(161);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 539:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == ' ') ADVANCE(220);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 540:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '1') ADVANCE(546);
+      if (lookahead == '3') ADVANCE(541);
+      if (lookahead == '6') ADVANCE(544);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 541:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(505);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 542:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(509);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 543:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '3') ADVANCE(542);
+      if (lookahead == '6') ADVANCE(545);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 544:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(507);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 545:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(511);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 546:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '6') ADVANCE(503);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 547:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == ':') ADVANCE(16);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_5(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 548:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(564);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 549:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(609);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 550:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(573);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 551:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(691);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 552:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(657);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 553:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(568);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 554:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(611);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 555:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(671);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 556:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(612);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 557:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(616);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 558:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(618);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 559:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(614);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 560:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(675);
+      if (lookahead == 'e') ADVANCE(566);
+      if (lookahead == 'u') ADVANCE(658);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 561:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(678);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 562:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(681);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 563:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'b') ADVANCE(666);
+      if (lookahead == 'n') ADVANCE(636);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 564:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'b') ADVANCE(622);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 565:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'b') ADVANCE(559);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 566:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'c') ADVANCE(598);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 567:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'c') ADVANCE(578);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 568:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'c') ADVANCE(673);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 569:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'c') ADVANCE(557);
+      if (lookahead == 'e') ADVANCE(653);
+      if (lookahead == 't') ADVANCE(655);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 570:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'd') ADVANCE(519);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 571:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'd') ADVANCE(285);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 572:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'd') ADVANCE(283);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 573:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'd') ADVANCE(588);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 574:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(652);
+      if (lookahead == 't') ADVANCE(655);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 575:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(535);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 576:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(533);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 577:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(523);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 578:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(531);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 579:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(653);
+      if (lookahead == 't') ADVANCE(655);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 580:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(289);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 581:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(293);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 582:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(695);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 583:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(696);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 584:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(664);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 585:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(571);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 586:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(634);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 587:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(663);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 588:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(572);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 589:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(660);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 590:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(654);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 591:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'e') ADVANCE(677);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 592:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'g') ADVANCE(271);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 593:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'g') ADVANCE(608);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 594:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'g') ADVANCE(621);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 595:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'h') ADVANCE(589);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 596:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(593);
+      if (lookahead == 'o') ADVANCE(641);
+      if (lookahead == 'y') ADVANCE(669);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 597:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(570);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 598:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(626);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 599:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(291);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 600:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(625);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 601:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(642);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 602:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(643);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 603:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(661);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 604:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(646);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 605:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(632);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 606:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(635);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 607:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(679);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 608:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'i') ADVANCE(637);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 609:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(547);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 610:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(501);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 611:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(515);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 612:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(287);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 613:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(697);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 614:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(296);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 615:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(647);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 616:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(552);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 617:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(575);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 618:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(667);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 619:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(640);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 620:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(613);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 621:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(580);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 622:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(581);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 623:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(644);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 624:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'l') ADVANCE(680);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 625:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'm') ADVANCE(577);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 626:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'm') ADVANCE(554);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 627:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(693);
+      if (lookahead == 'r') ADVANCE(656);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 628:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(517);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 629:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(525);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 630:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(595);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 631:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(266);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 632:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(594);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 633:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(670);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 634:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(567);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 635:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(592);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 636:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(645);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 637:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(672);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 638:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'n') ADVANCE(556);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 639:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(628);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 640:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(565);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 641:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(610);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 642:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(638);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 643:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(629);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 644:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(550);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 645:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(683);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 646:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(631);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 647:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'o') ADVANCE(555);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 648:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'p') ADVANCE(676);
+      if (lookahead == 'v') ADVANCE(587);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 649:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'p') ADVANCE(676);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 650:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'p') ADVANCE(617);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 651:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'p') ADVANCE(576);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 652:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'q') ADVANCE(686);
+      if (lookahead == 't') ADVANCE(538);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 653:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'q') ADVANCE(686);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 654:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'q') ADVANCE(688);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 655:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(499);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 656:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(551);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 657:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(539);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 658:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(561);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 659:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(553);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 660:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(607);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 661:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(585);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 662:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(690);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 663:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'r') ADVANCE(623);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 664:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(521);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 665:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(639);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 666:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(682);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 667:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(583);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 668:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(606);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 669:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(584);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 670:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(540);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 671:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(543);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 672:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(513);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 673:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(281);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 674:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(692);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 675:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(591);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 676:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(601);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 677:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(600);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 678:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(602);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 679:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(548);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 680:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(599);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 681:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(604);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 682:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(659);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 683:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 't') ADVANCE(562);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 684:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(597);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 685:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(650);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 686:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(586);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 687:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(624);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 688:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(603);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 689:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(620);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 690:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'u') ADVANCE(582);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 691:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'y') ADVANCE(534);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 692:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'y') ADVANCE(651);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 693:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == 'y') ADVANCE(674);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 694:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 695:
+      ACCEPT_TOKEN(sym_true);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 696:
+      ACCEPT_TOKEN(sym_false);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 697:
+      ACCEPT_TOKEN(sym_null);
+      if (lookahead == '\\') ADVANCE(231);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      END_STATE();
+    case 698:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(698);
+      END_STATE();
+    case 699:
       ACCEPT_TOKEN(sym__whitespace);
       END_STATE();
     default:
@@ -3765,399 +5239,431 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 0},
-  [2] = {.lex_state = 3},
-  [3] = {.lex_state = 3},
-  [4] = {.lex_state = 5},
-  [5] = {.lex_state = 5},
-  [6] = {.lex_state = 7},
-  [7] = {.lex_state = 7},
-  [8] = {.lex_state = 7},
-  [9] = {.lex_state = 7},
-  [10] = {.lex_state = 7},
-  [11] = {.lex_state = 7},
-  [12] = {.lex_state = 7},
-  [13] = {.lex_state = 7},
-  [14] = {.lex_state = 7},
-  [15] = {.lex_state = 7},
-  [16] = {.lex_state = 7},
-  [17] = {.lex_state = 7},
-  [18] = {.lex_state = 7},
-  [19] = {.lex_state = 7},
-  [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 0},
-  [23] = {.lex_state = 4},
-  [24] = {.lex_state = 4},
-  [25] = {.lex_state = 4},
-  [26] = {.lex_state = 4},
-  [27] = {.lex_state = 4},
-  [28] = {.lex_state = 4},
-  [29] = {.lex_state = 4},
-  [30] = {.lex_state = 4},
+  [1] = {.lex_state = 253},
+  [2] = {.lex_state = 253},
+  [3] = {.lex_state = 253},
+  [4] = {.lex_state = 253},
+  [5] = {.lex_state = 253},
+  [6] = {.lex_state = 253},
+  [7] = {.lex_state = 253},
+  [8] = {.lex_state = 253},
+  [9] = {.lex_state = 253},
+  [10] = {.lex_state = 253},
+  [11] = {.lex_state = 253},
+  [12] = {.lex_state = 253},
+  [13] = {.lex_state = 253},
+  [14] = {.lex_state = 253},
+  [15] = {.lex_state = 253},
+  [16] = {.lex_state = 253},
+  [17] = {.lex_state = 253},
+  [18] = {.lex_state = 253},
+  [19] = {.lex_state = 253},
+  [20] = {.lex_state = 253},
+  [21] = {.lex_state = 253},
+  [22] = {.lex_state = 253},
+  [23] = {.lex_state = 253},
+  [24] = {.lex_state = 253},
+  [25] = {.lex_state = 253},
+  [26] = {.lex_state = 253},
+  [27] = {.lex_state = 253},
+  [28] = {.lex_state = 253},
+  [29] = {.lex_state = 253},
+  [30] = {.lex_state = 253},
   [31] = {.lex_state = 4},
   [32] = {.lex_state = 4},
-  [33] = {.lex_state = 4},
-  [34] = {.lex_state = 4},
-  [35] = {.lex_state = 4},
-  [36] = {.lex_state = 4},
-  [37] = {.lex_state = 4},
-  [38] = {.lex_state = 4},
-  [39] = {.lex_state = 4},
-  [40] = {.lex_state = 4},
-  [41] = {.lex_state = 4},
-  [42] = {.lex_state = 4},
-  [43] = {.lex_state = 4},
-  [44] = {.lex_state = 4},
-  [45] = {.lex_state = 0},
-  [46] = {.lex_state = 0},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 4},
-  [49] = {.lex_state = 4},
-  [50] = {.lex_state = 4},
-  [51] = {.lex_state = 0},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 4},
-  [54] = {.lex_state = 4},
-  [55] = {.lex_state = 4},
-  [56] = {.lex_state = 4},
-  [57] = {.lex_state = 0},
-  [58] = {.lex_state = 0},
-  [59] = {.lex_state = 0},
-  [60] = {.lex_state = 0},
-  [61] = {.lex_state = 0},
-  [62] = {.lex_state = 0},
-  [63] = {.lex_state = 0},
-  [64] = {.lex_state = 0},
-  [65] = {.lex_state = 0},
-  [66] = {.lex_state = 0},
-  [67] = {.lex_state = 0},
-  [68] = {.lex_state = 0},
-  [69] = {.lex_state = 0},
-  [70] = {.lex_state = 0},
-  [71] = {.lex_state = 0},
-  [72] = {.lex_state = 0},
-  [73] = {.lex_state = 6},
-  [74] = {.lex_state = 0},
-  [75] = {.lex_state = 0},
-  [76] = {.lex_state = 6},
-  [77] = {.lex_state = 6},
-  [78] = {.lex_state = 0},
-  [79] = {.lex_state = 0},
-  [80] = {.lex_state = 6},
-  [81] = {.lex_state = 0},
-  [82] = {.lex_state = 6},
-  [83] = {.lex_state = 0},
-  [84] = {.lex_state = 0},
-  [85] = {.lex_state = 6},
-  [86] = {.lex_state = 0},
-  [87] = {.lex_state = 0},
-  [88] = {.lex_state = 0},
-  [89] = {.lex_state = 0},
-  [90] = {.lex_state = 6},
-  [91] = {.lex_state = 6},
-  [92] = {.lex_state = 6},
-  [93] = {.lex_state = 6},
-  [94] = {.lex_state = 6},
-  [95] = {.lex_state = 0},
-  [96] = {.lex_state = 0},
-  [97] = {.lex_state = 0},
-  [98] = {.lex_state = 0},
-  [99] = {.lex_state = 0},
-  [100] = {.lex_state = 0},
-  [101] = {.lex_state = 0},
-  [102] = {.lex_state = 0},
-  [103] = {.lex_state = 0},
-  [104] = {.lex_state = 0},
-  [105] = {.lex_state = 0},
-  [106] = {.lex_state = 0},
-  [107] = {.lex_state = 0},
-  [108] = {.lex_state = 0},
-  [109] = {.lex_state = 6},
-  [110] = {.lex_state = 6},
-  [111] = {.lex_state = 6},
-  [112] = {.lex_state = 0},
-  [113] = {.lex_state = 6},
-  [114] = {.lex_state = 0},
-  [115] = {.lex_state = 6},
-  [116] = {.lex_state = 6},
-  [117] = {.lex_state = 0},
-  [118] = {.lex_state = 6},
-  [119] = {.lex_state = 0},
-  [120] = {.lex_state = 0},
-  [121] = {.lex_state = 0},
-  [122] = {.lex_state = 0},
-  [123] = {.lex_state = 0},
-  [124] = {.lex_state = 6},
-  [125] = {.lex_state = 0},
-  [126] = {.lex_state = 6},
-  [127] = {.lex_state = 0},
-  [128] = {.lex_state = 0},
-  [129] = {.lex_state = 0},
-  [130] = {.lex_state = 6},
-  [131] = {.lex_state = 0},
-  [132] = {.lex_state = 0},
-  [133] = {.lex_state = 0},
-  [134] = {.lex_state = 0},
-  [135] = {.lex_state = 0},
-  [136] = {.lex_state = 0},
-  [137] = {.lex_state = 0},
-  [138] = {.lex_state = 6},
-  [139] = {.lex_state = 6},
-  [140] = {.lex_state = 0},
-  [141] = {.lex_state = 0},
-  [142] = {.lex_state = 6},
-  [143] = {.lex_state = 6},
-  [144] = {.lex_state = 0},
-  [145] = {.lex_state = 6},
-  [146] = {.lex_state = 0},
-  [147] = {.lex_state = 0},
-  [148] = {.lex_state = 0},
-  [149] = {.lex_state = 6},
-  [150] = {.lex_state = 6},
-  [151] = {.lex_state = 0},
-  [152] = {.lex_state = 0},
-  [153] = {.lex_state = 0},
-  [154] = {.lex_state = 0},
-  [155] = {.lex_state = 6},
-  [156] = {.lex_state = 0},
-  [157] = {.lex_state = 6},
-  [158] = {.lex_state = 0},
-  [159] = {.lex_state = 6},
-  [160] = {.lex_state = 0},
-  [161] = {.lex_state = 6},
-  [162] = {.lex_state = 0},
-  [163] = {.lex_state = 0},
-  [164] = {.lex_state = 0},
-  [165] = {.lex_state = 0},
-  [166] = {.lex_state = 0},
-  [167] = {.lex_state = 0},
-  [168] = {.lex_state = 0},
-  [169] = {.lex_state = 0},
-  [170] = {.lex_state = 0},
-  [171] = {.lex_state = 0},
-  [172] = {.lex_state = 0},
-  [173] = {.lex_state = 0},
-  [174] = {.lex_state = 0},
-  [175] = {.lex_state = 0},
-  [176] = {.lex_state = 0},
-  [177] = {.lex_state = 0},
-  [178] = {.lex_state = 0},
-  [179] = {.lex_state = 0},
-  [180] = {.lex_state = 0},
-  [181] = {.lex_state = 4},
-  [182] = {.lex_state = 4},
-  [183] = {.lex_state = 4},
-  [184] = {.lex_state = 0},
-  [185] = {.lex_state = 4},
-  [186] = {.lex_state = 0},
-  [187] = {.lex_state = 0},
-  [188] = {.lex_state = 0},
-  [189] = {.lex_state = 0},
-  [190] = {.lex_state = 0},
-  [191] = {.lex_state = 0},
-  [192] = {.lex_state = 0},
-  [193] = {.lex_state = 0},
-  [194] = {.lex_state = 0},
-  [195] = {.lex_state = 0},
-  [196] = {.lex_state = 0},
-  [197] = {.lex_state = 0},
-  [198] = {.lex_state = 0},
-  [199] = {.lex_state = 0},
-  [200] = {.lex_state = 0},
-  [201] = {.lex_state = 0},
-  [202] = {.lex_state = 0},
-  [203] = {.lex_state = 6},
-  [204] = {.lex_state = 0},
-  [205] = {.lex_state = 6},
-  [206] = {.lex_state = 6},
-  [207] = {.lex_state = 6},
-  [208] = {.lex_state = 6},
-  [209] = {.lex_state = 6},
-  [210] = {.lex_state = 6},
-  [211] = {.lex_state = 6},
-  [212] = {.lex_state = 6},
-  [213] = {.lex_state = 0},
-  [214] = {.lex_state = 0},
-  [215] = {.lex_state = 0},
-  [216] = {.lex_state = 0},
-  [217] = {.lex_state = 0},
-  [218] = {.lex_state = 0},
-  [219] = {.lex_state = 0},
-  [220] = {.lex_state = 0},
-  [221] = {.lex_state = 0},
-  [222] = {.lex_state = 0},
-  [223] = {.lex_state = 0},
-  [224] = {.lex_state = 0},
-  [225] = {.lex_state = 0},
-  [226] = {.lex_state = 0},
-  [227] = {.lex_state = 0},
-  [228] = {.lex_state = 0},
-  [229] = {.lex_state = 0},
-  [230] = {.lex_state = 0},
-  [231] = {.lex_state = 0},
-  [232] = {.lex_state = 0},
-  [233] = {.lex_state = 0},
-  [234] = {.lex_state = 0},
-  [235] = {.lex_state = 0},
-  [236] = {.lex_state = 0},
-  [237] = {.lex_state = 0},
-  [238] = {.lex_state = 0},
-  [239] = {.lex_state = 0},
-  [240] = {.lex_state = 3},
-  [241] = {.lex_state = 0},
-  [242] = {.lex_state = 0},
+  [33] = {.lex_state = 6},
+  [34] = {.lex_state = 6},
+  [35] = {.lex_state = 8},
+  [36] = {.lex_state = 8},
+  [37] = {.lex_state = 8},
+  [38] = {.lex_state = 8},
+  [39] = {.lex_state = 8},
+  [40] = {.lex_state = 8},
+  [41] = {.lex_state = 8},
+  [42] = {.lex_state = 8},
+  [43] = {.lex_state = 8},
+  [44] = {.lex_state = 8},
+  [45] = {.lex_state = 8},
+  [46] = {.lex_state = 8},
+  [47] = {.lex_state = 8},
+  [48] = {.lex_state = 8},
+  [49] = {.lex_state = 253},
+  [50] = {.lex_state = 253},
+  [51] = {.lex_state = 253},
+  [52] = {.lex_state = 5},
+  [53] = {.lex_state = 5},
+  [54] = {.lex_state = 5},
+  [55] = {.lex_state = 5},
+  [56] = {.lex_state = 5},
+  [57] = {.lex_state = 5},
+  [58] = {.lex_state = 5},
+  [59] = {.lex_state = 5},
+  [60] = {.lex_state = 5},
+  [61] = {.lex_state = 5},
+  [62] = {.lex_state = 5},
+  [63] = {.lex_state = 5},
+  [64] = {.lex_state = 5},
+  [65] = {.lex_state = 5},
+  [66] = {.lex_state = 5},
+  [67] = {.lex_state = 253},
+  [68] = {.lex_state = 5},
+  [69] = {.lex_state = 253},
+  [70] = {.lex_state = 5},
+  [71] = {.lex_state = 5},
+  [72] = {.lex_state = 5},
+  [73] = {.lex_state = 253},
+  [74] = {.lex_state = 5},
+  [75] = {.lex_state = 253},
+  [76] = {.lex_state = 5},
+  [77] = {.lex_state = 5},
+  [78] = {.lex_state = 253},
+  [79] = {.lex_state = 253},
+  [80] = {.lex_state = 253},
+  [81] = {.lex_state = 253},
+  [82] = {.lex_state = 253},
+  [83] = {.lex_state = 5},
+  [84] = {.lex_state = 253},
+  [85] = {.lex_state = 253},
+  [86] = {.lex_state = 253},
+  [87] = {.lex_state = 253},
+  [88] = {.lex_state = 253},
+  [89] = {.lex_state = 253},
+  [90] = {.lex_state = 5},
+  [91] = {.lex_state = 253},
+  [92] = {.lex_state = 5},
+  [93] = {.lex_state = 253},
+  [94] = {.lex_state = 253},
+  [95] = {.lex_state = 253},
+  [96] = {.lex_state = 253},
+  [97] = {.lex_state = 253},
+  [98] = {.lex_state = 253},
+  [99] = {.lex_state = 253},
+  [100] = {.lex_state = 253},
+  [101] = {.lex_state = 253},
+  [102] = {.lex_state = 7},
+  [103] = {.lex_state = 7},
+  [104] = {.lex_state = 7},
+  [105] = {.lex_state = 7},
+  [106] = {.lex_state = 253},
+  [107] = {.lex_state = 253},
+  [108] = {.lex_state = 253},
+  [109] = {.lex_state = 253},
+  [110] = {.lex_state = 253},
+  [111] = {.lex_state = 7},
+  [112] = {.lex_state = 7},
+  [113] = {.lex_state = 253},
+  [114] = {.lex_state = 253},
+  [115] = {.lex_state = 253},
+  [116] = {.lex_state = 253},
+  [117] = {.lex_state = 7},
+  [118] = {.lex_state = 7},
+  [119] = {.lex_state = 253},
+  [120] = {.lex_state = 253},
+  [121] = {.lex_state = 253},
+  [122] = {.lex_state = 7},
+  [123] = {.lex_state = 253},
+  [124] = {.lex_state = 253},
+  [125] = {.lex_state = 253},
+  [126] = {.lex_state = 7},
+  [127] = {.lex_state = 7},
+  [128] = {.lex_state = 253},
+  [129] = {.lex_state = 253},
+  [130] = {.lex_state = 253},
+  [131] = {.lex_state = 253},
+  [132] = {.lex_state = 253},
+  [133] = {.lex_state = 253},
+  [134] = {.lex_state = 253},
+  [135] = {.lex_state = 253},
+  [136] = {.lex_state = 7},
+  [137] = {.lex_state = 253},
+  [138] = {.lex_state = 253},
+  [139] = {.lex_state = 253},
+  [140] = {.lex_state = 253},
+  [141] = {.lex_state = 253},
+  [142] = {.lex_state = 253},
+  [143] = {.lex_state = 7},
+  [144] = {.lex_state = 253},
+  [145] = {.lex_state = 7},
+  [146] = {.lex_state = 253},
+  [147] = {.lex_state = 253},
+  [148] = {.lex_state = 253},
+  [149] = {.lex_state = 253},
+  [150] = {.lex_state = 7},
+  [151] = {.lex_state = 7},
+  [152] = {.lex_state = 7},
+  [153] = {.lex_state = 253},
+  [154] = {.lex_state = 7},
+  [155] = {.lex_state = 253},
+  [156] = {.lex_state = 253},
+  [157] = {.lex_state = 253},
+  [158] = {.lex_state = 7},
+  [159] = {.lex_state = 253},
+  [160] = {.lex_state = 253},
+  [161] = {.lex_state = 253},
+  [162] = {.lex_state = 253},
+  [163] = {.lex_state = 253},
+  [164] = {.lex_state = 7},
+  [165] = {.lex_state = 7},
+  [166] = {.lex_state = 253},
+  [167] = {.lex_state = 7},
+  [168] = {.lex_state = 253},
+  [169] = {.lex_state = 7},
+  [170] = {.lex_state = 7},
+  [171] = {.lex_state = 253},
+  [172] = {.lex_state = 253},
+  [173] = {.lex_state = 7},
+  [174] = {.lex_state = 253},
+  [175] = {.lex_state = 253},
+  [176] = {.lex_state = 253},
+  [177] = {.lex_state = 253},
+  [178] = {.lex_state = 7},
+  [179] = {.lex_state = 253},
+  [180] = {.lex_state = 253},
+  [181] = {.lex_state = 253},
+  [182] = {.lex_state = 253},
+  [183] = {.lex_state = 7},
+  [184] = {.lex_state = 253},
+  [185] = {.lex_state = 253},
+  [186] = {.lex_state = 7},
+  [187] = {.lex_state = 7},
+  [188] = {.lex_state = 7},
+  [189] = {.lex_state = 253},
+  [190] = {.lex_state = 7},
+  [191] = {.lex_state = 7},
+  [192] = {.lex_state = 253},
+  [193] = {.lex_state = 253},
+  [194] = {.lex_state = 253},
+  [195] = {.lex_state = 253},
+  [196] = {.lex_state = 253},
+  [197] = {.lex_state = 253},
+  [198] = {.lex_state = 253},
+  [199] = {.lex_state = 253},
+  [200] = {.lex_state = 253},
+  [201] = {.lex_state = 253},
+  [202] = {.lex_state = 253},
+  [203] = {.lex_state = 253},
+  [204] = {.lex_state = 253},
+  [205] = {.lex_state = 253},
+  [206] = {.lex_state = 253},
+  [207] = {.lex_state = 253},
+  [208] = {.lex_state = 253},
+  [209] = {.lex_state = 253},
+  [210] = {.lex_state = 253},
+  [211] = {.lex_state = 253},
+  [212] = {.lex_state = 5},
+  [213] = {.lex_state = 5},
+  [214] = {.lex_state = 5},
+  [215] = {.lex_state = 253},
+  [216] = {.lex_state = 5},
+  [217] = {.lex_state = 253},
+  [218] = {.lex_state = 253},
+  [219] = {.lex_state = 253},
+  [220] = {.lex_state = 253},
+  [221] = {.lex_state = 253},
+  [222] = {.lex_state = 253},
+  [223] = {.lex_state = 253},
+  [224] = {.lex_state = 253},
+  [225] = {.lex_state = 253},
+  [226] = {.lex_state = 253},
+  [227] = {.lex_state = 253},
+  [228] = {.lex_state = 253},
+  [229] = {.lex_state = 253},
+  [230] = {.lex_state = 253},
+  [231] = {.lex_state = 253},
+  [232] = {.lex_state = 7},
+  [233] = {.lex_state = 253},
+  [234] = {.lex_state = 253},
+  [235] = {.lex_state = 253},
+  [236] = {.lex_state = 2},
+  [237] = {.lex_state = 7},
+  [238] = {.lex_state = 2},
+  [239] = {.lex_state = 2},
+  [240] = {.lex_state = 2},
+  [241] = {.lex_state = 2},
+  [242] = {.lex_state = 2},
   [243] = {.lex_state = 2},
   [244] = {.lex_state = 2},
   [245] = {.lex_state = 2},
-  [246] = {.lex_state = 0},
+  [246] = {.lex_state = 2},
   [247] = {.lex_state = 2},
   [248] = {.lex_state = 2},
   [249] = {.lex_state = 2},
   [250] = {.lex_state = 2},
-  [251] = {.lex_state = 0},
-  [252] = {.lex_state = 2},
-  [253] = {.lex_state = 0},
-  [254] = {.lex_state = 0},
-  [255] = {.lex_state = 0},
-  [256] = {.lex_state = 3},
+  [251] = {.lex_state = 7},
+  [252] = {.lex_state = 7},
+  [253] = {.lex_state = 2},
+  [254] = {.lex_state = 2},
+  [255] = {.lex_state = 253},
+  [256] = {.lex_state = 2},
   [257] = {.lex_state = 2},
-  [258] = {.lex_state = 0},
-  [259] = {.lex_state = 0},
-  [260] = {.lex_state = 2},
-  [261] = {.lex_state = 2},
+  [258] = {.lex_state = 2},
+  [259] = {.lex_state = 2},
+  [260] = {.lex_state = 7},
+  [261] = {.lex_state = 7},
   [262] = {.lex_state = 2},
-  [263] = {.lex_state = 2},
+  [263] = {.lex_state = 7},
   [264] = {.lex_state = 2},
-  [265] = {.lex_state = 0},
-  [266] = {.lex_state = 2},
-  [267] = {.lex_state = 3},
-  [268] = {.lex_state = 0},
+  [265] = {.lex_state = 2},
+  [266] = {.lex_state = 7},
+  [267] = {.lex_state = 2},
+  [268] = {.lex_state = 2},
   [269] = {.lex_state = 2},
-  [270] = {.lex_state = 0},
+  [270] = {.lex_state = 2},
   [271] = {.lex_state = 2},
   [272] = {.lex_state = 2},
   [273] = {.lex_state = 2},
-  [274] = {.lex_state = 0},
+  [274] = {.lex_state = 2},
   [275] = {.lex_state = 2},
   [276] = {.lex_state = 2},
-  [277] = {.lex_state = 0},
-  [278] = {.lex_state = 0},
-  [279] = {.lex_state = 0},
-  [280] = {.lex_state = 0},
-  [281] = {.lex_state = 2},
-  [282] = {.lex_state = 2},
-  [283] = {.lex_state = 2},
-  [284] = {.lex_state = 2},
-  [285] = {.lex_state = 0},
-  [286] = {.lex_state = 0},
-  [287] = {.lex_state = 2},
-  [288] = {.lex_state = 0},
-  [289] = {.lex_state = 2},
-  [290] = {.lex_state = 0},
-  [291] = {.lex_state = 0},
-  [292] = {.lex_state = 5},
-  [293] = {.lex_state = 0},
-  [294] = {.lex_state = 0},
-  [295] = {.lex_state = 0},
-  [296] = {.lex_state = 0},
-  [297] = {.lex_state = 0},
-  [298] = {.lex_state = 0},
-  [299] = {.lex_state = 0},
-  [300] = {.lex_state = 0},
-  [301] = {.lex_state = 0},
-  [302] = {.lex_state = 0},
-  [303] = {.lex_state = 2},
-  [304] = {.lex_state = 0},
-  [305] = {.lex_state = 0},
-  [306] = {.lex_state = 0},
-  [307] = {.lex_state = 0},
-  [308] = {.lex_state = 0},
-  [309] = {.lex_state = 0},
-  [310] = {.lex_state = 2},
-  [311] = {.lex_state = 0},
-  [312] = {.lex_state = 0},
-  [313] = {.lex_state = 0},
-  [314] = {.lex_state = 0},
-  [315] = {.lex_state = 0},
-  [316] = {.lex_state = 0},
-  [317] = {.lex_state = 0},
-  [318] = {.lex_state = 2},
-  [319] = {.lex_state = 0},
-  [320] = {.lex_state = 2},
-  [321] = {.lex_state = 0},
-  [322] = {.lex_state = 2},
-  [323] = {.lex_state = 0},
-  [324] = {.lex_state = 0},
-  [325] = {.lex_state = 2},
-  [326] = {.lex_state = 0},
-  [327] = {.lex_state = 5},
-  [328] = {.lex_state = 0},
-  [329] = {.lex_state = 0},
-  [330] = {.lex_state = 2},
-  [331] = {.lex_state = 0},
-  [332] = {.lex_state = 2},
-  [333] = {.lex_state = 2},
-  [334] = {.lex_state = 2},
-  [335] = {.lex_state = 0},
-  [336] = {.lex_state = 0},
-  [337] = {.lex_state = 0},
-  [338] = {.lex_state = 2},
-  [339] = {.lex_state = 0},
-  [340] = {.lex_state = 0},
-  [341] = {.lex_state = 0},
-  [342] = {.lex_state = 0},
-  [343] = {.lex_state = 0},
-  [344] = {.lex_state = 0},
-  [345] = {.lex_state = 2},
-  [346] = {.lex_state = 2},
-  [347] = {.lex_state = 0},
-  [348] = {.lex_state = 0},
-  [349] = {.lex_state = 3},
-  [350] = {.lex_state = 0},
-  [351] = {.lex_state = 0},
-  [352] = {.lex_state = 2},
-  [353] = {.lex_state = 2},
-  [354] = {.lex_state = 0},
-  [355] = {.lex_state = 0},
-  [356] = {.lex_state = 0},
-  [357] = {.lex_state = 2},
-  [358] = {.lex_state = 0},
-  [359] = {.lex_state = 0},
-  [360] = {.lex_state = 0},
-  [361] = {.lex_state = 0},
-  [362] = {.lex_state = 0},
-  [363] = {.lex_state = 0},
-  [364] = {.lex_state = 0},
-  [365] = {.lex_state = 2},
-  [366] = {.lex_state = 0},
-  [367] = {.lex_state = 0},
-  [368] = {.lex_state = 0},
-  [369] = {.lex_state = 0},
-  [370] = {.lex_state = 0},
-  [371] = {.lex_state = 0},
-  [372] = {.lex_state = 0},
-  [373] = {.lex_state = 0},
-  [374] = {.lex_state = 2},
-  [375] = {.lex_state = 0},
-  [376] = {.lex_state = 0},
-  [377] = {.lex_state = 0},
-  [378] = {.lex_state = 0},
-  [379] = {.lex_state = 2},
-  [380] = {.lex_state = 0},
-  [381] = {.lex_state = 2},
-  [382] = {.lex_state = 0},
-  [383] = {.lex_state = 0},
-  [384] = {.lex_state = 0},
-  [385] = {.lex_state = 0},
-  [386] = {.lex_state = 0},
-  [387] = {.lex_state = 0},
-  [388] = {.lex_state = 0},
-  [389] = {.lex_state = 2},
-  [390] = {.lex_state = 2},
-  [391] = {.lex_state = 2},
-  [392] = {.lex_state = 0},
-  [393] = {.lex_state = 2},
+  [277] = {.lex_state = 7},
+  [278] = {.lex_state = 2},
+  [279] = {.lex_state = 2},
+  [280] = {.lex_state = 253},
+  [281] = {.lex_state = 253},
+  [282] = {.lex_state = 253},
+  [283] = {.lex_state = 253},
+  [284] = {.lex_state = 253},
+  [285] = {.lex_state = 253},
+  [286] = {.lex_state = 253},
+  [287] = {.lex_state = 253},
+  [288] = {.lex_state = 253},
+  [289] = {.lex_state = 253},
+  [290] = {.lex_state = 253},
+  [291] = {.lex_state = 253},
+  [292] = {.lex_state = 253},
+  [293] = {.lex_state = 253},
+  [294] = {.lex_state = 253},
+  [295] = {.lex_state = 253},
+  [296] = {.lex_state = 253},
+  [297] = {.lex_state = 253},
+  [298] = {.lex_state = 1},
+  [299] = {.lex_state = 1},
+  [300] = {.lex_state = 253},
+  [301] = {.lex_state = 253},
+  [302] = {.lex_state = 1},
+  [303] = {.lex_state = 253},
+  [304] = {.lex_state = 253},
+  [305] = {.lex_state = 253},
+  [306] = {.lex_state = 253},
+  [307] = {.lex_state = 253},
+  [308] = {.lex_state = 253},
+  [309] = {.lex_state = 253},
+  [310] = {.lex_state = 253},
+  [311] = {.lex_state = 4},
+  [312] = {.lex_state = 253},
+  [313] = {.lex_state = 4},
+  [314] = {.lex_state = 253},
+  [315] = {.lex_state = 253},
+  [316] = {.lex_state = 253},
+  [317] = {.lex_state = 253},
+  [318] = {.lex_state = 4},
+  [319] = {.lex_state = 4},
+  [320] = {.lex_state = 4},
+  [321] = {.lex_state = 253},
+  [322] = {.lex_state = 253},
+  [323] = {.lex_state = 253},
+  [324] = {.lex_state = 253},
+  [325] = {.lex_state = 253},
+  [326] = {.lex_state = 4},
+  [327] = {.lex_state = 4},
+  [328] = {.lex_state = 4},
+  [329] = {.lex_state = 4},
+  [330] = {.lex_state = 4},
+  [331] = {.lex_state = 3},
+  [332] = {.lex_state = 253},
+  [333] = {.lex_state = 253},
+  [334] = {.lex_state = 253},
+  [335] = {.lex_state = 253},
+  [336] = {.lex_state = 253},
+  [337] = {.lex_state = 253},
+  [338] = {.lex_state = 253},
+  [339] = {.lex_state = 253},
+  [340] = {.lex_state = 253},
+  [341] = {.lex_state = 253},
+  [342] = {.lex_state = 4},
+  [343] = {.lex_state = 3},
+  [344] = {.lex_state = 253},
+  [345] = {.lex_state = 253},
+  [346] = {.lex_state = 253},
+  [347] = {.lex_state = 253},
+  [348] = {.lex_state = 4},
+  [349] = {.lex_state = 253},
+  [350] = {.lex_state = 253},
+  [351] = {.lex_state = 3},
+  [352] = {.lex_state = 253},
+  [353] = {.lex_state = 253},
+  [354] = {.lex_state = 6},
+  [355] = {.lex_state = 253},
+  [356] = {.lex_state = 253},
+  [357] = {.lex_state = 253},
+  [358] = {.lex_state = 4},
+  [359] = {.lex_state = 253},
+  [360] = {.lex_state = 3},
+  [361] = {.lex_state = 3},
+  [362] = {.lex_state = 3},
+  [363] = {.lex_state = 3},
+  [364] = {.lex_state = 3},
+  [365] = {.lex_state = 3},
+  [366] = {.lex_state = 253},
+  [367] = {.lex_state = 3},
+  [368] = {.lex_state = 253},
+  [369] = {.lex_state = 253},
+  [370] = {.lex_state = 253},
+  [371] = {.lex_state = 253},
+  [372] = {.lex_state = 253},
+  [373] = {.lex_state = 253},
+  [374] = {.lex_state = 253},
+  [375] = {.lex_state = 253},
+  [376] = {.lex_state = 253},
+  [377] = {.lex_state = 253},
+  [378] = {.lex_state = 3},
+  [379] = {.lex_state = 3},
+  [380] = {.lex_state = 3},
+  [381] = {.lex_state = 253},
+  [382] = {.lex_state = 253},
+  [383] = {.lex_state = 3},
+  [384] = {.lex_state = 3},
+  [385] = {.lex_state = 3},
+  [386] = {.lex_state = 3},
+  [387] = {.lex_state = 253},
+  [388] = {.lex_state = 253},
+  [389] = {.lex_state = 253},
+  [390] = {.lex_state = 3},
+  [391] = {.lex_state = 253},
+  [392] = {.lex_state = 3},
+  [393] = {.lex_state = 4},
+  [394] = {.lex_state = 253},
+  [395] = {.lex_state = 3},
+  [396] = {.lex_state = 253},
+  [397] = {.lex_state = 253},
+  [398] = {.lex_state = 253},
+  [399] = {.lex_state = 253},
+  [400] = {.lex_state = 253},
+  [401] = {.lex_state = 253},
+  [402] = {.lex_state = 253},
+  [403] = {.lex_state = 253},
+  [404] = {.lex_state = 253},
+  [405] = {.lex_state = 4},
+  [406] = {.lex_state = 253},
+  [407] = {.lex_state = 253},
+  [408] = {.lex_state = 253},
+  [409] = {.lex_state = 253},
+  [410] = {.lex_state = 253},
+  [411] = {.lex_state = 253},
+  [412] = {.lex_state = 253},
+  [413] = {.lex_state = 253},
+  [414] = {.lex_state = 253},
+  [415] = {.lex_state = 3},
+  [416] = {.lex_state = 253},
+  [417] = {.lex_state = 3},
+  [418] = {.lex_state = 253},
+  [419] = {.lex_state = 4},
+  [420] = {.lex_state = 253},
+  [421] = {.lex_state = 3},
+  [422] = {.lex_state = 3},
+  [423] = {.lex_state = 253},
+  [424] = {.lex_state = 6},
+  [425] = {.lex_state = 253},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -4196,7 +5702,28 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_inheritable] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
     [anon_sym_setof] = ACTIONS(1),
-    [sym_str] = ACTIONS(1),
+    [anon_sym_global] = ACTIONS(1),
+    [anon_sym_AMP_AMP] = ACTIONS(1),
+    [anon_sym_PIPE_PIPE] = ACTIONS(1),
+    [anon_sym_GT_GT] = ACTIONS(1),
+    [anon_sym_LT_LT] = ACTIONS(1),
+    [anon_sym_AMP] = ACTIONS(1),
+    [anon_sym_CARET] = ACTIONS(1),
+    [anon_sym_PIPE] = ACTIONS(1),
+    [anon_sym_PLUS] = ACTIONS(1),
+    [anon_sym_DASH] = ACTIONS(1),
+    [anon_sym_STAR] = ACTIONS(1),
+    [anon_sym_SLASH] = ACTIONS(1),
+    [anon_sym_PERCENT] = ACTIONS(1),
+    [anon_sym_LT] = ACTIONS(1),
+    [anon_sym_LT_EQ] = ACTIONS(1),
+    [anon_sym_EQ] = ACTIONS(1),
+    [anon_sym_BANG_EQ] = ACTIONS(1),
+    [anon_sym_GT_EQ] = ACTIONS(1),
+    [anon_sym_GT] = ACTIONS(1),
+    [anon_sym_SQUOTE] = ACTIONS(1),
+    [sym_unescaped_single_string_fragment] = ACTIONS(1),
+    [sym_escape_sequence] = ACTIONS(1),
     [anon_sym_str] = ACTIONS(1),
     [anon_sym_bool] = ACTIONS(1),
     [anon_sym_int16] = ACTIONS(1),
@@ -4218,8 +5745,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_sequence] = ACTIONS(1),
     [anon_sym_anytype] = ACTIONS(1),
     [anon_sym_array] = ACTIONS(1),
-    [anon_sym_LT] = ACTIONS(1),
-    [anon_sym_GT] = ACTIONS(1),
     [anon_sym_tuple] = ACTIONS(1),
     [anon_sym_enum] = ACTIONS(1),
     [sym_true] = ACTIONS(1),
@@ -4229,1998 +5754,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__whitespace] = ACTIONS(3),
   },
   [1] = {
-    [sym_source_file] = STATE(360),
-    [sym_module] = STATE(236),
-    [aux_sym_source_file_repeat1] = STATE(236),
+    [sym_source_file] = STATE(420),
+    [sym_module] = STATE(306),
+    [aux_sym_source_file_repeat1] = STATE(306),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_module] = ACTIONS(7),
-    [sym_comment] = ACTIONS(3),
-    [sym__whitespace] = ACTIONS(3),
+    [sym_comment] = ACTIONS(9),
+    [sym__whitespace] = ACTIONS(9),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 11,
-    ACTIONS(9), 1,
-      anon_sym_optional,
-    ACTIONS(11), 1,
-      anon_sym_setof,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(234), 1,
-      sym_returnspec,
-    STATE(285), 1,
-      sym_type,
-    ACTIONS(3), 2,
+  [0] = 4,
+    ACTIONS(13), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [57] = 11,
-    ACTIONS(9), 1,
-      anon_sym_optional,
-    ACTIONS(11), 1,
-      anon_sym_setof,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(233), 1,
-      sym_returnspec,
-    STATE(285), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [114] = 9,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    ACTIONS(21), 1,
-      anon_sym_scalartype,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    STATE(36), 2,
-      sym_enum,
-      sym_type,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [166] = 9,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    ACTIONS(21), 1,
-      anon_sym_scalartype,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    STATE(39), 2,
-      sym_enum,
-      sym_type,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [218] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(295), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [266] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(54), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [314] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(53), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [362] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(55), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [410] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(382), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [458] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(48), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [506] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(280), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [554] = 9,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    ACTIONS(23), 1,
-      sym_identifier,
-    STATE(265), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 17,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [604] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(50), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [652] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(274), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [700] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(49), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [748] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(56), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [796] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(44), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [844] = 8,
-    ACTIONS(17), 1,
-      anon_sym_array,
-    ACTIONS(19), 1,
-      anon_sym_tuple,
-    STATE(302), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(32), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(15), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(27), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(13), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [892] = 14,
-    ACTIONS(25), 1,
-      anon_sym_RBRACE,
-    ACTIONS(27), 1,
-      anon_sym_type,
-    ACTIONS(29), 1,
-      anon_sym_scalar,
-    ACTIONS(31), 1,
-      anon_sym_link,
-    ACTIONS(33), 1,
-      anon_sym_property,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(37), 1,
-      anon_sym_constraint,
-    ACTIONS(39), 1,
-      anon_sym_alias,
-    ACTIONS(41), 1,
-      anon_sym_function,
-    STATE(187), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(199), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-    STATE(22), 9,
-      sym_object_type,
-      sym_scalar_type_def,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_alias,
-      sym_function,
-      aux_sym_schema_declarations_repeat1,
-  [950] = 14,
-    ACTIONS(45), 1,
-      anon_sym_RBRACE,
-    ACTIONS(47), 1,
-      anon_sym_type,
-    ACTIONS(50), 1,
-      anon_sym_scalar,
-    ACTIONS(53), 1,
-      anon_sym_link,
-    ACTIONS(56), 1,
-      anon_sym_property,
-    ACTIONS(59), 1,
-      anon_sym_annotation,
-    ACTIONS(62), 1,
-      anon_sym_constraint,
-    ACTIONS(65), 1,
-      anon_sym_alias,
-    ACTIONS(68), 1,
-      anon_sym_function,
-    STATE(187), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(199), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(71), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-    STATE(21), 9,
-      sym_object_type,
-      sym_scalar_type_def,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_alias,
-      sym_function,
-      aux_sym_schema_declarations_repeat1,
-  [1008] = 14,
-    ACTIONS(27), 1,
-      anon_sym_type,
-    ACTIONS(29), 1,
-      anon_sym_scalar,
-    ACTIONS(31), 1,
-      anon_sym_link,
-    ACTIONS(33), 1,
-      anon_sym_property,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(37), 1,
-      anon_sym_constraint,
-    ACTIONS(39), 1,
-      anon_sym_alias,
-    ACTIONS(41), 1,
-      anon_sym_function,
-    ACTIONS(74), 1,
-      anon_sym_RBRACE,
-    STATE(187), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(199), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-    STATE(21), 9,
-      sym_object_type,
-      sym_scalar_type_def,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_alias,
-      sym_function,
-      aux_sym_schema_declarations_repeat1,
-  [1066] = 9,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(80), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(82), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(84), 1,
-      anon_sym_SEMI,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    STATE(38), 1,
-      sym_extending,
-    STATE(66), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(78), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1111] = 9,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(90), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(92), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(94), 1,
-      anon_sym_SEMI,
-    STATE(40), 1,
-      sym_extending,
-    STATE(63), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(88), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1156] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(96), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
+    ACTIONS(15), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
       anon_sym_GT,
-  [1187] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(98), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1218] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(100), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1249] = 9,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(104), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(106), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(108), 1,
-      anon_sym_SEMI,
-    STATE(43), 1,
-      sym_extending,
-    STATE(86), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(102), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1294] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(110), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1325] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(112), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1356] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(114), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1387] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(116), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [1418] = 9,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(120), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(122), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(124), 1,
-      anon_sym_SEMI,
-    STATE(42), 1,
-      sym_extending,
-    STATE(84), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(118), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1463] = 4,
-    ACTIONS(128), 1,
-      anon_sym_COMMA,
-    STATE(34), 1,
-      aux_sym_extending_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(126), 21,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1497] = 4,
-    ACTIONS(133), 1,
-      anon_sym_COMMA,
-    STATE(34), 1,
-      aux_sym_extending_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(131), 21,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1531] = 4,
-    ACTIONS(133), 1,
-      anon_sym_COMMA,
-    STATE(35), 1,
-      aux_sym_extending_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(135), 21,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1565] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(137), 22,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1594] = 7,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(141), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(143), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(145), 1,
-      anon_sym_SEMI,
-    STATE(100), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(139), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1633] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(147), 22,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1662] = 7,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(151), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(153), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(155), 1,
-      anon_sym_SEMI,
-    STATE(97), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(149), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1701] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(157), 22,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1730] = 7,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(161), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(163), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(165), 1,
-      anon_sym_SEMI,
-    STATE(60), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(159), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1769] = 7,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(169), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(171), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(173), 1,
-      anon_sym_SEMI,
-    STATE(71), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(167), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1808] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(177), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(179), 1,
-      anon_sym_SEMI,
-    STATE(89), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(175), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1844] = 11,
-    ACTIONS(181), 1,
-      anon_sym_RBRACE,
-    ACTIONS(183), 1,
-      anon_sym_link,
-    ACTIONS(186), 1,
-      anon_sym_property,
-    ACTIONS(189), 1,
-      anon_sym_annotation,
-    ACTIONS(192), 1,
-      anon_sym_constraint,
-    ACTIONS(195), 1,
-      anon_sym_index,
-    STATE(204), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(213), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(45), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(198), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1890] = 11,
-    ACTIONS(31), 1,
-      anon_sym_link,
-    ACTIONS(33), 1,
-      anon_sym_property,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(37), 1,
-      anon_sym_constraint,
-    ACTIONS(201), 1,
-      anon_sym_RBRACE,
-    ACTIONS(203), 1,
-      anon_sym_index,
-    STATE(204), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(213), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(51), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [1936] = 4,
-    ACTIONS(207), 1,
-      anon_sym_cal_COLON_COLONlocal_date,
-    STATE(304), 1,
-      sym__scalar_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(205), 19,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [1968] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(211), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(213), 1,
-      anon_sym_SEMI,
-    STATE(65), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(209), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2004] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(217), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(219), 1,
-      anon_sym_SEMI,
-    STATE(67), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(215), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2040] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(223), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(225), 1,
-      anon_sym_SEMI,
-    STATE(70), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(221), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2076] = 11,
-    ACTIONS(31), 1,
-      anon_sym_link,
-    ACTIONS(33), 1,
-      anon_sym_property,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(37), 1,
-      anon_sym_constraint,
-    ACTIONS(203), 1,
-      anon_sym_index,
-    ACTIONS(227), 1,
-      anon_sym_RBRACE,
-    STATE(204), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(213), 1,
-      sym_modifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(45), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2122] = 4,
-    ACTIONS(231), 1,
-      anon_sym_cal_COLON_COLONlocal_date,
-    STATE(255), 1,
-      sym__scalar_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(229), 19,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [2154] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(235), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(237), 1,
-      anon_sym_SEMI,
-    STATE(72), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(233), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2190] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(241), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(243), 1,
-      anon_sym_SEMI,
-    STATE(61), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(239), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2226] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(247), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(249), 1,
-      anon_sym_SEMI,
-    STATE(74), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(245), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2262] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(253), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(255), 1,
-      anon_sym_SEMI,
-    STATE(88), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(251), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2298] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    STATE(96), 1,
-      sym_extending,
-    STATE(172), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(257), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2333] = 6,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    STATE(62), 1,
-      sym_extending,
-    STATE(180), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(259), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2368] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(261), 19,
+    ACTIONS(11), 34,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6233,6 +5789,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_alias,
       anon_sym_function,
       anon_sym_RPAREN,
+      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6240,13 +5797,897 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2394] = 3,
-    ACTIONS(249), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [50] = 3,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(245), 17,
+    ACTIONS(19), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(17), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [97] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(23), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(21), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [144] = 11,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 22,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+  [207] = 12,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 21,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_PIPE_PIPE,
+  [272] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(15), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(11), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [319] = 5,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(47), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(25), 29,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [370] = 9,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(47), 2,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 23,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+  [429] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(51), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(49), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [476] = 10,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(47), 1,
+      anon_sym_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 23,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+  [537] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(55), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(53), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [584] = 11,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(47), 1,
+      anon_sym_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 22,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+  [647] = 4,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(47), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(25), 31,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [696] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(47), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(25), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [743] = 6,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(47), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(25), 27,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [796] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(59), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(57), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [843] = 8,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(47), 2,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(25), 25,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+  [900] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(63), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(61), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [947] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(67), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(65), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [994] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(71), 1,
+      anon_sym_SEMI,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(69), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6264,13 +6705,42 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2421] = 3,
-    ACTIONS(255), 1,
+  [1061] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(77), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(251), 17,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(75), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6288,38 +6758,1320 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2448] = 4,
-    ACTIONS(76), 1,
+  [1128] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(81), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(79), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1195] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(85), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(83), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1262] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(89), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(87), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1329] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(93), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(91), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1396] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(97), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(95), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1463] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(101), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(99), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1530] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(105), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(103), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1597] = 14,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(109), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(107), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1664] = 11,
+    ACTIONS(111), 1,
+      anon_sym_optional,
+    ACTIONS(113), 1,
+      anon_sym_setof,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(309), 1,
+      sym_returnspec,
+    STATE(324), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1721] = 11,
+    ACTIONS(111), 1,
+      anon_sym_optional,
+    ACTIONS(113), 1,
+      anon_sym_setof,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(308), 1,
+      sym_returnspec,
+    STATE(324), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1778] = 9,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    ACTIONS(123), 1,
+      anon_sym_scalartype,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    STATE(65), 2,
+      sym_enum,
+      sym_type,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1830] = 9,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    ACTIONS(123), 1,
+      anon_sym_scalartype,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    STATE(71), 2,
+      sym_enum,
+      sym_type,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1882] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(74), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1930] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(348), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1978] = 9,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    ACTIONS(125), 1,
+      sym_identifier,
+    STATE(313), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 17,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [2028] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(318), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2076] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(393), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2124] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(83), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2172] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(108), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2220] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(76), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2268] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(133), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2316] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(77), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2364] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(315), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2412] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(107), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2460] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(342), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2508] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(114), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(57), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(58), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2556] = 14,
+    ACTIONS(127), 1,
+      anon_sym_RBRACE,
+    ACTIONS(129), 1,
+      anon_sym_type,
+    ACTIONS(132), 1,
+      anon_sym_scalar,
+    ACTIONS(135), 1,
+      anon_sym_link,
+    ACTIONS(138), 1,
+      anon_sym_property,
+    ACTIONS(141), 1,
+      anon_sym_annotation,
+    ACTIONS(144), 1,
+      anon_sym_constraint,
+    ACTIONS(147), 1,
+      anon_sym_alias,
+    ACTIONS(150), 1,
+      anon_sym_function,
+    STATE(225), 1,
+      sym_modifier,
+    STATE(234), 1,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(153), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(49), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [2614] = 14,
+    ACTIONS(156), 1,
+      anon_sym_RBRACE,
+    ACTIONS(158), 1,
+      anon_sym_type,
+    ACTIONS(160), 1,
+      anon_sym_scalar,
+    ACTIONS(162), 1,
+      anon_sym_link,
+    ACTIONS(164), 1,
+      anon_sym_property,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(168), 1,
+      anon_sym_constraint,
+    ACTIONS(170), 1,
+      anon_sym_alias,
+    ACTIONS(172), 1,
+      anon_sym_function,
+    STATE(225), 1,
+      sym_modifier,
+    STATE(234), 1,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(49), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [2672] = 14,
+    ACTIONS(158), 1,
+      anon_sym_type,
+    ACTIONS(160), 1,
+      anon_sym_scalar,
+    ACTIONS(162), 1,
+      anon_sym_link,
+    ACTIONS(164), 1,
+      anon_sym_property,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(168), 1,
+      anon_sym_constraint,
+    ACTIONS(170), 1,
+      anon_sym_alias,
+    ACTIONS(172), 1,
+      anon_sym_function,
+    ACTIONS(176), 1,
+      anon_sym_RBRACE,
+    STATE(225), 1,
+      sym_modifier,
+    STATE(234), 1,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(50), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [2730] = 9,
+    ACTIONS(178), 1,
       anon_sym_LBRACE,
-    STATE(162), 1,
+    ACTIONS(182), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(184), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(186), 1,
+      anon_sym_SEMI,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    STATE(92), 1,
+      sym_extending,
+    STATE(120), 1,
       sym_declarations,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(263), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2477] = 3,
-    ACTIONS(155), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(149), 17,
+    ACTIONS(180), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6337,36 +8089,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2504] = 2,
-    ACTIONS(3), 2,
+  [2775] = 9,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(192), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(194), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(196), 1,
+      anon_sym_SEMI,
+    STATE(72), 1,
+      sym_extending,
+    STATE(129), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(265), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2529] = 3,
-    ACTIONS(269), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(267), 17,
+    ACTIONS(190), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6384,13 +8125,228 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2556] = 3,
-    ACTIONS(145), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [2820] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(139), 17,
+    ACTIONS(198), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2851] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(200), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2882] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(202), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2913] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(204), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2944] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(206), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2975] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(208), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [3006] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(210), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [3037] = 9,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(214), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(216), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(218), 1,
+      anon_sym_SEMI,
+    STATE(66), 1,
+      sym_extending,
+    STATE(121), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(212), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6408,13 +8364,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2583] = 3,
-    ACTIONS(273), 1,
+  [3082] = 9,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(222), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(224), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(226), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    STATE(90), 1,
+      sym_extending,
+    STATE(131), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(271), 17,
+    ACTIONS(220), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6432,15 +8400,22 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2610] = 2,
-    ACTIONS(3), 2,
+  [3127] = 4,
+    ACTIONS(230), 1,
+      anon_sym_COMMA,
+    STATE(64), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(275), 18,
+    ACTIONS(228), 21,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
       anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
@@ -6455,15 +8430,22 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2635] = 2,
-    ACTIONS(3), 2,
+  [3161] = 4,
+    ACTIONS(234), 1,
+      anon_sym_COMMA,
+    STATE(64), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(277), 18,
+    ACTIONS(232), 21,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
       anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
@@ -6478,17 +8460,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2660] = 3,
-    ACTIONS(219), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [3195] = 4,
+    ACTIONS(230), 1,
+      anon_sym_COMMA,
+    STATE(63), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(215), 17,
+    ACTIONS(237), 21,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
@@ -6502,10 +8490,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2687] = 3,
+  [3229] = 7,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(241), 1,
+      anon_sym_DASH_GT,
     ACTIONS(243), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(245), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    STATE(106), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(239), 17,
@@ -6526,665 +8522,162 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2714] = 3,
-    ACTIONS(213), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [3268] = 5,
+    ACTIONS(13), 1,
+      anon_sym_LPAREN,
+    ACTIONS(247), 1,
+      anon_sym_COLON,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(209), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2741] = 8,
-    ACTIONS(279), 1,
-      anon_sym_RBRACE,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(15), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(11), 16,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [3303] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2778] = 3,
-    ACTIONS(179), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(175), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2805] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(289), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2830] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(291), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(73), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2867] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(291), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2904] = 3,
-    ACTIONS(295), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(293), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2931] = 3,
-    ACTIONS(299), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(297), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2958] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(301), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(77), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2995] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(303), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3020] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(305), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3057] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(307), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3082] = 3,
-    ACTIONS(165), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(159), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3109] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(309), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(90), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3146] = 3,
-    ACTIONS(173), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(167), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3173] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(311), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3198] = 3,
-    ACTIONS(315), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(313), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3225] = 3,
-    ACTIONS(319), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(317), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3252] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(321), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3289] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(323), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(82), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3326] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(323), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3363] = 8,
-    ACTIONS(325), 1,
-      anon_sym_RBRACE,
-    ACTIONS(327), 1,
-      anon_sym_annotation,
-    ACTIONS(330), 1,
-      anon_sym_using,
-    ACTIONS(336), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(93), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(333), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3400] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(283), 1,
-      anon_sym_using,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(321), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(92), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3437] = 3,
-    ACTIONS(341), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(339), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3464] = 4,
-    ACTIONS(76), 1,
+    ACTIONS(249), 22,
       anon_sym_LBRACE,
-    STATE(166), 1,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3332] = 5,
+    ACTIONS(13), 1,
+      anon_sym_LPAREN,
+    ACTIONS(251), 1,
+      anon_sym_COLON,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(15), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(11), 16,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [3367] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(253), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3396] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(255), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3425] = 7,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(259), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(261), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(263), 1,
+      anon_sym_SEMI,
+    STATE(101), 1,
       sym_declarations,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(343), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3493] = 3,
-    ACTIONS(237), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(233), 17,
+    ACTIONS(257), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -7202,16 +8695,58 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3520] = 2,
-    ACTIONS(3), 2,
+  [3464] = 11,
+    ACTIONS(265), 1,
+      anon_sym_RBRACE,
+    ACTIONS(267), 1,
+      anon_sym_link,
+    ACTIONS(270), 1,
+      anon_sym_property,
+    ACTIONS(273), 1,
+      anon_sym_annotation,
+    ACTIONS(276), 1,
+      anon_sym_constraint,
+    ACTIONS(279), 1,
+      anon_sym_index,
+    STATE(235), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(255), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(345), 18,
+    STATE(73), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(282), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3510] = 6,
+    ACTIONS(93), 1,
+      anon_sym_SEMI,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(285), 1,
+      anon_sym_COLON_EQ,
+    STATE(123), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(91), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
-      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
@@ -7225,37 +8760,874 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3545] = 3,
+  [3546] = 15,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(287), 1,
+      anon_sym_RPAREN,
+    ACTIONS(289), 1,
+      anon_sym_COMMA,
+    STATE(317), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [3600] = 6,
+    ACTIONS(109), 1,
+      anon_sym_SEMI,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(291), 1,
+      anon_sym_COLON_EQ,
+    STATE(135), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(107), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3636] = 6,
+    ACTIONS(85), 1,
+      anon_sym_SEMI,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(293), 1,
+      anon_sym_COLON_EQ,
+    STATE(125), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(83), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3672] = 15,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(295), 1,
+      anon_sym_RPAREN,
+    ACTIONS(297), 1,
+      anon_sym_COMMA,
+    STATE(325), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [3726] = 11,
+    ACTIONS(162), 1,
+      anon_sym_link,
+    ACTIONS(164), 1,
+      anon_sym_property,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(168), 1,
+      anon_sym_constraint,
+    ACTIONS(299), 1,
+      anon_sym_RBRACE,
+    ACTIONS(301), 1,
+      anon_sym_index,
+    STATE(235), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(255), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(73), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3772] = 11,
+    ACTIONS(162), 1,
+      anon_sym_link,
+    ACTIONS(164), 1,
+      anon_sym_property,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(168), 1,
+      anon_sym_constraint,
+    ACTIONS(301), 1,
+      anon_sym_index,
+    ACTIONS(303), 1,
+      anon_sym_RBRACE,
+    STATE(235), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(255), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(79), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3818] = 4,
+    ACTIONS(307), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(322), 1,
+      sym__scalar_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(305), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [3850] = 4,
+    ACTIONS(311), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(340), 1,
+      sym__scalar_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(309), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [3882] = 6,
+    ACTIONS(89), 1,
+      anon_sym_SEMI,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(313), 1,
+      anon_sym_COLON_EQ,
+    STATE(115), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(87), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3918] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(315), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [3967] = 6,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    STATE(130), 1,
+      sym_extending,
+    STATE(194), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(317), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4002] = 6,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    STATE(110), 1,
+      sym_extending,
+    STATE(211), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(319), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4037] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(321), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4086] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(323), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4134] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(325), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4182] = 4,
+    ACTIONS(329), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(331), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(327), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4212] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(333), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4260] = 4,
+    ACTIONS(337), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(339), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(335), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4290] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(341), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4338] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(343), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4386] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(345), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4434] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(347), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4482] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
     ACTIONS(349), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(347), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3572] = 3,
-    ACTIONS(225), 1,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4530] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(351), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(221), 17,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4578] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(353), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4626] = 13,
+    ACTIONS(29), 1,
+      anon_sym_AMP,
+    ACTIONS(31), 1,
+      anon_sym_CARET,
+    ACTIONS(33), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(355), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(27), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(35), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(39), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(41), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(43), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(37), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4674] = 3,
+    ACTIONS(109), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(107), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -7273,203 +9645,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3599] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(351), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3623] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(353), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3647] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(239), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3671] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(233), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3695] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(149), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3719] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(347), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3743] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(355), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3767] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(339), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3791] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
+  [4701] = 8,
     ACTIONS(357), 1,
       anon_sym_RBRACE,
     ACTIONS(359), 1,
+      anon_sym_annotation,
+    ACTIONS(362), 1,
       anon_sym_using,
-    ACTIONS(3), 2,
+    ACTIONS(368), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
+    STATE(102), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(365), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -7477,371 +9674,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3827] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(361), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(126), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3863] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(361), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3899] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(363), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3923] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(357), 1,
-      anon_sym_RBRACE,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(139), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3959] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(365), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3983] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(367), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(159), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4019] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(367), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4055] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(369), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4079] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
+  [4738] = 8,
     ACTIONS(371), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4115] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(373), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4139] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(375), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4163] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(377), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4187] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(245), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4211] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(317), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4235] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+    ACTIONS(375), 1,
       anon_sym_using,
     ACTIONS(379), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(116), 4,
+    STATE(127), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -7849,49 +9703,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4271] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(381), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
+  [4775] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4295] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+    ACTIONS(375), 1,
       anon_sym_using,
-    ACTIONS(383), 1,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(381), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
+    STATE(112), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -7899,93 +9732,206 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4331] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(313), 17,
+  [4812] = 8,
+    ACTIONS(371), 1,
       anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4355] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(385), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4379] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(221), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4403] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+    ACTIONS(375), 1,
       anon_sym_using,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(102), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4849] = 3,
+    ACTIONS(85), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(83), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4876] = 3,
+    ACTIONS(101), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(99), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4903] = 3,
+    ACTIONS(71), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(69), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4930] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(383), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4955] = 4,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    STATE(206), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(385), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4984] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(375), 1,
+      anon_sym_using,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(381), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(102), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5021] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(375), 1,
+      anon_sym_using,
+    ACTIONS(379), 1,
+      sym_identifier,
     ACTIONS(387), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
+    STATE(102), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -7993,15 +9939,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4439] = 2,
-    ACTIONS(3), 2,
+  [5058] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(167), 17,
+    ACTIONS(389), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
@@ -8015,74 +9962,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4463] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(139), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4487] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(389), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4511] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(267), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4535] = 2,
-    ACTIONS(3), 2,
+  [5083] = 3,
+    ACTIONS(393), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(391), 17,
@@ -8103,11 +9986,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4559] = 2,
-    ACTIONS(3), 2,
+  [5110] = 3,
+    ACTIONS(105), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(159), 17,
+    ACTIONS(103), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8125,15 +10010,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4583] = 2,
-    ACTIONS(3), 2,
+  [5137] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(393), 17,
+    ACTIONS(395), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
@@ -8147,27 +10033,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4607] = 8,
-    ACTIONS(281), 1,
+  [5162] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+    ACTIONS(375), 1,
       anon_sym_using,
-    ACTIONS(395), 1,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(397), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(149), 4,
+    STATE(111), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8175,99 +10062,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4643] = 8,
-    ACTIONS(281), 1,
+  [5199] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+    ACTIONS(375), 1,
       anon_sym_using,
-    ACTIONS(395), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4679] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(271), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4703] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(397), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4727] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
+    ACTIONS(379), 1,
       sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
     ACTIONS(399), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
+    STATE(102), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8275,77 +10091,99 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4763] = 8,
-    ACTIONS(281), 1,
+  [5236] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(401), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
       anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5261] = 3,
+    ACTIONS(339), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(335), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5288] = 3,
+    ACTIONS(245), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(239), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5315] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(375), 1,
       anon_sym_using,
-    ACTIONS(387), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(111), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4799] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(401), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4823] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
+    ACTIONS(379), 1,
       sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(399), 1,
+    ACTIONS(403), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(118), 4,
+    STATE(105), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8353,11 +10191,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4859] = 2,
-    ACTIONS(3), 2,
+  [5352] = 3,
+    ACTIONS(81), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(297), 17,
+    ACTIONS(79), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8375,11 +10215,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4883] = 2,
-    ACTIONS(3), 2,
+  [5379] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(403), 17,
+    ACTIONS(405), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5404] = 3,
+    ACTIONS(93), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(91), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8397,49 +10262,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4907] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(293), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
+  [5431] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4931] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
+    ACTIONS(375), 1,
+      anon_sym_using,
+    ACTIONS(379), 1,
       sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(405), 1,
+    ACTIONS(407), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
+    STATE(118), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8447,27 +10291,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4967] = 8,
-    ACTIONS(281), 1,
+  [5468] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-    ACTIONS(287), 1,
+    ACTIONS(375), 1,
+      anon_sym_using,
+    ACTIONS(379), 1,
       sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(405), 1,
+    ACTIONS(407), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(142), 4,
+    STATE(102), 5,
       sym_annotation,
       sym_using,
+      sym_uselang,
       sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+      aux_sym_function_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8475,11 +10320,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5003] = 2,
-    ACTIONS(3), 2,
+  [5505] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(407), 17,
+    ACTIONS(409), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5530] = 3,
+    ACTIONS(263), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(257), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8497,11 +10367,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5027] = 2,
-    ACTIONS(3), 2,
+  [5557] = 4,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    STATE(199), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(209), 17,
+    ACTIONS(411), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5586] = 3,
+    ACTIONS(331), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(327), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8519,11 +10416,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5051] = 2,
-    ACTIONS(3), 2,
+  [5613] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(409), 17,
+    ACTIONS(413), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5638] = 3,
+    ACTIONS(417), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(415), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8541,11 +10463,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5075] = 2,
-    ACTIONS(3), 2,
+  [5665] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(175), 17,
+    ACTIONS(419), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5690] = 3,
+    ACTIONS(89), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(87), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8563,27 +10510,27 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5099] = 8,
-    ACTIONS(281), 1,
+  [5717] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-    ACTIONS(287), 1,
+    ACTIONS(379), 1,
       sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(411), 1,
+    ACTIONS(421), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(109), 4,
+    STATE(183), 4,
       sym_annotation,
       sym_using,
       sym_computed,
       aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8591,11 +10538,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5135] = 2,
-    ACTIONS(3), 2,
+  [5753] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(215), 17,
+    ACTIONS(335), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8613,39 +10560,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5159] = 8,
-    ACTIONS(413), 1,
-      anon_sym_RBRACE,
-    ACTIONS(415), 1,
-      anon_sym_annotation,
-    ACTIONS(418), 1,
-      anon_sym_using,
-    ACTIONS(424), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+  [5777] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(421), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5195] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(251), 17,
+    ACTIONS(75), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8663,27 +10582,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5219] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(427), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
+  [5801] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(157), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+    ACTIONS(95), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8691,8 +10604,174 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5255] = 2,
-    ACTIONS(3), 2,
+  [5825] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(415), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5849] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(257), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5873] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(87), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5897] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(425), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(167), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5933] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(327), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5957] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(425), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5993] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(427), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6017] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(429), 17,
@@ -8713,27 +10792,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5279] = 8,
-    ACTIONS(281), 1,
-      anon_sym_annotation,
-    ACTIONS(287), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      anon_sym_using,
-    ACTIONS(427), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
+  [6041] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(217), 2,
+    ACTIONS(83), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6065] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(431), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6089] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(433), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    STATE(130), 4,
+    STATE(136), 4,
       sym_annotation,
       sym_using,
       sym_computed,
       aux_sym_constraint_repeat1,
-    ACTIONS(285), 7,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8741,422 +10864,27 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5315] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(431), 16,
+  [6125] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(433), 1,
       anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5338] = 2,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(433), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5361] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(435), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5384] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(437), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5407] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(439), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5430] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(441), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5453] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(443), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5476] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(445), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5499] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(447), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5522] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(449), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5545] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(343), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5568] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(451), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5591] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(453), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5614] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(455), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5637] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(457), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5660] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(459), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5683] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(461), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5706] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(463), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5729] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(263), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5752] = 7,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(465), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(467), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(193), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9164,23 +10892,27 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5783] = 7,
-    ACTIONS(35), 1,
+  [6161] = 8,
+    ACTIONS(373), 1,
       anon_sym_annotation,
-    ACTIONS(469), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(471), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(435), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(196), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    STATE(187), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9188,46 +10920,741 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5814] = 7,
-    ACTIONS(35), 1,
+  [6197] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(437), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
       anon_sym_annotation,
-    ACTIONS(473), 1,
-      anon_sym_COLON_EQ,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6221] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(439), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6257] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(441), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6281] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(443), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6305] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(91), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6329] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(445), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6365] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(447), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6389] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(449), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6413] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(107), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6437] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(451), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6461] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(239), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6485] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(421), 1,
+      anon_sym_RBRACE,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(186), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6521] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(445), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(154), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6557] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(453), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6581] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(455), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6617] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(79), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6641] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(457), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(178), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6677] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(455), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(158), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6713] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(459), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6737] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(461), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6761] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(463), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(190), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6797] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(465), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6821] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(69), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6845] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(391), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6869] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(103), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6893] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(463), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6929] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(467), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6953] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(469), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6977] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(471), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7001] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(473), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7025] = 8,
     ACTIONS(475), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(198), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5845] = 6,
-    ACTIONS(479), 1,
-      anon_sym_annotation,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(477), 2,
       anon_sym_RBRACE,
-      anon_sym_SEMI,
-    STATE(184), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    ACTIONS(477), 1,
+      anon_sym_annotation,
+    ACTIONS(480), 1,
+      anon_sym_using,
+    ACTIONS(486), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(482), 7,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(483), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9235,23 +11662,650 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5874] = 7,
-    ACTIONS(35), 1,
+  [7061] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(489), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
       anon_sym_annotation,
-    ACTIONS(485), 1,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7085] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(491), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7109] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(493), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7145] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(495), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7181] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(495), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(145), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7217] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(497), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7241] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(499), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(183), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7277] = 8,
+    ACTIONS(373), 1,
+      anon_sym_annotation,
+    ACTIONS(379), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_using,
+    ACTIONS(499), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(280), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(151), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(377), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7313] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(99), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7337] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(501), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7360] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(411), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7383] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(503), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7406] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(505), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7429] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(507), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7452] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(509), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7475] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(511), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7498] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(513), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7521] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(515), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7544] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(517), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7567] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(519), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7590] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(521), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7613] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(523), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7636] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(525), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7659] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(527), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7682] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(529), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7705] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(531), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7728] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(533), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7751] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(385), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7774] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(535), 1,
       anon_sym_COLON_EQ,
-    ACTIONS(487), 1,
+    ACTIONS(537), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(194), 2,
+    STATE(228), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(282), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9259,42 +12313,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5905] = 4,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(186), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(489), 4,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
+  [7805] = 7,
+    ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(491), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5929] = 7,
-    ACTIONS(494), 1,
-      anon_sym_scalar,
-    ACTIONS(496), 1,
-      anon_sym_link,
-    ACTIONS(498), 1,
-      anon_sym_property,
-    ACTIONS(500), 1,
-      anon_sym_annotation,
-    ACTIONS(3), 2,
+    ACTIONS(539), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(541), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(186), 2,
+    STATE(224), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9302,11 +12337,82 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5959] = 2,
-    ACTIONS(3), 2,
+  [7836] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(543), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(545), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(502), 13,
+    STATE(227), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7867] = 6,
+    ACTIONS(549), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(547), 2,
+      anon_sym_RBRACE,
+      anon_sym_SEMI,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(552), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7896] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(555), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(557), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(226), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7927] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(559), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -9320,11 +12426,55 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5979] = 2,
-    ACTIONS(3), 2,
+  [7947] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(561), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(504), 13,
+    STATE(230), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7975] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(561), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8003] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(563), 13,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
@@ -9338,21 +12488,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5999] = 6,
-    ACTIONS(35), 1,
+  [8023] = 6,
+    ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(506), 1,
+    ACTIONS(565), 1,
       anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(184), 2,
+    STATE(219), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(282), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9360,99 +12510,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6027] = 6,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(506), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
+  [8051] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(192), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6055] = 6,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(508), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(184), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6083] = 6,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(510), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(184), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6111] = 6,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(512), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(184), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6139] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(514), 13,
+    ACTIONS(567), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -9466,33 +12528,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6159] = 6,
-    ACTIONS(35), 1,
-      anon_sym_annotation,
-    ACTIONS(516), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [8071] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(184), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(214), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6187] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(518), 13,
+    ACTIONS(569), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -9506,21 +12546,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6207] = 6,
-    ACTIONS(35), 1,
+  [8091] = 6,
+    ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(520), 1,
+    ACTIONS(571), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(184), 2,
+    STATE(215), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(282), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9528,15 +12568,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6235] = 4,
-    ACTIONS(522), 1,
+  [8119] = 4,
+    ACTIONS(573), 1,
       anon_sym_type,
-    ACTIONS(526), 1,
+    ACTIONS(577), 1,
       anon_sym_constraint,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(524), 11,
+    ACTIONS(575), 11,
       anon_sym_scalar,
       anon_sym_link,
       anon_sym_property,
@@ -9548,21 +12588,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6259] = 6,
-    ACTIONS(35), 1,
+  [8143] = 6,
+    ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(528), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
+    ACTIONS(579), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(190), 2,
+    STATE(215), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(214), 2,
+    STATE(282), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9570,11 +12610,55 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6287] = 2,
-    ACTIONS(3), 2,
+  [8171] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(581), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(530), 13,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8199] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(583), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8227] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(585), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -9588,11 +12672,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6307] = 2,
-    ACTIONS(3), 2,
+  [8247] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(587), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(532), 13,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(282), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8275] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -9606,15 +12712,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6327] = 3,
-    ACTIONS(3), 2,
+  [8295] = 3,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(534), 3,
+    ACTIONS(591), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-    ACTIONS(536), 10,
+    ACTIONS(593), 10,
       anon_sym_annotation,
       anon_sym_using,
       anon_sym_abstract,
@@ -9625,173 +12731,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
       sym_identifier,
-  [6349] = 6,
-    ACTIONS(496), 1,
-      anon_sym_link,
-    ACTIONS(498), 1,
-      anon_sym_property,
-    ACTIONS(500), 1,
-      anon_sym_annotation,
-    ACTIONS(3), 2,
+  [8317] = 4,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(186), 2,
+    STATE(233), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6376] = 3,
-    ACTIONS(289), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(538), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6396] = 3,
-    ACTIONS(265), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(540), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6416] = 3,
-    ACTIONS(277), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(542), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6436] = 3,
-    ACTIONS(544), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(546), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6456] = 3,
-    ACTIONS(307), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(548), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6476] = 3,
-    ACTIONS(345), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(550), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6496] = 3,
-    ACTIONS(275), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(552), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6516] = 3,
-    ACTIONS(554), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(556), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [6536] = 3,
-    ACTIONS(526), 1,
-      anon_sym_constraint,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(524), 10,
+    ACTIONS(595), 4,
+      anon_sym_scalar,
       anon_sym_link,
       anon_sym_property,
       anon_sym_annotation,
+    ACTIONS(597), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9799,2334 +12751,3101 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6556] = 4,
-    ACTIONS(500), 1,
-      anon_sym_annotation,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(186), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6577] = 11,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(558), 1,
-      anon_sym_LBRACE,
-    ACTIONS(560), 1,
-      anon_sym_SEMI,
-    ACTIONS(562), 1,
-      anon_sym_LPAREN,
-    ACTIONS(564), 1,
-      anon_sym_on,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    STATE(218), 1,
-      sym_argspec,
-    STATE(222), 1,
-      sym_on,
-    STATE(230), 1,
-      sym_except,
-    STATE(290), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6612] = 11,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(562), 1,
-      anon_sym_LPAREN,
-    ACTIONS(564), 1,
-      anon_sym_on,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(568), 1,
-      anon_sym_LBRACE,
-    ACTIONS(570), 1,
-      anon_sym_SEMI,
-    STATE(219), 1,
-      sym_argspec,
-    STATE(224), 1,
-      sym_on,
-    STATE(242), 1,
-      sym_except,
-    STATE(298), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6647] = 4,
-    ACTIONS(572), 1,
-      anon_sym_annotation,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(186), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(43), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6668] = 9,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(564), 1,
-      anon_sym_on,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(574), 1,
-      anon_sym_LBRACE,
-    ACTIONS(576), 1,
-      anon_sym_SEMI,
-    STATE(225), 1,
-      sym_on,
-    STATE(231), 1,
-      sym_except,
-    STATE(291), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6697] = 9,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(564), 1,
-      anon_sym_on,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(578), 1,
-      anon_sym_LBRACE,
-    ACTIONS(580), 1,
-      anon_sym_SEMI,
-    STATE(223), 1,
-      sym_on,
-    STATE(238), 1,
-      sym_except,
-    STATE(311), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6726] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(582), 6,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [6739] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(584), 6,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [6752] = 7,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(574), 1,
-      anon_sym_LBRACE,
-    ACTIONS(576), 1,
-      anon_sym_SEMI,
-    STATE(231), 1,
-      sym_except,
-    STATE(291), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6775] = 7,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(586), 1,
-      anon_sym_LBRACE,
-    ACTIONS(588), 1,
-      anon_sym_SEMI,
-    STATE(228), 1,
-      sym_except,
-    STATE(294), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6798] = 7,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(578), 1,
-      anon_sym_LBRACE,
-    ACTIONS(580), 1,
-      anon_sym_SEMI,
-    STATE(238), 1,
-      sym_except,
-    STATE(311), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6821] = 7,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(590), 1,
-      anon_sym_LBRACE,
-    ACTIONS(592), 1,
-      anon_sym_SEMI,
-    STATE(239), 1,
-      sym_except,
-    STATE(288), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6844] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(594), 6,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [6857] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(596), 6,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [6870] = 5,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(598), 1,
-      anon_sym_LBRACE,
+  [8341] = 7,
     ACTIONS(600), 1,
-      anon_sym_SEMI,
-    STATE(306), 1,
-      sym_extending,
-    ACTIONS(3), 2,
+      anon_sym_scalar,
+    ACTIONS(602), 1,
+      anon_sym_link,
+    ACTIONS(604), 1,
+      anon_sym_property,
+    ACTIONS(606), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [6887] = 2,
-    ACTIONS(3), 2,
+    STATE(233), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8371] = 6,
+    ACTIONS(602), 1,
+      anon_sym_link,
+    ACTIONS(604), 1,
+      anon_sym_property,
+    ACTIONS(606), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(602), 4,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
+    STATE(233), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8398] = 9,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(610), 1,
+      anon_sym_RPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(78), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8431] = 3,
+    ACTIONS(389), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(620), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [8451] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(18), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8481] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(11), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8511] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(99), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8541] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(26), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8571] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(9), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8601] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(8), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8631] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(28), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8661] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(6), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8691] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(5), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8721] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(24), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8751] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(622), 1,
+      sym_identifier,
+    STATE(84), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8781] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(97), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8811] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(22), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8841] = 3,
+    ACTIONS(624), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(626), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [8861] = 3,
+    ACTIONS(401), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(628), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [8881] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(23), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8911] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(98), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8941] = 3,
+    ACTIONS(577), 1,
+      anon_sym_constraint,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(575), 10,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8961] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(93), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8991] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(95), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9021] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(27), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9051] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(94), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9081] = 3,
+    ACTIONS(383), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(630), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9101] = 3,
+    ACTIONS(419), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(632), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9121] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(91), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9151] = 3,
+    ACTIONS(395), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(634), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9171] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(88), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9201] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(96), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9231] = 3,
+    ACTIONS(636), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(638), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9251] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(87), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9281] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(25), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9311] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(640), 1,
+      sym_identifier,
+    STATE(75), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9341] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(89), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9371] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(14), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9401] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(13), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9431] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(16), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9461] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(15), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9491] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(29), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9521] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(21), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9551] = 3,
+    ACTIONS(413), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(642), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9571] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(100), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9601] = 8,
+    ACTIONS(608), 1,
+      anon_sym_LPAREN,
+    ACTIONS(612), 1,
+      anon_sym_global,
+    ACTIONS(614), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(616), 1,
+      sym_identifier,
+    STATE(30), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(7), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9631] = 4,
+    ACTIONS(644), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(233), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [9652] = 11,
+    ACTIONS(188), 1,
       anon_sym_extending,
+    ACTIONS(646), 1,
+      anon_sym_LBRACE,
+    ACTIONS(648), 1,
+      anon_sym_SEMI,
+    ACTIONS(650), 1,
+      anon_sym_LPAREN,
+    ACTIONS(652), 1,
+      anon_sym_on,
+    ACTIONS(654), 1,
       anon_sym_except,
-  [6898] = 5,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(574), 1,
-      anon_sym_LBRACE,
-    ACTIONS(576), 1,
-      anon_sym_SEMI,
-    STATE(291), 1,
+    STATE(284), 1,
+      sym_argspec,
+    STATE(293), 1,
+      sym_on,
+    STATE(301), 1,
+      sym_except,
+    STATE(341), 1,
       sym_extending,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [6915] = 5,
-    ACTIONS(86), 1,
+  [9687] = 4,
+    ACTIONS(606), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(233), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [9708] = 11,
+    ACTIONS(188), 1,
       anon_sym_extending,
-    ACTIONS(590), 1,
+    ACTIONS(650), 1,
+      anon_sym_LPAREN,
+    ACTIONS(652), 1,
+      anon_sym_on,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(656), 1,
       anon_sym_LBRACE,
-    ACTIONS(592), 1,
+    ACTIONS(658), 1,
+      anon_sym_SEMI,
+    STATE(285), 1,
+      sym_argspec,
+    STATE(286), 1,
+      sym_on,
+    STATE(294), 1,
+      sym_except,
+    STATE(336), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9743] = 9,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(652), 1,
+      anon_sym_on,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(660), 1,
+      anon_sym_LBRACE,
+    ACTIONS(662), 1,
       anon_sym_SEMI,
     STATE(288), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6932] = 5,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    STATE(177), 1,
-      sym_declarations,
-    STATE(301), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6949] = 5,
-    ACTIONS(604), 1,
-      anon_sym_LBRACE,
-    ACTIONS(606), 1,
-      anon_sym_SEMI,
-    ACTIONS(608), 1,
-      anon_sym_using,
-    STATE(300), 1,
-      sym_uselang,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6966] = 5,
-    ACTIONS(610), 1,
-      anon_sym_LBRACE,
-    ACTIONS(612), 1,
-      anon_sym_SEMI,
-    ACTIONS(614), 1,
-      anon_sym_using,
-    STATE(309), 1,
-      sym_uselang,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [6983] = 5,
-    ACTIONS(566), 1,
-      anon_sym_except,
-    ACTIONS(616), 1,
-      anon_sym_LBRACE,
-    ACTIONS(618), 1,
-      anon_sym_SEMI,
-    STATE(293), 1,
+      sym_on,
+    STATE(296), 1,
       sym_except,
+    STATE(334), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9772] = 9,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(652), 1,
+      anon_sym_on,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(664), 1,
+      anon_sym_LBRACE,
+    ACTIONS(666), 1,
+      anon_sym_SEMI,
+    STATE(290), 1,
+      sym_on,
+    STATE(303), 1,
+      sym_except,
+    STATE(339), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9801] = 7,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(664), 1,
+      anon_sym_LBRACE,
+    ACTIONS(666), 1,
+      anon_sym_SEMI,
+    STATE(303), 1,
+      sym_except,
+    STATE(339), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9824] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(668), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9837] = 7,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(670), 1,
+      anon_sym_LBRACE,
+    ACTIONS(672), 1,
+      anon_sym_SEMI,
+    STATE(307), 1,
+      sym_except,
+    STATE(338), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9860] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(674), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9873] = 7,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(676), 1,
+      anon_sym_LBRACE,
+    ACTIONS(678), 1,
+      anon_sym_SEMI,
+    STATE(295), 1,
+      sym_except,
+    STATE(353), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9896] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(680), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9909] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(682), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9922] = 7,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(660), 1,
+      anon_sym_LBRACE,
+    ACTIONS(662), 1,
+      anon_sym_SEMI,
+    STATE(296), 1,
+      sym_except,
+    STATE(334), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9945] = 5,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(664), 1,
+      anon_sym_LBRACE,
+    ACTIONS(666), 1,
+      anon_sym_SEMI,
+    STATE(339), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9962] = 5,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(684), 1,
+      anon_sym_LBRACE,
+    ACTIONS(686), 1,
+      anon_sym_SEMI,
+    STATE(346), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9979] = 5,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(670), 1,
+      anon_sym_LBRACE,
+    ACTIONS(672), 1,
+      anon_sym_SEMI,
+    STATE(338), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9996] = 5,
+    ACTIONS(654), 1,
+      anon_sym_except,
+    ACTIONS(688), 1,
+      anon_sym_LBRACE,
+    ACTIONS(690), 1,
+      anon_sym_SEMI,
+    STATE(345), 1,
+      sym_except,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10013] = 4,
+    ACTIONS(692), 1,
+      anon_sym_SQUOTE,
+    STATE(299), 1,
+      aux_sym_string_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [7000] = 4,
+    ACTIONS(694), 2,
+      sym_unescaped_single_string_fragment,
+      sym_escape_sequence,
+  [10028] = 4,
+    ACTIONS(696), 1,
+      anon_sym_SQUOTE,
+    STATE(299), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(698), 2,
+      sym_unescaped_single_string_fragment,
+      sym_escape_sequence,
+  [10043] = 4,
+    ACTIONS(701), 1,
+      ts_builtin_sym_end,
+    ACTIONS(703), 1,
+      anon_sym_module,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(300), 2,
+      sym_module,
+      aux_sym_source_file_repeat1,
+  [10058] = 5,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(660), 1,
+      anon_sym_LBRACE,
+    ACTIONS(662), 1,
+      anon_sym_SEMI,
+    STATE(334), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10075] = 4,
+    ACTIONS(706), 1,
+      anon_sym_SQUOTE,
+    STATE(298), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(708), 2,
+      sym_unescaped_single_string_fragment,
+      sym_escape_sequence,
+  [10090] = 5,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    ACTIONS(676), 1,
+      anon_sym_LBRACE,
+    ACTIONS(678), 1,
+      anon_sym_SEMI,
+    STATE(353), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10107] = 5,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    STATE(210), 1,
+      sym_declarations,
+    STATE(335), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10124] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(710), 4,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_except,
+  [10135] = 4,
     ACTIONS(7), 1,
       anon_sym_module,
-    ACTIONS(620), 1,
+    ACTIONS(712), 1,
       ts_builtin_sym_end,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(241), 2,
+    STATE(300), 2,
       sym_module,
       aux_sym_source_file_repeat1,
-  [7015] = 5,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    ACTIONS(86), 1,
+  [10150] = 5,
+    ACTIONS(188), 1,
       anon_sym_extending,
-    STATE(175), 1,
+    ACTIONS(714), 1,
+      anon_sym_LBRACE,
+    ACTIONS(716), 1,
+      anon_sym_SEMI,
+    STATE(357), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10167] = 5,
+    ACTIONS(718), 1,
+      anon_sym_LBRACE,
+    ACTIONS(720), 1,
+      anon_sym_SEMI,
+    ACTIONS(722), 1,
+      anon_sym_using,
+    STATE(352), 1,
+      sym_uselang,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10184] = 5,
+    ACTIONS(724), 1,
+      anon_sym_LBRACE,
+    ACTIONS(726), 1,
+      anon_sym_SEMI,
+    ACTIONS(728), 1,
+      anon_sym_using,
+    STATE(333), 1,
+      sym_uselang,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10201] = 5,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    ACTIONS(188), 1,
+      anon_sym_extending,
+    STATE(197), 1,
       sym_declarations,
-    STATE(297), 1,
+    STATE(355), 1,
       sym_extending,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7032] = 5,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(586), 1,
-      anon_sym_LBRACE,
-    ACTIONS(588), 1,
-      anon_sym_SEMI,
-    STATE(294), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7049] = 5,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(622), 1,
-      anon_sym_LBRACE,
-    ACTIONS(624), 1,
-      anon_sym_SEMI,
-    STATE(314), 1,
-      sym_extending,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7066] = 5,
-    ACTIONS(626), 1,
-      anon_sym_RPAREN,
-    ACTIONS(628), 1,
+  [10218] = 4,
+    ACTIONS(730), 1,
       anon_sym_COMMA,
-    ACTIONS(630), 1,
-      anon_sym_COLON,
-    STATE(246), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(3), 2,
+    ACTIONS(732), 1,
+      anon_sym_GT,
+    STATE(319), 1,
+      aux_sym__tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7083] = 4,
-    ACTIONS(632), 1,
-      ts_builtin_sym_end,
-    ACTIONS(634), 1,
-      anon_sym_module,
-    ACTIONS(3), 2,
+  [10232] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(241), 2,
-      sym_module,
-      aux_sym_source_file_repeat1,
-  [7098] = 5,
-    ACTIONS(86), 1,
-      anon_sym_extending,
-    ACTIONS(578), 1,
+    ACTIONS(734), 3,
       anon_sym_LBRACE,
-    ACTIONS(580), 1,
       anon_sym_SEMI,
+      anon_sym_extending,
+  [10242] = 4,
+    ACTIONS(730), 1,
+      anon_sym_COMMA,
+    ACTIONS(736), 1,
+      anon_sym_GT,
     STATE(311), 1,
-      sym_extending,
-    ACTIONS(3), 2,
+      aux_sym__tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7115] = 3,
-    STATE(377), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7127] = 3,
-    STATE(380), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7139] = 3,
-    STATE(88), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7151] = 4,
-    ACTIONS(628), 1,
-      anon_sym_COMMA,
-    ACTIONS(639), 1,
+  [10256] = 4,
+    ACTIONS(315), 1,
       anon_sym_RPAREN,
-    STATE(254), 1,
+    ACTIONS(738), 1,
+      anon_sym_COMMA,
+    STATE(314), 1,
       aux_sym_argspec_repeat1,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7165] = 3,
-    STATE(72), 1,
-      sym_expr,
-    ACTIONS(3), 2,
+  [10270] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7177] = 3,
-    STATE(89), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7189] = 3,
-    STATE(67), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7201] = 3,
-    STATE(70), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7213] = 4,
-    ACTIONS(641), 1,
-      anon_sym_COMMA,
-    ACTIONS(644), 1,
-      anon_sym_GT,
-    STATE(251), 1,
-      aux_sym_enum_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7227] = 3,
-    STATE(65), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7239] = 4,
-    ACTIONS(646), 1,
-      anon_sym_COMMA,
-    ACTIONS(648), 1,
-      anon_sym_GT,
-    STATE(279), 1,
-      aux_sym__named_tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7253] = 4,
+    ACTIONS(741), 3,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_using,
+  [10280] = 4,
     ACTIONS(650), 1,
-      anon_sym_RPAREN,
-    ACTIONS(652), 1,
-      anon_sym_COMMA,
-    STATE(254), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7267] = 4,
-    ACTIONS(628), 1,
-      anon_sym_COMMA,
-    ACTIONS(655), 1,
-      anon_sym_RPAREN,
-    STATE(268), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7281] = 3,
-    ACTIONS(657), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(650), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7293] = 3,
-    STATE(369), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7305] = 4,
-    ACTIONS(659), 1,
-      anon_sym_COMMA,
-    ACTIONS(661), 1,
-      anon_sym_GT,
-    STATE(278), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7319] = 4,
-    ACTIONS(663), 1,
-      anon_sym_COMMA,
-    ACTIONS(665), 1,
-      anon_sym_GT,
-    STATE(277), 1,
-      aux_sym_enum_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7333] = 3,
-    STATE(100), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7345] = 3,
-    STATE(378), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7357] = 3,
-    STATE(354), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7369] = 3,
-    STATE(79), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7381] = 3,
-    STATE(78), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7393] = 4,
-    ACTIONS(659), 1,
-      anon_sym_COMMA,
-    ACTIONS(667), 1,
-      anon_sym_GT,
-    STATE(258), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7407] = 3,
-    STATE(376), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7419] = 3,
-    ACTIONS(669), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(100), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [7431] = 4,
-    ACTIONS(628), 1,
-      anon_sym_COMMA,
-    ACTIONS(671), 1,
-      anon_sym_RPAREN,
-    STATE(254), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7445] = 3,
-    STATE(74), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7457] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(673), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_extending,
-  [7467] = 3,
-    STATE(97), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7479] = 3,
-    STATE(388), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7491] = 3,
-    STATE(336), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7503] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(675), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_using,
-  [7513] = 3,
-    STATE(385), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7525] = 3,
-    STATE(60), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7537] = 4,
-    ACTIONS(663), 1,
-      anon_sym_COMMA,
-    ACTIONS(677), 1,
-      anon_sym_GT,
-    STATE(251), 1,
-      aux_sym_enum_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7551] = 4,
-    ACTIONS(679), 1,
-      anon_sym_COMMA,
-    ACTIONS(682), 1,
-      anon_sym_GT,
-    STATE(278), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7565] = 4,
-    ACTIONS(684), 1,
-      anon_sym_COMMA,
-    ACTIONS(687), 1,
-      anon_sym_GT,
-    STATE(279), 1,
-      aux_sym__named_tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7579] = 4,
-    ACTIONS(646), 1,
-      anon_sym_COMMA,
-    ACTIONS(689), 1,
-      anon_sym_GT,
-    STATE(253), 1,
-      aux_sym__named_tuple_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7593] = 3,
-    STATE(386), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7605] = 3,
-    STATE(61), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7617] = 3,
-    STATE(71), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7629] = 3,
-    STATE(99), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7641] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(691), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_using,
-  [7651] = 4,
-    ACTIONS(562), 1,
       anon_sym_LPAREN,
-    ACTIONS(693), 1,
-      anon_sym_RPAREN,
-    STATE(370), 1,
-      sym_argspec,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7665] = 3,
-    STATE(95), 1,
-      sym_expr,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(637), 2,
-      sym_str,
-      sym_identifier,
-  [7677] = 3,
-    ACTIONS(622), 1,
-      anon_sym_LBRACE,
-    ACTIONS(624), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7688] = 3,
-    ACTIONS(695), 1,
-      anon_sym_LPAREN,
-    ACTIONS(697), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7699] = 3,
-    ACTIONS(574), 1,
-      anon_sym_LBRACE,
-    ACTIONS(576), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7710] = 3,
-    ACTIONS(590), 1,
-      anon_sym_LBRACE,
-    ACTIONS(592), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7721] = 3,
-    ACTIONS(699), 1,
-      anon_sym_LBRACE,
-    ACTIONS(701), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7732] = 3,
-    ACTIONS(703), 1,
-      anon_sym_LBRACE,
-    ACTIONS(705), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7743] = 3,
-    ACTIONS(598), 1,
-      anon_sym_LBRACE,
-    ACTIONS(600), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7754] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(682), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [7763] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(707), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [7772] = 3,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    STATE(179), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7783] = 3,
-    ACTIONS(578), 1,
-      anon_sym_LBRACE,
-    ACTIONS(580), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7794] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(709), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [7803] = 3,
-    ACTIONS(610), 1,
-      anon_sym_LBRACE,
-    ACTIONS(612), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7814] = 3,
-    ACTIONS(76), 1,
-      anon_sym_LBRACE,
-    STATE(174), 1,
-      sym_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7825] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(711), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [7834] = 3,
-    ACTIONS(697), 1,
-      sym_identifier,
-    ACTIONS(713), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7845] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(715), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7854] = 3,
-    ACTIONS(717), 1,
-      anon_sym_LBRACE,
-    ACTIONS(719), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7865] = 3,
-    ACTIONS(721), 1,
-      anon_sym_LBRACE,
-    ACTIONS(723), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7876] = 3,
-    ACTIONS(725), 1,
-      anon_sym_LBRACE,
-    ACTIONS(727), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7887] = 3,
-    ACTIONS(564), 1,
-      anon_sym_on,
-    STATE(235), 1,
-      sym_on,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7898] = 3,
-    ACTIONS(729), 1,
-      anon_sym_LBRACE,
-    ACTIONS(731), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7909] = 3,
-    ACTIONS(697), 1,
-      sym_identifier,
-    ACTIONS(733), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7920] = 3,
-    ACTIONS(586), 1,
-      anon_sym_LBRACE,
-    ACTIONS(588), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7931] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(644), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [7940] = 3,
-    ACTIONS(735), 1,
-      anon_sym_LBRACE,
-    STATE(299), 1,
-      sym_schema_declarations,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7951] = 3,
-    ACTIONS(737), 1,
-      anon_sym_LBRACE,
-    ACTIONS(739), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7962] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(741), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [7971] = 2,
     ACTIONS(743), 1,
-      anon_sym_edgedb,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    STATE(418), 1,
+      sym_argspec,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7979] = 2,
-    ACTIONS(727), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [7987] = 2,
+  [10294] = 4,
+    ACTIONS(289), 1,
+      anon_sym_COMMA,
     ACTIONS(745), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    STATE(314), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [7995] = 2,
+  [10308] = 4,
     ACTIONS(747), 1,
-      anon_sym_edgedb,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8003] = 2,
+      anon_sym_COMMA,
     ACTIONS(749), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_GT,
+    STATE(330), 1,
+      aux_sym__named_tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8011] = 2,
+  [10322] = 4,
     ACTIONS(751), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      anon_sym_COMMA,
+    ACTIONS(754), 1,
+      anon_sym_GT,
+    STATE(319), 1,
+      aux_sym__tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8019] = 2,
-    ACTIONS(753), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+  [10336] = 4,
+    ACTIONS(756), 1,
+      anon_sym_COMMA,
+    ACTIONS(758), 1,
+      anon_sym_GT,
+    STATE(329), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8027] = 2,
-    ACTIONS(755), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [10350] = 4,
+    ACTIONS(321), 1,
+      anon_sym_RPAREN,
+    ACTIONS(760), 1,
+      anon_sym_COMMA,
+    STATE(321), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8035] = 2,
-    ACTIONS(757), 1,
-      anon_sym_LT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8043] = 2,
-    ACTIONS(759), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8051] = 2,
-    ACTIONS(761), 1,
-      anon_sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8059] = 2,
+  [10364] = 4,
+    ACTIONS(289), 1,
+      anon_sym_COMMA,
     ACTIONS(763), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    STATE(323), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8067] = 2,
-    ACTIONS(733), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8075] = 2,
-    ACTIONS(588), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8083] = 2,
+  [10378] = 4,
+    ACTIONS(289), 1,
+      anon_sym_COMMA,
     ACTIONS(765), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    STATE(314), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8091] = 2,
-    ACTIONS(767), 1,
+  [10392] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(767), 3,
+      anon_sym_LBRACE,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8099] = 2,
+      anon_sym_using,
+  [10402] = 4,
+    ACTIONS(297), 1,
+      anon_sym_COMMA,
     ACTIONS(769), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    STATE(321), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8107] = 2,
+  [10416] = 4,
+    ACTIONS(756), 1,
+      anon_sym_COMMA,
     ACTIONS(771), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_GT,
+    STATE(320), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8115] = 2,
+  [10430] = 4,
     ACTIONS(773), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      anon_sym_COMMA,
+    ACTIONS(776), 1,
+      anon_sym_GT,
+    STATE(327), 1,
+      aux_sym__named_tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8123] = 2,
-    ACTIONS(775), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8131] = 2,
-    ACTIONS(777), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8139] = 2,
-    ACTIONS(779), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8147] = 2,
-    ACTIONS(781), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8155] = 2,
-    ACTIONS(783), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8163] = 2,
-    ACTIONS(785), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8171] = 2,
-    ACTIONS(787), 1,
-      anon_sym_enum,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8179] = 2,
-    ACTIONS(789), 1,
-      anon_sym_LT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8187] = 2,
-    ACTIONS(791), 1,
-      anon_sym_LT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8195] = 2,
-    ACTIONS(793), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8203] = 2,
-    ACTIONS(795), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8211] = 2,
-    ACTIONS(797), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8219] = 2,
-    ACTIONS(799), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8227] = 2,
-    ACTIONS(592), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8235] = 2,
-    ACTIONS(801), 1,
+  [10444] = 3,
+    ACTIONS(778), 1,
       anon_sym_COLON,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8243] = 2,
-    ACTIONS(600), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(206), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10456] = 4,
+    ACTIONS(780), 1,
+      anon_sym_COMMA,
+    ACTIONS(783), 1,
+      anon_sym_GT,
+    STATE(329), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8251] = 2,
-    ACTIONS(624), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [10470] = 4,
+    ACTIONS(747), 1,
+      anon_sym_COMMA,
+    ACTIONS(785), 1,
+      anon_sym_GT,
+    STATE(327), 1,
+      aux_sym__named_tuple_repeat1,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8259] = 2,
-    ACTIONS(803), 1,
+  [10484] = 3,
+    ACTIONS(787), 1,
+      anon_sym_LPAREN,
+    ACTIONS(789), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8267] = 2,
-    ACTIONS(805), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+  [10495] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8275] = 2,
-    ACTIONS(807), 1,
+    ACTIONS(791), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [10504] = 3,
+    ACTIONS(718), 1,
+      anon_sym_LBRACE,
+    ACTIONS(720), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8283] = 2,
-    ACTIONS(731), 1,
+  [10515] = 3,
+    ACTIONS(670), 1,
+      anon_sym_LBRACE,
+    ACTIONS(672), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8291] = 2,
-    ACTIONS(809), 1,
+  [10526] = 3,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    STATE(208), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10537] = 3,
+    ACTIONS(664), 1,
+      anon_sym_LBRACE,
+    ACTIONS(666), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10548] = 3,
+    ACTIONS(652), 1,
+      anon_sym_on,
+    STATE(297), 1,
+      sym_on,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10559] = 3,
+    ACTIONS(714), 1,
+      anon_sym_LBRACE,
+    ACTIONS(716), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10570] = 3,
+    ACTIONS(676), 1,
+      anon_sym_LBRACE,
+    ACTIONS(678), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10581] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(793), 2,
       anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8299] = 2,
-    ACTIONS(811), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8307] = 2,
-    ACTIONS(813), 1,
+      anon_sym_COMMA,
+  [10590] = 3,
+    ACTIONS(660), 1,
+      anon_sym_LBRACE,
+    ACTIONS(662), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8315] = 2,
+  [10601] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(795), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10610] = 3,
+    ACTIONS(789), 1,
+      sym_identifier,
+    ACTIONS(797), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10621] = 3,
+    ACTIONS(799), 1,
+      anon_sym_LBRACE,
+    ACTIONS(801), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10632] = 3,
+    ACTIONS(803), 1,
+      anon_sym_LBRACE,
+    ACTIONS(805), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10643] = 3,
+    ACTIONS(807), 1,
+      anon_sym_LBRACE,
+    ACTIONS(809), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10654] = 3,
+    ACTIONS(811), 1,
+      anon_sym_LBRACE,
+    STATE(332), 1,
+      sym_schema_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10665] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(754), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10674] = 3,
+    ACTIONS(813), 1,
+      anon_sym_LBRACE,
     ACTIONS(815), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8323] = 2,
-    ACTIONS(817), 1,
+  [10685] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(817), 2,
       ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8331] = 2,
-    ACTIONS(819), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8339] = 2,
-    ACTIONS(821), 1,
-      anon_sym_using,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8347] = 2,
-    ACTIONS(823), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8355] = 2,
-    ACTIONS(719), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8363] = 2,
-    ACTIONS(825), 1,
+      anon_sym_module,
+  [10694] = 3,
+    ACTIONS(789), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(819), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8371] = 2,
+  [10705] = 3,
+    ACTIONS(821), 1,
+      anon_sym_LBRACE,
+    ACTIONS(823), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10716] = 3,
+    ACTIONS(684), 1,
+      anon_sym_LBRACE,
+    ACTIONS(686), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10727] = 3,
+    ACTIONS(825), 1,
+      anon_sym_LBRACE,
     ACTIONS(827), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      anon_sym_COLON_EQ,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8379] = 2,
-    ACTIONS(829), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [10738] = 3,
+    ACTIONS(178), 1,
+      anon_sym_LBRACE,
+    STATE(201), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8387] = 2,
-    ACTIONS(723), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+  [10749] = 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8395] = 2,
+    ACTIONS(829), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [10758] = 3,
     ACTIONS(831), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8403] = 2,
+      anon_sym_LBRACE,
     ACTIONS(833), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8411] = 2,
-    ACTIONS(835), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8419] = 2,
-    ACTIONS(837), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8427] = 2,
+  [10769] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(783), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10778] = 2,
+    ACTIONS(835), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10786] = 2,
+    ACTIONS(837), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10794] = 2,
     ACTIONS(839), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8435] = 2,
+  [10802] = 2,
     ACTIONS(841), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8443] = 2,
+  [10810] = 2,
     ACTIONS(843), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8451] = 2,
+  [10818] = 2,
     ACTIONS(845), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8459] = 2,
+  [10826] = 2,
     ACTIONS(847), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8467] = 2,
+  [10834] = 2,
     ACTIONS(849), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8475] = 2,
+  [10842] = 2,
     ACTIONS(851), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8483] = 2,
+  [10850] = 2,
     ACTIONS(853), 1,
-      anon_sym_RBRACE,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8491] = 2,
-    ACTIONS(855), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8499] = 2,
-    ACTIONS(857), 1,
-      anon_sym_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [8507] = 2,
-    ACTIONS(739), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8515] = 2,
+  [10858] = 2,
+    ACTIONS(686), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10866] = 2,
+    ACTIONS(855), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10874] = 2,
+    ACTIONS(857), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10882] = 2,
     ACTIONS(859), 1,
       anon_sym_LPAREN,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8523] = 2,
+  [10890] = 2,
     ACTIONS(861), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8531] = 2,
+  [10898] = 2,
     ACTIONS(863), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8539] = 2,
+  [10906] = 2,
     ACTIONS(865), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
+      anon_sym_edgedb,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8547] = 2,
+  [10914] = 2,
+    ACTIONS(833), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10922] = 2,
     ACTIONS(867), 1,
       anon_sym_SEMI,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8555] = 2,
+  [10930] = 2,
     ACTIONS(869), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8563] = 2,
+  [10938] = 2,
     ACTIONS(871), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8571] = 2,
+  [10946] = 2,
     ACTIONS(873), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8579] = 2,
+  [10954] = 2,
     ACTIONS(875), 1,
-      anon_sym_type,
-    ACTIONS(3), 2,
+      anon_sym_COLON,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [8587] = 2,
+  [10962] = 2,
     ACTIONS(877), 1,
+      anon_sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10970] = 2,
+    ACTIONS(879), 1,
       sym_identifier,
-    ACTIONS(3), 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10978] = 2,
+    ACTIONS(881), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10986] = 2,
+    ACTIONS(883), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10994] = 2,
+    ACTIONS(885), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11002] = 2,
+    ACTIONS(815), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11010] = 2,
+    ACTIONS(887), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11018] = 2,
+    ACTIONS(672), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11026] = 2,
+    ACTIONS(889), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11034] = 2,
+    ACTIONS(891), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11042] = 2,
+    ACTIONS(893), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11050] = 2,
+    ACTIONS(895), 1,
+      anon_sym_GT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11058] = 2,
+    ACTIONS(897), 1,
+      anon_sym_edgedb,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11066] = 2,
+    ACTIONS(899), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11074] = 2,
+    ACTIONS(801), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11082] = 2,
+    ACTIONS(901), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11090] = 2,
+    ACTIONS(823), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11098] = 2,
+    ACTIONS(903), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11106] = 2,
+    ACTIONS(905), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11114] = 2,
+    ACTIONS(907), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11122] = 2,
+    ACTIONS(909), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11130] = 2,
+    ACTIONS(678), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11138] = 2,
+    ACTIONS(911), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11146] = 2,
+    ACTIONS(913), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11154] = 2,
+    ACTIONS(915), 1,
+      anon_sym_using,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11162] = 2,
+    ACTIONS(917), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11170] = 2,
+    ACTIONS(919), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11178] = 2,
+    ACTIONS(716), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11186] = 2,
+    ACTIONS(809), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11194] = 2,
+    ACTIONS(921), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11202] = 2,
+    ACTIONS(923), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11210] = 2,
+    ACTIONS(925), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11218] = 2,
+    ACTIONS(927), 1,
+      anon_sym_enum,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11226] = 2,
+    ACTIONS(929), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11234] = 2,
+    ACTIONS(931), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11242] = 2,
+    ACTIONS(933), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11250] = 2,
+    ACTIONS(935), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11258] = 2,
+    ACTIONS(937), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11266] = 2,
+    ACTIONS(939), 1,
+      ts_builtin_sym_end,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11274] = 2,
+    ACTIONS(941), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11282] = 2,
+    ACTIONS(943), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11290] = 2,
+    ACTIONS(945), 1,
+      anon_sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11298] = 2,
+    ACTIONS(947), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [11306] = 2,
+    ACTIONS(787), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 57,
-  [SMALL_STATE(4)] = 114,
-  [SMALL_STATE(5)] = 166,
-  [SMALL_STATE(6)] = 218,
-  [SMALL_STATE(7)] = 266,
-  [SMALL_STATE(8)] = 314,
-  [SMALL_STATE(9)] = 362,
-  [SMALL_STATE(10)] = 410,
-  [SMALL_STATE(11)] = 458,
-  [SMALL_STATE(12)] = 506,
-  [SMALL_STATE(13)] = 554,
-  [SMALL_STATE(14)] = 604,
-  [SMALL_STATE(15)] = 652,
-  [SMALL_STATE(16)] = 700,
-  [SMALL_STATE(17)] = 748,
-  [SMALL_STATE(18)] = 796,
-  [SMALL_STATE(19)] = 844,
-  [SMALL_STATE(20)] = 892,
-  [SMALL_STATE(21)] = 950,
-  [SMALL_STATE(22)] = 1008,
-  [SMALL_STATE(23)] = 1066,
-  [SMALL_STATE(24)] = 1111,
-  [SMALL_STATE(25)] = 1156,
-  [SMALL_STATE(26)] = 1187,
-  [SMALL_STATE(27)] = 1218,
-  [SMALL_STATE(28)] = 1249,
-  [SMALL_STATE(29)] = 1294,
-  [SMALL_STATE(30)] = 1325,
-  [SMALL_STATE(31)] = 1356,
-  [SMALL_STATE(32)] = 1387,
-  [SMALL_STATE(33)] = 1418,
-  [SMALL_STATE(34)] = 1463,
-  [SMALL_STATE(35)] = 1497,
-  [SMALL_STATE(36)] = 1531,
-  [SMALL_STATE(37)] = 1565,
-  [SMALL_STATE(38)] = 1594,
-  [SMALL_STATE(39)] = 1633,
-  [SMALL_STATE(40)] = 1662,
-  [SMALL_STATE(41)] = 1701,
-  [SMALL_STATE(42)] = 1730,
-  [SMALL_STATE(43)] = 1769,
-  [SMALL_STATE(44)] = 1808,
-  [SMALL_STATE(45)] = 1844,
-  [SMALL_STATE(46)] = 1890,
-  [SMALL_STATE(47)] = 1936,
-  [SMALL_STATE(48)] = 1968,
-  [SMALL_STATE(49)] = 2004,
-  [SMALL_STATE(50)] = 2040,
-  [SMALL_STATE(51)] = 2076,
-  [SMALL_STATE(52)] = 2122,
-  [SMALL_STATE(53)] = 2154,
-  [SMALL_STATE(54)] = 2190,
-  [SMALL_STATE(55)] = 2226,
-  [SMALL_STATE(56)] = 2262,
-  [SMALL_STATE(57)] = 2298,
-  [SMALL_STATE(58)] = 2333,
-  [SMALL_STATE(59)] = 2368,
-  [SMALL_STATE(60)] = 2394,
-  [SMALL_STATE(61)] = 2421,
-  [SMALL_STATE(62)] = 2448,
-  [SMALL_STATE(63)] = 2477,
-  [SMALL_STATE(64)] = 2504,
-  [SMALL_STATE(65)] = 2529,
-  [SMALL_STATE(66)] = 2556,
-  [SMALL_STATE(67)] = 2583,
-  [SMALL_STATE(68)] = 2610,
-  [SMALL_STATE(69)] = 2635,
-  [SMALL_STATE(70)] = 2660,
-  [SMALL_STATE(71)] = 2687,
-  [SMALL_STATE(72)] = 2714,
-  [SMALL_STATE(73)] = 2741,
-  [SMALL_STATE(74)] = 2778,
-  [SMALL_STATE(75)] = 2805,
-  [SMALL_STATE(76)] = 2830,
-  [SMALL_STATE(77)] = 2867,
-  [SMALL_STATE(78)] = 2904,
-  [SMALL_STATE(79)] = 2931,
-  [SMALL_STATE(80)] = 2958,
-  [SMALL_STATE(81)] = 2995,
-  [SMALL_STATE(82)] = 3020,
-  [SMALL_STATE(83)] = 3057,
-  [SMALL_STATE(84)] = 3082,
-  [SMALL_STATE(85)] = 3109,
-  [SMALL_STATE(86)] = 3146,
-  [SMALL_STATE(87)] = 3173,
-  [SMALL_STATE(88)] = 3198,
-  [SMALL_STATE(89)] = 3225,
-  [SMALL_STATE(90)] = 3252,
-  [SMALL_STATE(91)] = 3289,
-  [SMALL_STATE(92)] = 3326,
-  [SMALL_STATE(93)] = 3363,
-  [SMALL_STATE(94)] = 3400,
-  [SMALL_STATE(95)] = 3437,
-  [SMALL_STATE(96)] = 3464,
-  [SMALL_STATE(97)] = 3493,
-  [SMALL_STATE(98)] = 3520,
-  [SMALL_STATE(99)] = 3545,
-  [SMALL_STATE(100)] = 3572,
-  [SMALL_STATE(101)] = 3599,
-  [SMALL_STATE(102)] = 3623,
-  [SMALL_STATE(103)] = 3647,
-  [SMALL_STATE(104)] = 3671,
-  [SMALL_STATE(105)] = 3695,
-  [SMALL_STATE(106)] = 3719,
-  [SMALL_STATE(107)] = 3743,
-  [SMALL_STATE(108)] = 3767,
-  [SMALL_STATE(109)] = 3791,
-  [SMALL_STATE(110)] = 3827,
-  [SMALL_STATE(111)] = 3863,
-  [SMALL_STATE(112)] = 3899,
-  [SMALL_STATE(113)] = 3923,
-  [SMALL_STATE(114)] = 3959,
-  [SMALL_STATE(115)] = 3983,
-  [SMALL_STATE(116)] = 4019,
-  [SMALL_STATE(117)] = 4055,
-  [SMALL_STATE(118)] = 4079,
-  [SMALL_STATE(119)] = 4115,
-  [SMALL_STATE(120)] = 4139,
-  [SMALL_STATE(121)] = 4163,
-  [SMALL_STATE(122)] = 4187,
-  [SMALL_STATE(123)] = 4211,
-  [SMALL_STATE(124)] = 4235,
-  [SMALL_STATE(125)] = 4271,
-  [SMALL_STATE(126)] = 4295,
-  [SMALL_STATE(127)] = 4331,
-  [SMALL_STATE(128)] = 4355,
-  [SMALL_STATE(129)] = 4379,
-  [SMALL_STATE(130)] = 4403,
-  [SMALL_STATE(131)] = 4439,
-  [SMALL_STATE(132)] = 4463,
-  [SMALL_STATE(133)] = 4487,
-  [SMALL_STATE(134)] = 4511,
-  [SMALL_STATE(135)] = 4535,
-  [SMALL_STATE(136)] = 4559,
-  [SMALL_STATE(137)] = 4583,
-  [SMALL_STATE(138)] = 4607,
-  [SMALL_STATE(139)] = 4643,
-  [SMALL_STATE(140)] = 4679,
-  [SMALL_STATE(141)] = 4703,
-  [SMALL_STATE(142)] = 4727,
-  [SMALL_STATE(143)] = 4763,
-  [SMALL_STATE(144)] = 4799,
-  [SMALL_STATE(145)] = 4823,
-  [SMALL_STATE(146)] = 4859,
-  [SMALL_STATE(147)] = 4883,
-  [SMALL_STATE(148)] = 4907,
-  [SMALL_STATE(149)] = 4931,
-  [SMALL_STATE(150)] = 4967,
-  [SMALL_STATE(151)] = 5003,
-  [SMALL_STATE(152)] = 5027,
-  [SMALL_STATE(153)] = 5051,
-  [SMALL_STATE(154)] = 5075,
-  [SMALL_STATE(155)] = 5099,
-  [SMALL_STATE(156)] = 5135,
-  [SMALL_STATE(157)] = 5159,
-  [SMALL_STATE(158)] = 5195,
-  [SMALL_STATE(159)] = 5219,
-  [SMALL_STATE(160)] = 5255,
-  [SMALL_STATE(161)] = 5279,
-  [SMALL_STATE(162)] = 5315,
-  [SMALL_STATE(163)] = 5338,
-  [SMALL_STATE(164)] = 5361,
-  [SMALL_STATE(165)] = 5384,
-  [SMALL_STATE(166)] = 5407,
-  [SMALL_STATE(167)] = 5430,
-  [SMALL_STATE(168)] = 5453,
-  [SMALL_STATE(169)] = 5476,
-  [SMALL_STATE(170)] = 5499,
-  [SMALL_STATE(171)] = 5522,
-  [SMALL_STATE(172)] = 5545,
-  [SMALL_STATE(173)] = 5568,
-  [SMALL_STATE(174)] = 5591,
-  [SMALL_STATE(175)] = 5614,
-  [SMALL_STATE(176)] = 5637,
-  [SMALL_STATE(177)] = 5660,
-  [SMALL_STATE(178)] = 5683,
-  [SMALL_STATE(179)] = 5706,
-  [SMALL_STATE(180)] = 5729,
-  [SMALL_STATE(181)] = 5752,
-  [SMALL_STATE(182)] = 5783,
-  [SMALL_STATE(183)] = 5814,
-  [SMALL_STATE(184)] = 5845,
-  [SMALL_STATE(185)] = 5874,
-  [SMALL_STATE(186)] = 5905,
-  [SMALL_STATE(187)] = 5929,
-  [SMALL_STATE(188)] = 5959,
-  [SMALL_STATE(189)] = 5979,
-  [SMALL_STATE(190)] = 5999,
-  [SMALL_STATE(191)] = 6027,
-  [SMALL_STATE(192)] = 6055,
-  [SMALL_STATE(193)] = 6083,
-  [SMALL_STATE(194)] = 6111,
-  [SMALL_STATE(195)] = 6139,
-  [SMALL_STATE(196)] = 6159,
-  [SMALL_STATE(197)] = 6187,
-  [SMALL_STATE(198)] = 6207,
-  [SMALL_STATE(199)] = 6235,
-  [SMALL_STATE(200)] = 6259,
-  [SMALL_STATE(201)] = 6287,
-  [SMALL_STATE(202)] = 6307,
-  [SMALL_STATE(203)] = 6327,
-  [SMALL_STATE(204)] = 6349,
-  [SMALL_STATE(205)] = 6376,
-  [SMALL_STATE(206)] = 6396,
-  [SMALL_STATE(207)] = 6416,
-  [SMALL_STATE(208)] = 6436,
-  [SMALL_STATE(209)] = 6456,
-  [SMALL_STATE(210)] = 6476,
-  [SMALL_STATE(211)] = 6496,
-  [SMALL_STATE(212)] = 6516,
-  [SMALL_STATE(213)] = 6536,
-  [SMALL_STATE(214)] = 6556,
-  [SMALL_STATE(215)] = 6577,
-  [SMALL_STATE(216)] = 6612,
-  [SMALL_STATE(217)] = 6647,
-  [SMALL_STATE(218)] = 6668,
-  [SMALL_STATE(219)] = 6697,
-  [SMALL_STATE(220)] = 6726,
-  [SMALL_STATE(221)] = 6739,
-  [SMALL_STATE(222)] = 6752,
-  [SMALL_STATE(223)] = 6775,
-  [SMALL_STATE(224)] = 6798,
-  [SMALL_STATE(225)] = 6821,
-  [SMALL_STATE(226)] = 6844,
-  [SMALL_STATE(227)] = 6857,
-  [SMALL_STATE(228)] = 6870,
-  [SMALL_STATE(229)] = 6887,
-  [SMALL_STATE(230)] = 6898,
-  [SMALL_STATE(231)] = 6915,
-  [SMALL_STATE(232)] = 6932,
-  [SMALL_STATE(233)] = 6949,
-  [SMALL_STATE(234)] = 6966,
-  [SMALL_STATE(235)] = 6983,
-  [SMALL_STATE(236)] = 7000,
-  [SMALL_STATE(237)] = 7015,
-  [SMALL_STATE(238)] = 7032,
-  [SMALL_STATE(239)] = 7049,
-  [SMALL_STATE(240)] = 7066,
-  [SMALL_STATE(241)] = 7083,
-  [SMALL_STATE(242)] = 7098,
-  [SMALL_STATE(243)] = 7115,
-  [SMALL_STATE(244)] = 7127,
-  [SMALL_STATE(245)] = 7139,
-  [SMALL_STATE(246)] = 7151,
-  [SMALL_STATE(247)] = 7165,
-  [SMALL_STATE(248)] = 7177,
-  [SMALL_STATE(249)] = 7189,
-  [SMALL_STATE(250)] = 7201,
-  [SMALL_STATE(251)] = 7213,
-  [SMALL_STATE(252)] = 7227,
-  [SMALL_STATE(253)] = 7239,
-  [SMALL_STATE(254)] = 7253,
-  [SMALL_STATE(255)] = 7267,
-  [SMALL_STATE(256)] = 7281,
-  [SMALL_STATE(257)] = 7293,
-  [SMALL_STATE(258)] = 7305,
-  [SMALL_STATE(259)] = 7319,
-  [SMALL_STATE(260)] = 7333,
-  [SMALL_STATE(261)] = 7345,
-  [SMALL_STATE(262)] = 7357,
-  [SMALL_STATE(263)] = 7369,
-  [SMALL_STATE(264)] = 7381,
-  [SMALL_STATE(265)] = 7393,
-  [SMALL_STATE(266)] = 7407,
-  [SMALL_STATE(267)] = 7419,
-  [SMALL_STATE(268)] = 7431,
-  [SMALL_STATE(269)] = 7445,
-  [SMALL_STATE(270)] = 7457,
-  [SMALL_STATE(271)] = 7467,
-  [SMALL_STATE(272)] = 7479,
-  [SMALL_STATE(273)] = 7491,
-  [SMALL_STATE(274)] = 7503,
-  [SMALL_STATE(275)] = 7513,
-  [SMALL_STATE(276)] = 7525,
-  [SMALL_STATE(277)] = 7537,
-  [SMALL_STATE(278)] = 7551,
-  [SMALL_STATE(279)] = 7565,
-  [SMALL_STATE(280)] = 7579,
-  [SMALL_STATE(281)] = 7593,
-  [SMALL_STATE(282)] = 7605,
-  [SMALL_STATE(283)] = 7617,
-  [SMALL_STATE(284)] = 7629,
-  [SMALL_STATE(285)] = 7641,
-  [SMALL_STATE(286)] = 7651,
-  [SMALL_STATE(287)] = 7665,
-  [SMALL_STATE(288)] = 7677,
-  [SMALL_STATE(289)] = 7688,
-  [SMALL_STATE(290)] = 7699,
-  [SMALL_STATE(291)] = 7710,
-  [SMALL_STATE(292)] = 7721,
-  [SMALL_STATE(293)] = 7732,
-  [SMALL_STATE(294)] = 7743,
-  [SMALL_STATE(295)] = 7754,
-  [SMALL_STATE(296)] = 7763,
-  [SMALL_STATE(297)] = 7772,
-  [SMALL_STATE(298)] = 7783,
-  [SMALL_STATE(299)] = 7794,
-  [SMALL_STATE(300)] = 7803,
-  [SMALL_STATE(301)] = 7814,
-  [SMALL_STATE(302)] = 7825,
-  [SMALL_STATE(303)] = 7834,
-  [SMALL_STATE(304)] = 7845,
-  [SMALL_STATE(305)] = 7854,
-  [SMALL_STATE(306)] = 7865,
-  [SMALL_STATE(307)] = 7876,
-  [SMALL_STATE(308)] = 7887,
-  [SMALL_STATE(309)] = 7898,
-  [SMALL_STATE(310)] = 7909,
-  [SMALL_STATE(311)] = 7920,
-  [SMALL_STATE(312)] = 7931,
-  [SMALL_STATE(313)] = 7940,
-  [SMALL_STATE(314)] = 7951,
-  [SMALL_STATE(315)] = 7962,
-  [SMALL_STATE(316)] = 7971,
-  [SMALL_STATE(317)] = 7979,
-  [SMALL_STATE(318)] = 7987,
-  [SMALL_STATE(319)] = 7995,
-  [SMALL_STATE(320)] = 8003,
-  [SMALL_STATE(321)] = 8011,
-  [SMALL_STATE(322)] = 8019,
-  [SMALL_STATE(323)] = 8027,
-  [SMALL_STATE(324)] = 8035,
-  [SMALL_STATE(325)] = 8043,
-  [SMALL_STATE(326)] = 8051,
-  [SMALL_STATE(327)] = 8059,
-  [SMALL_STATE(328)] = 8067,
-  [SMALL_STATE(329)] = 8075,
-  [SMALL_STATE(330)] = 8083,
-  [SMALL_STATE(331)] = 8091,
-  [SMALL_STATE(332)] = 8099,
-  [SMALL_STATE(333)] = 8107,
-  [SMALL_STATE(334)] = 8115,
-  [SMALL_STATE(335)] = 8123,
-  [SMALL_STATE(336)] = 8131,
-  [SMALL_STATE(337)] = 8139,
-  [SMALL_STATE(338)] = 8147,
-  [SMALL_STATE(339)] = 8155,
-  [SMALL_STATE(340)] = 8163,
-  [SMALL_STATE(341)] = 8171,
-  [SMALL_STATE(342)] = 8179,
-  [SMALL_STATE(343)] = 8187,
-  [SMALL_STATE(344)] = 8195,
-  [SMALL_STATE(345)] = 8203,
-  [SMALL_STATE(346)] = 8211,
-  [SMALL_STATE(347)] = 8219,
-  [SMALL_STATE(348)] = 8227,
-  [SMALL_STATE(349)] = 8235,
-  [SMALL_STATE(350)] = 8243,
-  [SMALL_STATE(351)] = 8251,
-  [SMALL_STATE(352)] = 8259,
-  [SMALL_STATE(353)] = 8267,
-  [SMALL_STATE(354)] = 8275,
-  [SMALL_STATE(355)] = 8283,
-  [SMALL_STATE(356)] = 8291,
-  [SMALL_STATE(357)] = 8299,
-  [SMALL_STATE(358)] = 8307,
-  [SMALL_STATE(359)] = 8315,
-  [SMALL_STATE(360)] = 8323,
-  [SMALL_STATE(361)] = 8331,
-  [SMALL_STATE(362)] = 8339,
-  [SMALL_STATE(363)] = 8347,
-  [SMALL_STATE(364)] = 8355,
-  [SMALL_STATE(365)] = 8363,
-  [SMALL_STATE(366)] = 8371,
-  [SMALL_STATE(367)] = 8379,
-  [SMALL_STATE(368)] = 8387,
-  [SMALL_STATE(369)] = 8395,
-  [SMALL_STATE(370)] = 8403,
-  [SMALL_STATE(371)] = 8411,
-  [SMALL_STATE(372)] = 8419,
-  [SMALL_STATE(373)] = 8427,
-  [SMALL_STATE(374)] = 8435,
-  [SMALL_STATE(375)] = 8443,
-  [SMALL_STATE(376)] = 8451,
-  [SMALL_STATE(377)] = 8459,
-  [SMALL_STATE(378)] = 8467,
-  [SMALL_STATE(379)] = 8475,
-  [SMALL_STATE(380)] = 8483,
-  [SMALL_STATE(381)] = 8491,
-  [SMALL_STATE(382)] = 8499,
-  [SMALL_STATE(383)] = 8507,
-  [SMALL_STATE(384)] = 8515,
-  [SMALL_STATE(385)] = 8523,
-  [SMALL_STATE(386)] = 8531,
-  [SMALL_STATE(387)] = 8539,
-  [SMALL_STATE(388)] = 8547,
-  [SMALL_STATE(389)] = 8555,
-  [SMALL_STATE(390)] = 8563,
-  [SMALL_STATE(391)] = 8571,
-  [SMALL_STATE(392)] = 8579,
-  [SMALL_STATE(393)] = 8587,
+  [SMALL_STATE(3)] = 50,
+  [SMALL_STATE(4)] = 97,
+  [SMALL_STATE(5)] = 144,
+  [SMALL_STATE(6)] = 207,
+  [SMALL_STATE(7)] = 272,
+  [SMALL_STATE(8)] = 319,
+  [SMALL_STATE(9)] = 370,
+  [SMALL_STATE(10)] = 429,
+  [SMALL_STATE(11)] = 476,
+  [SMALL_STATE(12)] = 537,
+  [SMALL_STATE(13)] = 584,
+  [SMALL_STATE(14)] = 647,
+  [SMALL_STATE(15)] = 696,
+  [SMALL_STATE(16)] = 743,
+  [SMALL_STATE(17)] = 796,
+  [SMALL_STATE(18)] = 843,
+  [SMALL_STATE(19)] = 900,
+  [SMALL_STATE(20)] = 947,
+  [SMALL_STATE(21)] = 994,
+  [SMALL_STATE(22)] = 1061,
+  [SMALL_STATE(23)] = 1128,
+  [SMALL_STATE(24)] = 1195,
+  [SMALL_STATE(25)] = 1262,
+  [SMALL_STATE(26)] = 1329,
+  [SMALL_STATE(27)] = 1396,
+  [SMALL_STATE(28)] = 1463,
+  [SMALL_STATE(29)] = 1530,
+  [SMALL_STATE(30)] = 1597,
+  [SMALL_STATE(31)] = 1664,
+  [SMALL_STATE(32)] = 1721,
+  [SMALL_STATE(33)] = 1778,
+  [SMALL_STATE(34)] = 1830,
+  [SMALL_STATE(35)] = 1882,
+  [SMALL_STATE(36)] = 1930,
+  [SMALL_STATE(37)] = 1978,
+  [SMALL_STATE(38)] = 2028,
+  [SMALL_STATE(39)] = 2076,
+  [SMALL_STATE(40)] = 2124,
+  [SMALL_STATE(41)] = 2172,
+  [SMALL_STATE(42)] = 2220,
+  [SMALL_STATE(43)] = 2268,
+  [SMALL_STATE(44)] = 2316,
+  [SMALL_STATE(45)] = 2364,
+  [SMALL_STATE(46)] = 2412,
+  [SMALL_STATE(47)] = 2460,
+  [SMALL_STATE(48)] = 2508,
+  [SMALL_STATE(49)] = 2556,
+  [SMALL_STATE(50)] = 2614,
+  [SMALL_STATE(51)] = 2672,
+  [SMALL_STATE(52)] = 2730,
+  [SMALL_STATE(53)] = 2775,
+  [SMALL_STATE(54)] = 2820,
+  [SMALL_STATE(55)] = 2851,
+  [SMALL_STATE(56)] = 2882,
+  [SMALL_STATE(57)] = 2913,
+  [SMALL_STATE(58)] = 2944,
+  [SMALL_STATE(59)] = 2975,
+  [SMALL_STATE(60)] = 3006,
+  [SMALL_STATE(61)] = 3037,
+  [SMALL_STATE(62)] = 3082,
+  [SMALL_STATE(63)] = 3127,
+  [SMALL_STATE(64)] = 3161,
+  [SMALL_STATE(65)] = 3195,
+  [SMALL_STATE(66)] = 3229,
+  [SMALL_STATE(67)] = 3268,
+  [SMALL_STATE(68)] = 3303,
+  [SMALL_STATE(69)] = 3332,
+  [SMALL_STATE(70)] = 3367,
+  [SMALL_STATE(71)] = 3396,
+  [SMALL_STATE(72)] = 3425,
+  [SMALL_STATE(73)] = 3464,
+  [SMALL_STATE(74)] = 3510,
+  [SMALL_STATE(75)] = 3546,
+  [SMALL_STATE(76)] = 3600,
+  [SMALL_STATE(77)] = 3636,
+  [SMALL_STATE(78)] = 3672,
+  [SMALL_STATE(79)] = 3726,
+  [SMALL_STATE(80)] = 3772,
+  [SMALL_STATE(81)] = 3818,
+  [SMALL_STATE(82)] = 3850,
+  [SMALL_STATE(83)] = 3882,
+  [SMALL_STATE(84)] = 3918,
+  [SMALL_STATE(85)] = 3967,
+  [SMALL_STATE(86)] = 4002,
+  [SMALL_STATE(87)] = 4037,
+  [SMALL_STATE(88)] = 4086,
+  [SMALL_STATE(89)] = 4134,
+  [SMALL_STATE(90)] = 4182,
+  [SMALL_STATE(91)] = 4212,
+  [SMALL_STATE(92)] = 4260,
+  [SMALL_STATE(93)] = 4290,
+  [SMALL_STATE(94)] = 4338,
+  [SMALL_STATE(95)] = 4386,
+  [SMALL_STATE(96)] = 4434,
+  [SMALL_STATE(97)] = 4482,
+  [SMALL_STATE(98)] = 4530,
+  [SMALL_STATE(99)] = 4578,
+  [SMALL_STATE(100)] = 4626,
+  [SMALL_STATE(101)] = 4674,
+  [SMALL_STATE(102)] = 4701,
+  [SMALL_STATE(103)] = 4738,
+  [SMALL_STATE(104)] = 4775,
+  [SMALL_STATE(105)] = 4812,
+  [SMALL_STATE(106)] = 4849,
+  [SMALL_STATE(107)] = 4876,
+  [SMALL_STATE(108)] = 4903,
+  [SMALL_STATE(109)] = 4930,
+  [SMALL_STATE(110)] = 4955,
+  [SMALL_STATE(111)] = 4984,
+  [SMALL_STATE(112)] = 5021,
+  [SMALL_STATE(113)] = 5058,
+  [SMALL_STATE(114)] = 5083,
+  [SMALL_STATE(115)] = 5110,
+  [SMALL_STATE(116)] = 5137,
+  [SMALL_STATE(117)] = 5162,
+  [SMALL_STATE(118)] = 5199,
+  [SMALL_STATE(119)] = 5236,
+  [SMALL_STATE(120)] = 5261,
+  [SMALL_STATE(121)] = 5288,
+  [SMALL_STATE(122)] = 5315,
+  [SMALL_STATE(123)] = 5352,
+  [SMALL_STATE(124)] = 5379,
+  [SMALL_STATE(125)] = 5404,
+  [SMALL_STATE(126)] = 5431,
+  [SMALL_STATE(127)] = 5468,
+  [SMALL_STATE(128)] = 5505,
+  [SMALL_STATE(129)] = 5530,
+  [SMALL_STATE(130)] = 5557,
+  [SMALL_STATE(131)] = 5586,
+  [SMALL_STATE(132)] = 5613,
+  [SMALL_STATE(133)] = 5638,
+  [SMALL_STATE(134)] = 5665,
+  [SMALL_STATE(135)] = 5690,
+  [SMALL_STATE(136)] = 5717,
+  [SMALL_STATE(137)] = 5753,
+  [SMALL_STATE(138)] = 5777,
+  [SMALL_STATE(139)] = 5801,
+  [SMALL_STATE(140)] = 5825,
+  [SMALL_STATE(141)] = 5849,
+  [SMALL_STATE(142)] = 5873,
+  [SMALL_STATE(143)] = 5897,
+  [SMALL_STATE(144)] = 5933,
+  [SMALL_STATE(145)] = 5957,
+  [SMALL_STATE(146)] = 5993,
+  [SMALL_STATE(147)] = 6017,
+  [SMALL_STATE(148)] = 6041,
+  [SMALL_STATE(149)] = 6065,
+  [SMALL_STATE(150)] = 6089,
+  [SMALL_STATE(151)] = 6125,
+  [SMALL_STATE(152)] = 6161,
+  [SMALL_STATE(153)] = 6197,
+  [SMALL_STATE(154)] = 6221,
+  [SMALL_STATE(155)] = 6257,
+  [SMALL_STATE(156)] = 6281,
+  [SMALL_STATE(157)] = 6305,
+  [SMALL_STATE(158)] = 6329,
+  [SMALL_STATE(159)] = 6365,
+  [SMALL_STATE(160)] = 6389,
+  [SMALL_STATE(161)] = 6413,
+  [SMALL_STATE(162)] = 6437,
+  [SMALL_STATE(163)] = 6461,
+  [SMALL_STATE(164)] = 6485,
+  [SMALL_STATE(165)] = 6521,
+  [SMALL_STATE(166)] = 6557,
+  [SMALL_STATE(167)] = 6581,
+  [SMALL_STATE(168)] = 6617,
+  [SMALL_STATE(169)] = 6641,
+  [SMALL_STATE(170)] = 6677,
+  [SMALL_STATE(171)] = 6713,
+  [SMALL_STATE(172)] = 6737,
+  [SMALL_STATE(173)] = 6761,
+  [SMALL_STATE(174)] = 6797,
+  [SMALL_STATE(175)] = 6821,
+  [SMALL_STATE(176)] = 6845,
+  [SMALL_STATE(177)] = 6869,
+  [SMALL_STATE(178)] = 6893,
+  [SMALL_STATE(179)] = 6929,
+  [SMALL_STATE(180)] = 6953,
+  [SMALL_STATE(181)] = 6977,
+  [SMALL_STATE(182)] = 7001,
+  [SMALL_STATE(183)] = 7025,
+  [SMALL_STATE(184)] = 7061,
+  [SMALL_STATE(185)] = 7085,
+  [SMALL_STATE(186)] = 7109,
+  [SMALL_STATE(187)] = 7145,
+  [SMALL_STATE(188)] = 7181,
+  [SMALL_STATE(189)] = 7217,
+  [SMALL_STATE(190)] = 7241,
+  [SMALL_STATE(191)] = 7277,
+  [SMALL_STATE(192)] = 7313,
+  [SMALL_STATE(193)] = 7337,
+  [SMALL_STATE(194)] = 7360,
+  [SMALL_STATE(195)] = 7383,
+  [SMALL_STATE(196)] = 7406,
+  [SMALL_STATE(197)] = 7429,
+  [SMALL_STATE(198)] = 7452,
+  [SMALL_STATE(199)] = 7475,
+  [SMALL_STATE(200)] = 7498,
+  [SMALL_STATE(201)] = 7521,
+  [SMALL_STATE(202)] = 7544,
+  [SMALL_STATE(203)] = 7567,
+  [SMALL_STATE(204)] = 7590,
+  [SMALL_STATE(205)] = 7613,
+  [SMALL_STATE(206)] = 7636,
+  [SMALL_STATE(207)] = 7659,
+  [SMALL_STATE(208)] = 7682,
+  [SMALL_STATE(209)] = 7705,
+  [SMALL_STATE(210)] = 7728,
+  [SMALL_STATE(211)] = 7751,
+  [SMALL_STATE(212)] = 7774,
+  [SMALL_STATE(213)] = 7805,
+  [SMALL_STATE(214)] = 7836,
+  [SMALL_STATE(215)] = 7867,
+  [SMALL_STATE(216)] = 7896,
+  [SMALL_STATE(217)] = 7927,
+  [SMALL_STATE(218)] = 7947,
+  [SMALL_STATE(219)] = 7975,
+  [SMALL_STATE(220)] = 8003,
+  [SMALL_STATE(221)] = 8023,
+  [SMALL_STATE(222)] = 8051,
+  [SMALL_STATE(223)] = 8071,
+  [SMALL_STATE(224)] = 8091,
+  [SMALL_STATE(225)] = 8119,
+  [SMALL_STATE(226)] = 8143,
+  [SMALL_STATE(227)] = 8171,
+  [SMALL_STATE(228)] = 8199,
+  [SMALL_STATE(229)] = 8227,
+  [SMALL_STATE(230)] = 8247,
+  [SMALL_STATE(231)] = 8275,
+  [SMALL_STATE(232)] = 8295,
+  [SMALL_STATE(233)] = 8317,
+  [SMALL_STATE(234)] = 8341,
+  [SMALL_STATE(235)] = 8371,
+  [SMALL_STATE(236)] = 8398,
+  [SMALL_STATE(237)] = 8431,
+  [SMALL_STATE(238)] = 8451,
+  [SMALL_STATE(239)] = 8481,
+  [SMALL_STATE(240)] = 8511,
+  [SMALL_STATE(241)] = 8541,
+  [SMALL_STATE(242)] = 8571,
+  [SMALL_STATE(243)] = 8601,
+  [SMALL_STATE(244)] = 8631,
+  [SMALL_STATE(245)] = 8661,
+  [SMALL_STATE(246)] = 8691,
+  [SMALL_STATE(247)] = 8721,
+  [SMALL_STATE(248)] = 8751,
+  [SMALL_STATE(249)] = 8781,
+  [SMALL_STATE(250)] = 8811,
+  [SMALL_STATE(251)] = 8841,
+  [SMALL_STATE(252)] = 8861,
+  [SMALL_STATE(253)] = 8881,
+  [SMALL_STATE(254)] = 8911,
+  [SMALL_STATE(255)] = 8941,
+  [SMALL_STATE(256)] = 8961,
+  [SMALL_STATE(257)] = 8991,
+  [SMALL_STATE(258)] = 9021,
+  [SMALL_STATE(259)] = 9051,
+  [SMALL_STATE(260)] = 9081,
+  [SMALL_STATE(261)] = 9101,
+  [SMALL_STATE(262)] = 9121,
+  [SMALL_STATE(263)] = 9151,
+  [SMALL_STATE(264)] = 9171,
+  [SMALL_STATE(265)] = 9201,
+  [SMALL_STATE(266)] = 9231,
+  [SMALL_STATE(267)] = 9251,
+  [SMALL_STATE(268)] = 9281,
+  [SMALL_STATE(269)] = 9311,
+  [SMALL_STATE(270)] = 9341,
+  [SMALL_STATE(271)] = 9371,
+  [SMALL_STATE(272)] = 9401,
+  [SMALL_STATE(273)] = 9431,
+  [SMALL_STATE(274)] = 9461,
+  [SMALL_STATE(275)] = 9491,
+  [SMALL_STATE(276)] = 9521,
+  [SMALL_STATE(277)] = 9551,
+  [SMALL_STATE(278)] = 9571,
+  [SMALL_STATE(279)] = 9601,
+  [SMALL_STATE(280)] = 9631,
+  [SMALL_STATE(281)] = 9652,
+  [SMALL_STATE(282)] = 9687,
+  [SMALL_STATE(283)] = 9708,
+  [SMALL_STATE(284)] = 9743,
+  [SMALL_STATE(285)] = 9772,
+  [SMALL_STATE(286)] = 9801,
+  [SMALL_STATE(287)] = 9824,
+  [SMALL_STATE(288)] = 9837,
+  [SMALL_STATE(289)] = 9860,
+  [SMALL_STATE(290)] = 9873,
+  [SMALL_STATE(291)] = 9896,
+  [SMALL_STATE(292)] = 9909,
+  [SMALL_STATE(293)] = 9922,
+  [SMALL_STATE(294)] = 9945,
+  [SMALL_STATE(295)] = 9962,
+  [SMALL_STATE(296)] = 9979,
+  [SMALL_STATE(297)] = 9996,
+  [SMALL_STATE(298)] = 10013,
+  [SMALL_STATE(299)] = 10028,
+  [SMALL_STATE(300)] = 10043,
+  [SMALL_STATE(301)] = 10058,
+  [SMALL_STATE(302)] = 10075,
+  [SMALL_STATE(303)] = 10090,
+  [SMALL_STATE(304)] = 10107,
+  [SMALL_STATE(305)] = 10124,
+  [SMALL_STATE(306)] = 10135,
+  [SMALL_STATE(307)] = 10150,
+  [SMALL_STATE(308)] = 10167,
+  [SMALL_STATE(309)] = 10184,
+  [SMALL_STATE(310)] = 10201,
+  [SMALL_STATE(311)] = 10218,
+  [SMALL_STATE(312)] = 10232,
+  [SMALL_STATE(313)] = 10242,
+  [SMALL_STATE(314)] = 10256,
+  [SMALL_STATE(315)] = 10270,
+  [SMALL_STATE(316)] = 10280,
+  [SMALL_STATE(317)] = 10294,
+  [SMALL_STATE(318)] = 10308,
+  [SMALL_STATE(319)] = 10322,
+  [SMALL_STATE(320)] = 10336,
+  [SMALL_STATE(321)] = 10350,
+  [SMALL_STATE(322)] = 10364,
+  [SMALL_STATE(323)] = 10378,
+  [SMALL_STATE(324)] = 10392,
+  [SMALL_STATE(325)] = 10402,
+  [SMALL_STATE(326)] = 10416,
+  [SMALL_STATE(327)] = 10430,
+  [SMALL_STATE(328)] = 10444,
+  [SMALL_STATE(329)] = 10456,
+  [SMALL_STATE(330)] = 10470,
+  [SMALL_STATE(331)] = 10484,
+  [SMALL_STATE(332)] = 10495,
+  [SMALL_STATE(333)] = 10504,
+  [SMALL_STATE(334)] = 10515,
+  [SMALL_STATE(335)] = 10526,
+  [SMALL_STATE(336)] = 10537,
+  [SMALL_STATE(337)] = 10548,
+  [SMALL_STATE(338)] = 10559,
+  [SMALL_STATE(339)] = 10570,
+  [SMALL_STATE(340)] = 10581,
+  [SMALL_STATE(341)] = 10590,
+  [SMALL_STATE(342)] = 10601,
+  [SMALL_STATE(343)] = 10610,
+  [SMALL_STATE(344)] = 10621,
+  [SMALL_STATE(345)] = 10632,
+  [SMALL_STATE(346)] = 10643,
+  [SMALL_STATE(347)] = 10654,
+  [SMALL_STATE(348)] = 10665,
+  [SMALL_STATE(349)] = 10674,
+  [SMALL_STATE(350)] = 10685,
+  [SMALL_STATE(351)] = 10694,
+  [SMALL_STATE(352)] = 10705,
+  [SMALL_STATE(353)] = 10716,
+  [SMALL_STATE(354)] = 10727,
+  [SMALL_STATE(355)] = 10738,
+  [SMALL_STATE(356)] = 10749,
+  [SMALL_STATE(357)] = 10758,
+  [SMALL_STATE(358)] = 10769,
+  [SMALL_STATE(359)] = 10778,
+  [SMALL_STATE(360)] = 10786,
+  [SMALL_STATE(361)] = 10794,
+  [SMALL_STATE(362)] = 10802,
+  [SMALL_STATE(363)] = 10810,
+  [SMALL_STATE(364)] = 10818,
+  [SMALL_STATE(365)] = 10826,
+  [SMALL_STATE(366)] = 10834,
+  [SMALL_STATE(367)] = 10842,
+  [SMALL_STATE(368)] = 10850,
+  [SMALL_STATE(369)] = 10858,
+  [SMALL_STATE(370)] = 10866,
+  [SMALL_STATE(371)] = 10874,
+  [SMALL_STATE(372)] = 10882,
+  [SMALL_STATE(373)] = 10890,
+  [SMALL_STATE(374)] = 10898,
+  [SMALL_STATE(375)] = 10906,
+  [SMALL_STATE(376)] = 10914,
+  [SMALL_STATE(377)] = 10922,
+  [SMALL_STATE(378)] = 10930,
+  [SMALL_STATE(379)] = 10938,
+  [SMALL_STATE(380)] = 10946,
+  [SMALL_STATE(381)] = 10954,
+  [SMALL_STATE(382)] = 10962,
+  [SMALL_STATE(383)] = 10970,
+  [SMALL_STATE(384)] = 10978,
+  [SMALL_STATE(385)] = 10986,
+  [SMALL_STATE(386)] = 10994,
+  [SMALL_STATE(387)] = 11002,
+  [SMALL_STATE(388)] = 11010,
+  [SMALL_STATE(389)] = 11018,
+  [SMALL_STATE(390)] = 11026,
+  [SMALL_STATE(391)] = 11034,
+  [SMALL_STATE(392)] = 11042,
+  [SMALL_STATE(393)] = 11050,
+  [SMALL_STATE(394)] = 11058,
+  [SMALL_STATE(395)] = 11066,
+  [SMALL_STATE(396)] = 11074,
+  [SMALL_STATE(397)] = 11082,
+  [SMALL_STATE(398)] = 11090,
+  [SMALL_STATE(399)] = 11098,
+  [SMALL_STATE(400)] = 11106,
+  [SMALL_STATE(401)] = 11114,
+  [SMALL_STATE(402)] = 11122,
+  [SMALL_STATE(403)] = 11130,
+  [SMALL_STATE(404)] = 11138,
+  [SMALL_STATE(405)] = 11146,
+  [SMALL_STATE(406)] = 11154,
+  [SMALL_STATE(407)] = 11162,
+  [SMALL_STATE(408)] = 11170,
+  [SMALL_STATE(409)] = 11178,
+  [SMALL_STATE(410)] = 11186,
+  [SMALL_STATE(411)] = 11194,
+  [SMALL_STATE(412)] = 11202,
+  [SMALL_STATE(413)] = 11210,
+  [SMALL_STATE(414)] = 11218,
+  [SMALL_STATE(415)] = 11226,
+  [SMALL_STATE(416)] = 11234,
+  [SMALL_STATE(417)] = 11242,
+  [SMALL_STATE(418)] = 11250,
+  [SMALL_STATE(419)] = 11258,
+  [SMALL_STATE(420)] = 11266,
+  [SMALL_STATE(421)] = 11274,
+  [SMALL_STATE(422)] = 11282,
+  [SMALL_STATE(423)] = 11290,
+  [SMALL_STATE(424)] = 11298,
+  [SMALL_STATE(425)] = 11306,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(357),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(267),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(320),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(338),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(345),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(393),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2),
-  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(320),
-  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(326),
-  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(330),
-  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(333),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(334),
-  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(338),
-  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(345),
-  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(393),
-  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(189),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 2, .production_id = 1),
-  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
-  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [86] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 2, .production_id = 1),
-  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
-  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
-  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
-  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 2),
-  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
-  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 2),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6),
-  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6), SHIFT_REPEAT(5),
-  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 3, .production_id = 5),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 2, .production_id = 3),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 5),
-  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 1),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 3),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 1),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 6),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 2),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 2),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 2),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
-  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(330),
-  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(333),
-  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(334),
-  [192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(338),
-  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(308),
-  [198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(189),
-  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
-  [207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(304),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 1),
-  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
-  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 1),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
-  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 1),
-  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
-  [231] = {.entry = {.count = 1, .reusable = false}}, SHIFT(255),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 1),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 2),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 2),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 2),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
-  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 3, .production_id = 2),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 4),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expr, 1),
-  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 4),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 2),
-  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 1),
-  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 1),
-  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 3, .production_id = 1),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 1),
-  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
-  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(389),
-  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(310),
-  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
-  [287] = {.entry = {.count = 1, .reusable = false}}, SHIFT(327),
-  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 6, .production_id = 2),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
-  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 1),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 1),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
-  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
-  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
-  [307] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 2),
-  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
-  [311] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
-  [313] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 2),
-  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 2),
-  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
-  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(317),
-  [325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_repeat1, 2),
-  [327] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(389),
-  [330] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(310),
-  [333] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(189),
-  [336] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(327),
-  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 2),
-  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 2),
-  [345] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 1),
-  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 8, .production_id = 2),
-  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 2),
-  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 2),
-  [355] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 2),
-  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
-  [359] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
-  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
-  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 2),
-  [365] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 1),
-  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
-  [369] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 2),
-  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
-  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 1),
-  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 8, .production_id = 1),
-  [377] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 1),
-  [379] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
-  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 2),
-  [383] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
-  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 9, .production_id = 2),
-  [387] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
-  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 1),
-  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 9, .production_id = 2),
-  [393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 1),
-  [395] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
-  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 1),
-  [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
-  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 1),
-  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 11, .production_id = 2),
-  [405] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
-  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 2),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 3, .production_id = 1),
-  [411] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
-  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_constraint_repeat1, 2),
-  [415] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(389),
-  [418] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(328),
-  [421] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(189),
-  [424] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(327),
-  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
-  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 1),
-  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 6, .production_id = 4),
-  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 7, .production_id = 1),
-  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 14, .production_id = 1),
-  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 7, .production_id = 1),
-  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 2),
-  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 12, .production_id = 1),
-  [443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 11, .production_id = 1),
-  [445] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 10, .production_id = 1),
-  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 9, .production_id = 1),
-  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 13, .production_id = 1),
-  [451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 15, .production_id = 1),
-  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5, .production_id = 2),
-  [455] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3, .production_id = 1),
-  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 5, .production_id = 1),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 2),
-  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 8, .production_id = 1),
-  [463] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 1),
-  [465] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
-  [467] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [469] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [471] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [473] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
-  [475] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
-  [477] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2),
-  [479] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(334),
-  [482] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(189),
-  [485] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
-  [487] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2),
-  [491] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2), SHIFT_REPEAT(189),
-  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
-  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
-  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
-  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
-  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 5),
-  [504] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
-  [506] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
-  [508] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
-  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 4),
-  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 6),
-  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
-  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 1),
-  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
-  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(335),
-  [530] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 3),
-  [532] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 7),
-  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uselang, 2, .production_id = 8),
-  [536] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_uselang, 2, .production_id = 8),
-  [538] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 6, .production_id = 2),
-  [540] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 2),
-  [542] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 1),
-  [544] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_computed, 4, .production_id = 7),
-  [546] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_computed, 4, .production_id = 7),
-  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 2),
-  [550] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 1),
-  [552] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 3, .production_id = 1),
-  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 5),
-  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 5),
-  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
-  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
-  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
-  [568] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [570] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
-  [574] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [576] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 6),
-  [584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 4),
-  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 3),
-  [596] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 5),
-  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_on, 4),
-  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
-  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
-  [616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
-  [620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [622] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [624] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [626] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
-  [628] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
-  [630] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [632] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
-  [634] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(357),
-  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [641] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2), SHIFT_REPEAT(379),
-  [644] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2),
-  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(332),
-  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [650] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2),
-  [652] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2), SHIFT_REPEAT(353),
-  [655] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [657] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [659] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [661] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [663] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
-  [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [667] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [669] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
-  [673] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except, 4),
-  [675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 2),
-  [677] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [679] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(6),
-  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
-  [684] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(332),
-  [687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
-  [689] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 1),
-  [693] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
-  [695] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
-  [697] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
-  [699] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
-  [701] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [703] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [705] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [707] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
-  [709] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
-  [711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
-  [713] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
-  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 4),
-  [717] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [719] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
-  [721] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [723] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [725] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [727] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [729] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [731] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [733] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
-  [735] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [737] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [739] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [741] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
-  [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
-  [745] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [747] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
-  [749] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [751] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [753] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [755] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [757] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
-  [759] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [761] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
-  [763] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
-  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [767] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
-  [771] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [773] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [775] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [777] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [779] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [781] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
-  [783] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
-  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
-  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [791] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [793] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [795] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
-  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
-  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [817] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [823] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [827] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [829] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
-  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
-  [837] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
-  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
-  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
-  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
-  [853] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
-  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [859] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
-  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [875] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
-  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 1),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
+  [15] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 1),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 5, .production_id = 7),
+  [19] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 5, .production_id = 7),
+  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 3, .production_id = 7),
+  [23] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 3, .production_id = 7),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(242),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(272),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(273),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
+  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
+  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3),
+  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 3),
+  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 4, .production_id = 7),
+  [59] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 4, .production_id = 7),
+  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 2),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 2),
+  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 1),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 1),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 1),
+  [85] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 2),
+  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 1),
+  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 2),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 1),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 2),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 2),
+  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [119] = {.entry = {.count = 1, .reusable = false}}, SHIFT(412),
+  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(413),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(414),
+  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(364),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(423),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(380),
+  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(361),
+  [141] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(360),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(386),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(417),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(362),
+  [153] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(220),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(423),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(417),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 2, .production_id = 1),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 2),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
+  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
+  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 2, .production_id = 1),
+  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [220] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 2),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 3, .production_id = 5),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6),
+  [234] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6), SHIFT_REPEAT(34),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 2, .production_id = 3),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 1),
+  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
+  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 6),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 5),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 3),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 2),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
+  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(380),
+  [270] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(361),
+  [273] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(360),
+  [276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(386),
+  [279] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(337),
+  [282] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(220),
+  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
+  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
+  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
+  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
+  [303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
+  [307] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
+  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
+  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
+  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
+  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2),
+  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 3, .production_id = 2),
+  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 4),
+  [321] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fncall_repeat1, 2),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 2),
+  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(416),
+  [335] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 1),
+  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
+  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
+  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
+  [351] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
+  [353] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [357] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_repeat1, 2),
+  [359] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(421),
+  [362] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(331),
+  [365] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(220),
+  [368] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(424),
+  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
+  [373] = {.entry = {.count = 1, .reusable = false}}, SHIFT(421),
+  [375] = {.entry = {.count = 1, .reusable = false}}, SHIFT(331),
+  [377] = {.entry = {.count = 1, .reusable = false}}, SHIFT(220),
+  [379] = {.entry = {.count = 1, .reusable = false}}, SHIFT(424),
+  [381] = {.entry = {.count = 1, .reusable = true}}, SHIFT(404),
+  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 4),
+  [387] = {.entry = {.count = 1, .reusable = true}}, SHIFT(407),
+  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 1),
+  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(399),
+  [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(396),
+  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [403] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
+  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
+  [407] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
+  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 2),
+  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 2),
+  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [421] = {.entry = {.count = 1, .reusable = true}}, SHIFT(401),
+  [423] = {.entry = {.count = 1, .reusable = false}}, SHIFT(425),
+  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(410),
+  [427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 2),
+  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 1),
+  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 2),
+  [433] = {.entry = {.count = 1, .reusable = true}}, SHIFT(408),
+  [435] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
+  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 2),
+  [439] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
+  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 1),
+  [443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 9, .production_id = 2),
+  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(377),
+  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 1),
+  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 1),
+  [451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 1),
+  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 2),
+  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
+  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 2),
+  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 1),
+  [463] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
+  [465] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 3, .production_id = 1),
+  [467] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 1),
+  [469] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 2),
+  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 1),
+  [473] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 2),
+  [475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_constraint_repeat1, 2),
+  [477] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(421),
+  [480] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(425),
+  [483] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(220),
+  [486] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(424),
+  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 1),
+  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 11, .production_id = 2),
+  [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
+  [495] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
+  [497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 2),
+  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(376),
+  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 11, .production_id = 1),
+  [503] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 8, .production_id = 1),
+  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 15, .production_id = 1),
+  [507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3, .production_id = 1),
+  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 10, .production_id = 1),
+  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 2),
+  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 9, .production_id = 1),
+  [515] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 1),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 7, .production_id = 1),
+  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 14, .production_id = 1),
+  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 7, .production_id = 1),
+  [523] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 5, .production_id = 1),
+  [525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 6, .production_id = 4),
+  [527] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 13, .production_id = 1),
+  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5, .production_id = 2),
+  [531] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 12, .production_id = 1),
+  [533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 2),
+  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [537] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [539] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
+  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
+  [543] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2),
+  [549] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(360),
+  [552] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(220),
+  [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
+  [559] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 7),
+  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(402),
+  [563] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
+  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 3),
+  [569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 6),
+  [571] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
+  [575] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 1),
+  [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
+  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
+  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [585] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 5),
+  [587] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [589] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 4),
+  [591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uselang, 2, .production_id = 9),
+  [593] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_uselang, 2, .production_id = 9),
+  [595] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2),
+  [597] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2), SHIFT_REPEAT(220),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(382),
+  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
+  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(385),
+  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
+  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [612] = {.entry = {.count = 1, .reusable = false}}, SHIFT(395),
+  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
+  [616] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [618] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [622] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 5),
+  [626] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 5),
+  [628] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [630] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [632] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [634] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [636] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [638] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [640] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [642] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(422),
+  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
+  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
+  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(400),
+  [656] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [666] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [668] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 6),
+  [670] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [674] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 3),
+  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [680] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 4),
+  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 5),
+  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
+  [690] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
+  [692] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [694] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
+  [696] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2),
+  [698] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(299),
+  [701] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
+  [703] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(363),
+  [706] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
+  [710] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_on, 4),
+  [712] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
+  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [718] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
+  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
+  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except, 4),
+  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [738] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2), SHIFT_REPEAT(248),
+  [741] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 2),
+  [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(419),
+  [745] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
+  [747] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [749] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [751] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(36),
+  [754] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
+  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
+  [758] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [760] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fncall_repeat1, 2), SHIFT_REPEAT(267),
+  [763] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
+  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
+  [767] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 1),
+  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [771] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [773] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(367),
+  [776] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
+  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [780] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2), SHIFT_REPEAT(392),
+  [783] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2),
+  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [791] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
+  [793] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 4),
+  [795] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
+  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(394),
+  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
+  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [817] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
+  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
+  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [823] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(406),
+  [827] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
+  [829] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
+  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [837] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
+  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
+  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
+  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
+  [853] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [859] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
+  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
+  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(388),
+  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
+  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
+  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [875] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(415),
+  [879] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [883] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
+  [887] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [891] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
+  [895] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [897] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
+  [899] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [901] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [903] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [905] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [907] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [909] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
+  [911] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [913] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [915] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
+  [917] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [919] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [921] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
+  [923] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [925] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [927] = {.entry = {.count = 1, .reusable = true}}, SHIFT(411),
+  [929] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [931] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
+  [933] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
+  [935] = {.entry = {.count = 1, .reusable = true}}, SHIFT(405),
+  [937] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [939] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [941] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [943] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [945] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [947] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -14,98 +14,125 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 83
+#define STATE_COUNT 394
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 82
+#define SYMBOL_COUNT 109
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 60
+#define TOKEN_COUNT 67
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 1
-#define MAX_ALIAS_SEQUENCE_LENGTH 7
-#define PRODUCTION_ID_COUNT 2
+#define FIELD_COUNT 3
+#define MAX_ALIAS_SEQUENCE_LENGTH 15
+#define PRODUCTION_ID_COUNT 9
 
 enum {
   anon_sym_module = 1,
   anon_sym_LBRACE = 2,
   anon_sym_RBRACE = 3,
   anon_sym_type = 4,
-  anon_sym_extending = 5,
-  anon_sym_COMMA = 6,
-  anon_sym_required = 7,
-  anon_sym_optional = 8,
-  anon_sym_single = 9,
-  anon_sym_multi = 10,
-  anon_sym_abstract = 11,
-  anon_sym_delegated = 12,
-  anon_sym_inheritable = 13,
-  anon_sym_COLON = 14,
-  anon_sym___subject__ = 15,
-  anon_sym_annotation = 16,
-  anon_sym_COLON_EQ = 17,
-  anon_sym_SEMI = 18,
-  anon_sym_property = 19,
-  anon_sym_DASH_GT = 20,
-  anon_sym_link = 21,
-  anon_sym_contraint = 22,
+  anon_sym_scalar = 5,
+  anon_sym_link = 6,
+  anon_sym_DASH_GT = 7,
+  anon_sym_COLON_EQ = 8,
+  anon_sym_SEMI = 9,
+  anon_sym_property = 10,
+  anon_sym_annotation = 11,
+  anon_sym_constraint = 12,
+  anon_sym_index = 13,
+  anon_sym_alias = 14,
+  anon_sym_using = 15,
+  anon_sym_function = 16,
+  anon_sym_LPAREN = 17,
+  anon_sym_RPAREN = 18,
+  anon_sym_edgedb = 19,
+  anon_sym_extension = 20,
+  anon_sym_extending = 21,
+  anon_sym_COMMA = 22,
   anon_sym_on = 23,
-  anon_sym_using = 24,
-  anon_sym_errmessage = 25,
-  sym_str = 26,
-  anon_sym_str = 27,
-  anon_sym_bool = 28,
-  anon_sym_int16 = 29,
-  anon_sym_int32 = 30,
-  anon_sym_int64 = 31,
-  anon_sym_float32 = 32,
-  anon_sym_float64 = 33,
-  anon_sym_bigint = 34,
-  anon_sym_decimal = 35,
-  anon_sym_json = 36,
-  anon_sym_uuid = 37,
-  anon_sym_bytes = 38,
-  anon_sym_datetime = 39,
-  anon_sym_duration = 40,
-  anon_sym_cal_COLON_COLONlocal_datetime = 41,
-  anon_sym_cal_COLON_COLONlocal_date = 42,
-  anon_sym_cal_COLON_COLONlocal_time = 43,
-  anon_sym_cal_COLON_COLONrelative_duration = 44,
-  anon_sym_sequence = 45,
-  anon_sym_anytype = 46,
-  anon_sym_array = 47,
-  anon_sym_LT = 48,
-  anon_sym_GT = 49,
-  anon_sym_tuple = 50,
-  anon_sym_scalartype = 51,
-  anon_sym_TODO = 52,
-  anon_sym_enum = 53,
-  sym_identifier = 54,
-  sym_true = 55,
-  sym_false = 56,
-  sym_null = 57,
-  sym_comment = 58,
-  sym__whitespace = 59,
-  sym_source_file = 60,
-  sym_module = 61,
-  sym_schema_declarations = 62,
-  sym_object_type = 63,
-  sym_extends = 64,
-  sym_declarations = 65,
-  sym_modifier = 66,
-  sym_property = 67,
-  sym_link = 68,
-  sym__scalar_type = 69,
-  sym_array = 70,
-  sym_tuple = 71,
-  sym__tuple = 72,
-  sym__named_tuple = 73,
-  sym_type = 74,
-  aux_sym_source_file_repeat1 = 75,
-  aux_sym_schema_declarations_repeat1 = 76,
-  aux_sym_object_type_repeat1 = 77,
-  aux_sym_extends_repeat1 = 78,
-  aux_sym_declarations_repeat1 = 79,
-  aux_sym__tuple_repeat1 = 80,
-  aux_sym__named_tuple_repeat1 = 81,
+  anon_sym_except = 24,
+  anon_sym_abstract = 25,
+  anon_sym_overloaded = 26,
+  anon_sym_required = 27,
+  anon_sym_optional = 28,
+  anon_sym_single = 29,
+  anon_sym_multi = 30,
+  anon_sym_inheritable = 31,
+  anon_sym_COLON = 32,
+  anon_sym_setof = 33,
+  sym_str = 34,
+  anon_sym_str = 35,
+  anon_sym_bool = 36,
+  anon_sym_int16 = 37,
+  anon_sym_int32 = 38,
+  anon_sym_int64 = 39,
+  anon_sym_float32 = 40,
+  anon_sym_float64 = 41,
+  anon_sym_bigint = 42,
+  anon_sym_decimal = 43,
+  anon_sym_json = 44,
+  anon_sym_uuid = 45,
+  anon_sym_bytes = 46,
+  anon_sym_datetime = 47,
+  anon_sym_duration = 48,
+  anon_sym_cal_COLON_COLONlocal_datetime = 49,
+  anon_sym_cal_COLON_COLONlocal_date = 50,
+  anon_sym_cal_COLON_COLONlocal_time = 51,
+  anon_sym_cal_COLON_COLONrelative_duration = 52,
+  anon_sym_sequence = 53,
+  anon_sym_anytype = 54,
+  anon_sym_array = 55,
+  anon_sym_LT = 56,
+  anon_sym_GT = 57,
+  anon_sym_tuple = 58,
+  anon_sym_scalartype = 59,
+  anon_sym_enum = 60,
+  sym_identifier = 61,
+  sym_true = 62,
+  sym_false = 63,
+  sym_null = 64,
+  sym_comment = 65,
+  sym__whitespace = 66,
+  sym_source_file = 67,
+  sym_module = 68,
+  sym_schema_declarations = 69,
+  sym_object_type = 70,
+  sym_declarations = 71,
+  sym_scalar_type_def = 72,
+  sym_link = 73,
+  sym_property = 74,
+  sym_annotation = 75,
+  sym_constraint = 76,
+  sym_index = 77,
+  sym_alias = 78,
+  sym_function = 79,
+  sym_extending = 80,
+  sym_using = 81,
+  sym_uselang = 82,
+  sym_on = 83,
+  sym_except = 84,
+  sym_computed = 85,
+  sym_modifier = 86,
+  sym_argspec = 87,
+  sym_returnspec = 88,
+  sym_expr = 89,
+  sym__scalar_type = 90,
+  sym_array = 91,
+  sym_tuple = 92,
+  sym__tuple = 93,
+  sym__named_tuple = 94,
+  sym_enum = 95,
+  sym_type = 96,
+  aux_sym_source_file_repeat1 = 97,
+  aux_sym_schema_declarations_repeat1 = 98,
+  aux_sym_declarations_repeat1 = 99,
+  aux_sym_scalar_type_def_repeat1 = 100,
+  aux_sym_annotation_repeat1 = 101,
+  aux_sym_constraint_repeat1 = 102,
+  aux_sym_function_repeat1 = 103,
+  aux_sym_extending_repeat1 = 104,
+  aux_sym_argspec_repeat1 = 105,
+  aux_sym__tuple_repeat1 = 106,
+  aux_sym__named_tuple_repeat1 = 107,
+  aux_sym_enum_repeat1 = 108,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -114,27 +141,35 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
   [anon_sym_type] = "type",
+  [anon_sym_scalar] = "scalar",
+  [anon_sym_link] = "link",
+  [anon_sym_DASH_GT] = "->",
+  [anon_sym_COLON_EQ] = ":=",
+  [anon_sym_SEMI] = ";",
+  [anon_sym_property] = "property",
+  [anon_sym_annotation] = "annotation",
+  [anon_sym_constraint] = "constraint",
+  [anon_sym_index] = "index",
+  [anon_sym_alias] = "alias",
+  [anon_sym_using] = "using",
+  [anon_sym_function] = "function",
+  [anon_sym_LPAREN] = "(",
+  [anon_sym_RPAREN] = ")",
+  [anon_sym_edgedb] = "edgedb",
+  [anon_sym_extension] = "extension",
   [anon_sym_extending] = "extending",
   [anon_sym_COMMA] = ",",
+  [anon_sym_on] = "on",
+  [anon_sym_except] = "except",
+  [anon_sym_abstract] = "abstract",
+  [anon_sym_overloaded] = "overloaded",
   [anon_sym_required] = "required",
   [anon_sym_optional] = "optional",
   [anon_sym_single] = "single",
   [anon_sym_multi] = "multi",
-  [anon_sym_abstract] = "abstract",
-  [anon_sym_delegated] = "delegated",
   [anon_sym_inheritable] = "inheritable",
   [anon_sym_COLON] = ":",
-  [anon_sym___subject__] = "__subject__",
-  [anon_sym_annotation] = "annotation",
-  [anon_sym_COLON_EQ] = ":=",
-  [anon_sym_SEMI] = ";",
-  [anon_sym_property] = "property",
-  [anon_sym_DASH_GT] = "->",
-  [anon_sym_link] = "link",
-  [anon_sym_contraint] = "contraint",
-  [anon_sym_on] = "on",
-  [anon_sym_using] = "using",
-  [anon_sym_errmessage] = "errmessage",
+  [anon_sym_setof] = "set of",
   [sym_str] = "str",
   [anon_sym_str] = "str",
   [anon_sym_bool] = "bool",
@@ -161,7 +196,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_GT] = ">",
   [anon_sym_tuple] = "tuple",
   [anon_sym_scalartype] = "scalar type",
-  [anon_sym_TODO] = "TODO",
   [anon_sym_enum] = "enum",
   [sym_identifier] = "identifier",
   [sym_true] = "true",
@@ -173,24 +207,44 @@ static const char * const ts_symbol_names[] = {
   [sym_module] = "module",
   [sym_schema_declarations] = "schema_declarations",
   [sym_object_type] = "object_type",
-  [sym_extends] = "extends",
   [sym_declarations] = "declarations",
-  [sym_modifier] = "modifier",
-  [sym_property] = "property",
+  [sym_scalar_type_def] = "scalar_type_def",
   [sym_link] = "link",
+  [sym_property] = "property",
+  [sym_annotation] = "annotation",
+  [sym_constraint] = "constraint",
+  [sym_index] = "index",
+  [sym_alias] = "alias",
+  [sym_function] = "function",
+  [sym_extending] = "extending",
+  [sym_using] = "using",
+  [sym_uselang] = "uselang",
+  [sym_on] = "on",
+  [sym_except] = "except",
+  [sym_computed] = "computed",
+  [sym_modifier] = "modifier",
+  [sym_argspec] = "argspec",
+  [sym_returnspec] = "returnspec",
+  [sym_expr] = "expr",
   [sym__scalar_type] = "_scalar_type",
   [sym_array] = "array",
   [sym_tuple] = "tuple",
   [sym__tuple] = "_tuple",
   [sym__named_tuple] = "_named_tuple",
+  [sym_enum] = "enum",
   [sym_type] = "type",
   [aux_sym_source_file_repeat1] = "source_file_repeat1",
   [aux_sym_schema_declarations_repeat1] = "schema_declarations_repeat1",
-  [aux_sym_object_type_repeat1] = "object_type_repeat1",
-  [aux_sym_extends_repeat1] = "extends_repeat1",
   [aux_sym_declarations_repeat1] = "declarations_repeat1",
+  [aux_sym_scalar_type_def_repeat1] = "scalar_type_def_repeat1",
+  [aux_sym_annotation_repeat1] = "annotation_repeat1",
+  [aux_sym_constraint_repeat1] = "constraint_repeat1",
+  [aux_sym_function_repeat1] = "function_repeat1",
+  [aux_sym_extending_repeat1] = "extending_repeat1",
+  [aux_sym_argspec_repeat1] = "argspec_repeat1",
   [aux_sym__tuple_repeat1] = "_tuple_repeat1",
   [aux_sym__named_tuple_repeat1] = "_named_tuple_repeat1",
+  [aux_sym_enum_repeat1] = "enum_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -199,27 +253,35 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_type] = anon_sym_type,
+  [anon_sym_scalar] = anon_sym_scalar,
+  [anon_sym_link] = anon_sym_link,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
+  [anon_sym_COLON_EQ] = anon_sym_COLON_EQ,
+  [anon_sym_SEMI] = anon_sym_SEMI,
+  [anon_sym_property] = anon_sym_property,
+  [anon_sym_annotation] = anon_sym_annotation,
+  [anon_sym_constraint] = anon_sym_constraint,
+  [anon_sym_index] = anon_sym_index,
+  [anon_sym_alias] = anon_sym_alias,
+  [anon_sym_using] = anon_sym_using,
+  [anon_sym_function] = anon_sym_function,
+  [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [anon_sym_edgedb] = anon_sym_edgedb,
+  [anon_sym_extension] = anon_sym_extension,
   [anon_sym_extending] = anon_sym_extending,
   [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_on] = anon_sym_on,
+  [anon_sym_except] = anon_sym_except,
+  [anon_sym_abstract] = anon_sym_abstract,
+  [anon_sym_overloaded] = anon_sym_overloaded,
   [anon_sym_required] = anon_sym_required,
   [anon_sym_optional] = anon_sym_optional,
   [anon_sym_single] = anon_sym_single,
   [anon_sym_multi] = anon_sym_multi,
-  [anon_sym_abstract] = anon_sym_abstract,
-  [anon_sym_delegated] = anon_sym_delegated,
   [anon_sym_inheritable] = anon_sym_inheritable,
   [anon_sym_COLON] = anon_sym_COLON,
-  [anon_sym___subject__] = anon_sym___subject__,
-  [anon_sym_annotation] = anon_sym_annotation,
-  [anon_sym_COLON_EQ] = anon_sym_COLON_EQ,
-  [anon_sym_SEMI] = anon_sym_SEMI,
-  [anon_sym_property] = anon_sym_property,
-  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
-  [anon_sym_link] = anon_sym_link,
-  [anon_sym_contraint] = anon_sym_contraint,
-  [anon_sym_on] = anon_sym_on,
-  [anon_sym_using] = anon_sym_using,
-  [anon_sym_errmessage] = anon_sym_errmessage,
+  [anon_sym_setof] = anon_sym_setof,
   [sym_str] = sym_str,
   [anon_sym_str] = anon_sym_str,
   [anon_sym_bool] = anon_sym_bool,
@@ -246,7 +308,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_GT] = anon_sym_GT,
   [anon_sym_tuple] = anon_sym_tuple,
   [anon_sym_scalartype] = anon_sym_scalartype,
-  [anon_sym_TODO] = anon_sym_TODO,
   [anon_sym_enum] = anon_sym_enum,
   [sym_identifier] = sym_identifier,
   [sym_true] = sym_true,
@@ -258,24 +319,44 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_module] = sym_module,
   [sym_schema_declarations] = sym_schema_declarations,
   [sym_object_type] = sym_object_type,
-  [sym_extends] = sym_extends,
   [sym_declarations] = sym_declarations,
-  [sym_modifier] = sym_modifier,
-  [sym_property] = sym_property,
+  [sym_scalar_type_def] = sym_scalar_type_def,
   [sym_link] = sym_link,
+  [sym_property] = sym_property,
+  [sym_annotation] = sym_annotation,
+  [sym_constraint] = sym_constraint,
+  [sym_index] = sym_index,
+  [sym_alias] = sym_alias,
+  [sym_function] = sym_function,
+  [sym_extending] = sym_extending,
+  [sym_using] = sym_using,
+  [sym_uselang] = sym_uselang,
+  [sym_on] = sym_on,
+  [sym_except] = sym_except,
+  [sym_computed] = sym_computed,
+  [sym_modifier] = sym_modifier,
+  [sym_argspec] = sym_argspec,
+  [sym_returnspec] = sym_returnspec,
+  [sym_expr] = sym_expr,
   [sym__scalar_type] = sym__scalar_type,
   [sym_array] = sym_array,
   [sym_tuple] = sym_tuple,
   [sym__tuple] = sym__tuple,
   [sym__named_tuple] = sym__named_tuple,
+  [sym_enum] = sym_enum,
   [sym_type] = sym_type,
   [aux_sym_source_file_repeat1] = aux_sym_source_file_repeat1,
   [aux_sym_schema_declarations_repeat1] = aux_sym_schema_declarations_repeat1,
-  [aux_sym_object_type_repeat1] = aux_sym_object_type_repeat1,
-  [aux_sym_extends_repeat1] = aux_sym_extends_repeat1,
   [aux_sym_declarations_repeat1] = aux_sym_declarations_repeat1,
+  [aux_sym_scalar_type_def_repeat1] = aux_sym_scalar_type_def_repeat1,
+  [aux_sym_annotation_repeat1] = aux_sym_annotation_repeat1,
+  [aux_sym_constraint_repeat1] = aux_sym_constraint_repeat1,
+  [aux_sym_function_repeat1] = aux_sym_function_repeat1,
+  [aux_sym_extending_repeat1] = aux_sym_extending_repeat1,
+  [aux_sym_argspec_repeat1] = aux_sym_argspec_repeat1,
   [aux_sym__tuple_repeat1] = aux_sym__tuple_repeat1,
   [aux_sym__named_tuple_repeat1] = aux_sym__named_tuple_repeat1,
+  [aux_sym_enum_repeat1] = aux_sym_enum_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -299,11 +380,91 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_scalar] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_link] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COLON_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_SEMI] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_property] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_annotation] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_constraint] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_index] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_alias] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_using] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_function] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_edgedb] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_extension] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_extending] = {
     .visible = true,
     .named = false,
   },
   [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_on] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_except] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_abstract] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_overloaded] = {
     .visible = true,
     .named = false,
   },
@@ -323,14 +484,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_abstract] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_delegated] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_inheritable] = {
     .visible = true,
     .named = false,
@@ -339,47 +492,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym___subject__] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_annotation] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_COLON_EQ] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_SEMI] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_property] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_DASH_GT] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_link] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_contraint] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_on] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_using] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_errmessage] = {
+  [anon_sym_setof] = {
     .visible = true,
     .named = false,
   },
@@ -487,10 +600,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_TODO] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_enum] = {
     .visible = true,
     .named = false,
@@ -535,15 +644,15 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_extends] = {
-    .visible = true,
-    .named = true,
-  },
   [sym_declarations] = {
     .visible = true,
     .named = true,
   },
-  [sym_modifier] = {
+  [sym_scalar_type_def] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_link] = {
     .visible = true,
     .named = true,
   },
@@ -551,7 +660,63 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_link] = {
+  [sym_annotation] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_constraint] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_index] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_alias] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_function] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_extending] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_using] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_uselang] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_on] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_except] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_computed] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_modifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_argspec] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_returnspec] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_expr] = {
     .visible = true,
     .named = true,
   },
@@ -575,6 +740,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
+  [sym_enum] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_type] = {
     .visible = true,
     .named = true,
@@ -587,15 +756,31 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_object_type_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_extends_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
   [aux_sym_declarations_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_scalar_type_def_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_annotation_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_constraint_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_function_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_extending_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_argspec_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -607,24 +792,55 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_enum_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
 };
 
 enum {
-  field_name = 1,
+  field_language = 1,
+  field_name = 2,
+  field_supertype = 3,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
+  [field_language] = "language",
   [field_name] = "name",
+  [field_supertype] = "supertype",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 1},
+  [2] = {.index = 1, .length = 1},
+  [3] = {.index = 2, .length = 1},
+  [4] = {.index = 3, .length = 1},
+  [5] = {.index = 4, .length = 2},
+  [6] = {.index = 6, .length = 2},
+  [7] = {.index = 8, .length = 1},
+  [8] = {.index = 9, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
     {field_name, 1},
+  [1] =
+    {field_name, 2},
+  [2] =
+    {field_supertype, 1},
+  [3] =
+    {field_name, 3},
+  [4] =
+    {field_supertype, 1},
+    {field_supertype, 2, .inherited = true},
+  [6] =
+    {field_supertype, 0, .inherited = true},
+    {field_supertype, 1, .inherited = true},
+  [8] =
+    {field_name, 0},
+  [9] =
+    {field_language, 1},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -719,6 +935,317 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [80] = 80,
   [81] = 81,
   [82] = 82,
+  [83] = 83,
+  [84] = 84,
+  [85] = 85,
+  [86] = 86,
+  [87] = 87,
+  [88] = 88,
+  [89] = 89,
+  [90] = 90,
+  [91] = 91,
+  [92] = 92,
+  [93] = 93,
+  [94] = 94,
+  [95] = 95,
+  [96] = 96,
+  [97] = 97,
+  [98] = 98,
+  [99] = 99,
+  [100] = 100,
+  [101] = 101,
+  [102] = 102,
+  [103] = 103,
+  [104] = 104,
+  [105] = 105,
+  [106] = 106,
+  [107] = 107,
+  [108] = 108,
+  [109] = 109,
+  [110] = 110,
+  [111] = 111,
+  [112] = 112,
+  [113] = 113,
+  [114] = 114,
+  [115] = 115,
+  [116] = 116,
+  [117] = 117,
+  [118] = 118,
+  [119] = 119,
+  [120] = 120,
+  [121] = 121,
+  [122] = 122,
+  [123] = 123,
+  [124] = 124,
+  [125] = 125,
+  [126] = 126,
+  [127] = 127,
+  [128] = 128,
+  [129] = 129,
+  [130] = 130,
+  [131] = 131,
+  [132] = 132,
+  [133] = 133,
+  [134] = 134,
+  [135] = 135,
+  [136] = 136,
+  [137] = 137,
+  [138] = 138,
+  [139] = 139,
+  [140] = 140,
+  [141] = 141,
+  [142] = 142,
+  [143] = 143,
+  [144] = 144,
+  [145] = 145,
+  [146] = 146,
+  [147] = 147,
+  [148] = 148,
+  [149] = 149,
+  [150] = 150,
+  [151] = 151,
+  [152] = 152,
+  [153] = 153,
+  [154] = 154,
+  [155] = 155,
+  [156] = 156,
+  [157] = 157,
+  [158] = 158,
+  [159] = 159,
+  [160] = 160,
+  [161] = 161,
+  [162] = 162,
+  [163] = 163,
+  [164] = 164,
+  [165] = 165,
+  [166] = 166,
+  [167] = 167,
+  [168] = 168,
+  [169] = 169,
+  [170] = 170,
+  [171] = 171,
+  [172] = 172,
+  [173] = 173,
+  [174] = 174,
+  [175] = 175,
+  [176] = 176,
+  [177] = 177,
+  [178] = 178,
+  [179] = 179,
+  [180] = 180,
+  [181] = 181,
+  [182] = 182,
+  [183] = 182,
+  [184] = 184,
+  [185] = 181,
+  [186] = 186,
+  [187] = 187,
+  [188] = 188,
+  [189] = 189,
+  [190] = 190,
+  [191] = 191,
+  [192] = 192,
+  [193] = 193,
+  [194] = 193,
+  [195] = 195,
+  [196] = 196,
+  [197] = 197,
+  [198] = 196,
+  [199] = 199,
+  [200] = 200,
+  [201] = 201,
+  [202] = 202,
+  [203] = 203,
+  [204] = 204,
+  [205] = 75,
+  [206] = 64,
+  [207] = 69,
+  [208] = 208,
+  [209] = 83,
+  [210] = 98,
+  [211] = 68,
+  [212] = 212,
+  [213] = 213,
+  [214] = 214,
+  [215] = 215,
+  [216] = 216,
+  [217] = 214,
+  [218] = 218,
+  [219] = 219,
+  [220] = 220,
+  [221] = 221,
+  [222] = 222,
+  [223] = 223,
+  [224] = 224,
+  [225] = 225,
+  [226] = 226,
+  [227] = 227,
+  [228] = 228,
+  [229] = 229,
+  [230] = 230,
+  [231] = 231,
+  [232] = 232,
+  [233] = 233,
+  [234] = 234,
+  [235] = 235,
+  [236] = 236,
+  [237] = 237,
+  [238] = 238,
+  [239] = 239,
+  [240] = 240,
+  [241] = 241,
+  [242] = 242,
+  [243] = 243,
+  [244] = 244,
+  [245] = 245,
+  [246] = 246,
+  [247] = 247,
+  [248] = 248,
+  [249] = 249,
+  [250] = 250,
+  [251] = 251,
+  [252] = 252,
+  [253] = 253,
+  [254] = 254,
+  [255] = 255,
+  [256] = 256,
+  [257] = 257,
+  [258] = 258,
+  [259] = 259,
+  [260] = 260,
+  [261] = 261,
+  [262] = 262,
+  [263] = 263,
+  [264] = 264,
+  [265] = 265,
+  [266] = 266,
+  [267] = 267,
+  [268] = 268,
+  [269] = 269,
+  [270] = 270,
+  [271] = 271,
+  [272] = 272,
+  [273] = 273,
+  [274] = 274,
+  [275] = 272,
+  [276] = 276,
+  [277] = 277,
+  [278] = 278,
+  [279] = 279,
+  [280] = 280,
+  [281] = 273,
+  [282] = 282,
+  [283] = 283,
+  [284] = 284,
+  [285] = 285,
+  [286] = 286,
+  [287] = 287,
+  [288] = 288,
+  [289] = 289,
+  [290] = 290,
+  [291] = 291,
+  [292] = 292,
+  [293] = 293,
+  [294] = 294,
+  [295] = 295,
+  [296] = 296,
+  [297] = 297,
+  [298] = 298,
+  [299] = 299,
+  [300] = 300,
+  [301] = 301,
+  [302] = 302,
+  [303] = 303,
+  [304] = 304,
+  [305] = 305,
+  [306] = 306,
+  [307] = 307,
+  [308] = 308,
+  [309] = 309,
+  [310] = 310,
+  [311] = 311,
+  [312] = 312,
+  [313] = 313,
+  [314] = 314,
+  [315] = 315,
+  [316] = 316,
+  [317] = 317,
+  [318] = 318,
+  [319] = 319,
+  [320] = 320,
+  [321] = 321,
+  [322] = 322,
+  [323] = 323,
+  [324] = 324,
+  [325] = 325,
+  [326] = 326,
+  [327] = 327,
+  [328] = 328,
+  [329] = 329,
+  [330] = 330,
+  [331] = 331,
+  [332] = 332,
+  [333] = 333,
+  [334] = 334,
+  [335] = 335,
+  [336] = 336,
+  [337] = 337,
+  [338] = 338,
+  [339] = 339,
+  [340] = 340,
+  [341] = 341,
+  [342] = 342,
+  [343] = 343,
+  [344] = 344,
+  [345] = 345,
+  [346] = 346,
+  [347] = 347,
+  [348] = 348,
+  [349] = 349,
+  [350] = 350,
+  [351] = 351,
+  [352] = 352,
+  [353] = 353,
+  [354] = 354,
+  [355] = 355,
+  [356] = 356,
+  [357] = 357,
+  [358] = 358,
+  [359] = 359,
+  [360] = 360,
+  [361] = 361,
+  [362] = 362,
+  [363] = 363,
+  [364] = 364,
+  [365] = 365,
+  [366] = 366,
+  [367] = 367,
+  [368] = 368,
+  [369] = 369,
+  [370] = 370,
+  [371] = 371,
+  [372] = 372,
+  [373] = 373,
+  [374] = 374,
+  [375] = 375,
+  [376] = 376,
+  [377] = 377,
+  [378] = 378,
+  [379] = 379,
+  [380] = 380,
+  [381] = 381,
+  [382] = 382,
+  [383] = 383,
+  [384] = 384,
+  [385] = 385,
+  [386] = 336,
+  [387] = 387,
+  [388] = 385,
+  [389] = 334,
+  [390] = 318,
+  [391] = 391,
+  [392] = 392,
+  [393] = 393,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -726,1686 +1253,2509 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(232);
-      if (lookahead == '#') ADVANCE(380);
-      if (lookahead == '\'') ADVANCE(4);
-      if (lookahead == ',') ADVANCE(238);
-      if (lookahead == '-') ADVANCE(14);
-      if (lookahead == ':') ADVANCE(247);
-      if (lookahead == ';') ADVANCE(251);
-      if (lookahead == '<') ADVANCE(298);
-      if (lookahead == '>') ADVANCE(299);
-      if (lookahead == 'T') ADVANCE(16);
-      if (lookahead == '_') ADVANCE(20);
-      if (lookahead == 'a') ADVANCE(44);
-      if (lookahead == 'b') ADVANCE(95);
-      if (lookahead == 'c') ADVANCE(23);
+      if (eof) ADVANCE(258);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == '\'') ADVANCE(8);
+      if (lookahead == '(') ADVANCE(277);
+      if (lookahead == ')') ADVANCE(278);
+      if (lookahead == ',') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(19);
+      if (lookahead == ':') ADVANCE(300);
+      if (lookahead == ';') ADVANCE(267);
+      if (lookahead == '<') ADVANCE(341);
+      if (lookahead == '>') ADVANCE(342);
+      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'b') ADVANCE(103);
+      if (lookahead == 'c') ADVANCE(22);
       if (lookahead == 'd') ADVANCE(35);
-      if (lookahead == 'e') ADVANCE(145);
-      if (lookahead == 'f') ADVANCE(25);
-      if (lookahead == 'i') ADVANCE(138);
-      if (lookahead == 'j') ADVANCE(188);
-      if (lookahead == 'l') ADVANCE(99);
-      if (lookahead == 'm') ADVANCE(156);
-      if (lookahead == 'n') ADVANCE(221);
-      if (lookahead == 'o') ADVANCE(139);
-      if (lookahead == 'p') ADVANCE(180);
-      if (lookahead == 'r') ADVANCE(59);
+      if (lookahead == 'e') ADVANCE(58);
+      if (lookahead == 'f') ADVANCE(23);
+      if (lookahead == 'i') ADVANCE(148);
+      if (lookahead == 'j') ADVANCE(211);
+      if (lookahead == 'l') ADVANCE(110);
+      if (lookahead == 'm') ADVANCE(171);
+      if (lookahead == 'n') ADVANCE(244);
+      if (lookahead == 'o') ADVANCE(149);
+      if (lookahead == 'p') ADVANCE(200);
+      if (lookahead == 'r') ADVANCE(67);
       if (lookahead == 's') ADVANCE(46);
-      if (lookahead == 't') ADVANCE(178);
-      if (lookahead == 'u') ADVANCE(194);
-      if (lookahead == '{') ADVANCE(234);
-      if (lookahead == '}') ADVANCE(235);
+      if (lookahead == 't') ADVANCE(198);
+      if (lookahead == 'u') ADVANCE(215);
+      if (lookahead == '{') ADVANCE(260);
+      if (lookahead == '}') ADVANCE(261);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(381);
+          lookahead == ' ') ADVANCE(493);
       END_STATE();
     case 1:
-      if (lookahead == ' ') ADVANCE(214);
+      if (lookahead == ' ') ADVANCE(172);
       END_STATE();
     case 2:
-      if (lookahead == '#') ADVANCE(380);
-      if (lookahead == ',') ADVANCE(238);
-      if (lookahead == ':') ADVANCE(246);
-      if (lookahead == '>') ADVANCE(299);
-      if (lookahead == 'a') ADVANCE(344);
-      if (lookahead == 'b') ADVANCE(331);
-      if (lookahead == 'c') ADVANCE(313);
-      if (lookahead == 'd') ADVANCE(317);
-      if (lookahead == 'f') ADVANCE(340);
-      if (lookahead == 'i') ADVANCE(347);
-      if (lookahead == 'j') ADVANCE(361);
-      if (lookahead == 's') ADVANCE(322);
-      if (lookahead == 't') ADVANCE(370);
-      if (lookahead == 'u') ADVANCE(371);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == '\'') ADVANCE(8);
+      if (lookahead == '(') ADVANCE(277);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(381);
+          lookahead == ' ') ADVANCE(493);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(380);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == ')') ADVANCE(278);
+      if (lookahead == ',') ADVANCE(282);
+      if (lookahead == ':') ADVANCE(299);
+      if (lookahead == '>') ADVANCE(342);
+      if (lookahead == 'a') ADVANCE(426);
+      if (lookahead == 'b') ADVANCE(400);
+      if (lookahead == 'c') ADVANCE(358);
+      if (lookahead == 'd') ADVANCE(367);
+      if (lookahead == 'f') ADVANCE(417);
+      if (lookahead == 'i') ADVANCE(432);
+      if (lookahead == 'j') ADVANCE(462);
+      if (lookahead == 'o') ADVANCE(447);
+      if (lookahead == 's') ADVANCE(380);
+      if (lookahead == 't') ADVANCE(481);
+      if (lookahead == 'u') ADVANCE(480);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(381);
+          lookahead == ' ') ADVANCE(493);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 4:
-      if (lookahead == '\'') ADVANCE(259);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(4);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == ',') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(19);
+      if (lookahead == ':') ADVANCE(18);
+      if (lookahead == ';') ADVANCE(267);
+      if (lookahead == '>') ADVANCE(342);
+      if (lookahead == 'a') ADVANCE(44);
+      if (lookahead == 'c') ADVANCE(173);
+      if (lookahead == 'e') ADVANCE(252);
+      if (lookahead == 'f') ADVANCE(242);
+      if (lookahead == 'i') ADVANCE(158);
+      if (lookahead == 'l') ADVANCE(110);
+      if (lookahead == 'm') ADVANCE(243);
+      if (lookahead == 'o') ADVANCE(187);
+      if (lookahead == 'p') ADVANCE(200);
+      if (lookahead == 'r') ADVANCE(67);
+      if (lookahead == 's') ADVANCE(47);
+      if (lookahead == 't') ADVANCE(255);
+      if (lookahead == 'u') ADVANCE(214);
+      if (lookahead == '{') ADVANCE(260);
+      if (lookahead == '}') ADVANCE(261);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(493);
       END_STATE();
     case 5:
-      if (lookahead == '1') ADVANCE(11);
-      if (lookahead == '3') ADVANCE(6);
-      if (lookahead == '6') ADVANCE(9);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == ':') ADVANCE(18);
+      if (lookahead == 'a') ADVANCE(426);
+      if (lookahead == 'b') ADVANCE(400);
+      if (lookahead == 'c') ADVANCE(358);
+      if (lookahead == 'd') ADVANCE(367);
+      if (lookahead == 'f') ADVANCE(417);
+      if (lookahead == 'i') ADVANCE(432);
+      if (lookahead == 'j') ADVANCE(462);
+      if (lookahead == 's') ADVANCE(375);
+      if (lookahead == 't') ADVANCE(481);
+      if (lookahead == 'u') ADVANCE(480);
+      if (lookahead == '{') ADVANCE(260);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(493);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 6:
-      if (lookahead == '2') ADVANCE(266);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == ';') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(370);
+      if (lookahead == 'i') ADVANCE(429);
+      if (lookahead == 'm') ADVANCE(483);
+      if (lookahead == 'o') ADVANCE(446);
+      if (lookahead == 'r') ADVANCE(394);
+      if (lookahead == 's') ADVANCE(409);
+      if (lookahead == 'u') ADVANCE(464);
+      if (lookahead == '{') ADVANCE(260);
+      if (lookahead == '}') ADVANCE(261);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(493);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 7:
-      if (lookahead == '2') ADVANCE(270);
+      if (lookahead == '#') ADVANCE(492);
+      if (lookahead == 'a') ADVANCE(426);
+      if (lookahead == 'b') ADVANCE(400);
+      if (lookahead == 'c') ADVANCE(358);
+      if (lookahead == 'd') ADVANCE(367);
+      if (lookahead == 'f') ADVANCE(417);
+      if (lookahead == 'i') ADVANCE(432);
+      if (lookahead == 'j') ADVANCE(462);
+      if (lookahead == 's') ADVANCE(385);
+      if (lookahead == 't') ADVANCE(481);
+      if (lookahead == 'u') ADVANCE(480);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(493);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 8:
-      if (lookahead == '3') ADVANCE(7);
-      if (lookahead == '6') ADVANCE(10);
+      if (lookahead == '\'') ADVANCE(302);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(8);
       END_STATE();
     case 9:
-      if (lookahead == '4') ADVANCE(268);
+      if (lookahead == '1') ADVANCE(15);
+      if (lookahead == '3') ADVANCE(10);
+      if (lookahead == '6') ADVANCE(13);
       END_STATE();
     case 10:
-      if (lookahead == '4') ADVANCE(272);
+      if (lookahead == '2') ADVANCE(309);
       END_STATE();
     case 11:
-      if (lookahead == '6') ADVANCE(264);
+      if (lookahead == '2') ADVANCE(313);
       END_STATE();
     case 12:
-      if (lookahead == ':') ADVANCE(124);
+      if (lookahead == '3') ADVANCE(11);
+      if (lookahead == '6') ADVANCE(14);
       END_STATE();
     case 13:
-      if (lookahead == ':') ADVANCE(12);
+      if (lookahead == '4') ADVANCE(311);
       END_STATE();
     case 14:
-      if (lookahead == '>') ADVANCE(253);
+      if (lookahead == '4') ADVANCE(315);
       END_STATE();
     case 15:
-      if (lookahead == 'D') ADVANCE(17);
+      if (lookahead == '6') ADVANCE(307);
       END_STATE();
     case 16:
-      if (lookahead == 'O') ADVANCE(15);
+      if (lookahead == ':') ADVANCE(135);
       END_STATE();
     case 17:
-      if (lookahead == 'O') ADVANCE(303);
+      if (lookahead == ':') ADVANCE(16);
       END_STATE();
     case 18:
-      if (lookahead == '_') ADVANCE(248);
+      if (lookahead == '=') ADVANCE(266);
       END_STATE();
     case 19:
-      if (lookahead == '_') ADVANCE(58);
+      if (lookahead == '>') ADVANCE(265);
       END_STATE();
     case 20:
-      if (lookahead == '_') ADVANCE(190);
+      if (lookahead == '_') ADVANCE(62);
       END_STATE();
     case 21:
-      if (lookahead == '_') ADVANCE(18);
+      if (lookahead == '_') ADVANCE(59);
       END_STATE();
     case 22:
-      if (lookahead == '_') ADVANCE(55);
+      if (lookahead == 'a') ADVANCE(126);
+      if (lookahead == 'o') ADVANCE(170);
       END_STATE();
     case 23:
-      if (lookahead == 'a') ADVANCE(116);
-      if (lookahead == 'o') ADVANCE(155);
+      if (lookahead == 'a') ADVANCE(132);
+      if (lookahead == 'l') ADVANCE(178);
+      if (lookahead == 'u') ADVANCE(159);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(48);
+      if (lookahead == 'a') ADVANCE(253);
       END_STATE();
     case 25:
-      if (lookahead == 'a') ADVANCE(122);
-      if (lookahead == 'l') ADVANCE(158);
-      END_STATE();
-    case 26:
       if (lookahead == 'a') ADVANCE(45);
       END_STATE();
+    case 26:
+      if (lookahead == 'a') ADVANCE(50);
+      END_STATE();
     case 27:
-      if (lookahead == 'a') ADVANCE(228);
-      END_STATE();
-    case 28:
-      if (lookahead == 'a') ADVANCE(91);
-      END_STATE();
-    case 29:
-      if (lookahead == 'a') ADVANCE(196);
-      END_STATE();
-    case 30:
-      if (lookahead == 'a') ADVANCE(123);
-      END_STATE();
-    case 31:
-      if (lookahead == 'a') ADVANCE(175);
-      END_STATE();
-    case 32:
-      if (lookahead == 'a') ADVANCE(119);
-      END_STATE();
-    case 33:
-      if (lookahead == 'a') ADVANCE(120);
-      END_STATE();
-    case 34:
-      if (lookahead == 'a') ADVANCE(121);
-      END_STATE();
-    case 35:
-      if (lookahead == 'a') ADVANCE(202);
-      if (lookahead == 'e') ADVANCE(47);
-      if (lookahead == 'u') ADVANCE(179);
-      END_STATE();
-    case 36:
-      if (lookahead == 'a') ADVANCE(109);
-      END_STATE();
-    case 37:
       if (lookahead == 'a') ADVANCE(209);
       END_STATE();
+    case 28:
+      if (lookahead == 'a') ADVANCE(63);
+      END_STATE();
+    case 29:
+      if (lookahead == 'a') ADVANCE(218);
+      END_STATE();
+    case 30:
+      if (lookahead == 'a') ADVANCE(134);
+      END_STATE();
+    case 31:
+      if (lookahead == 'a') ADVANCE(197);
+      END_STATE();
+    case 32:
+      if (lookahead == 'a') ADVANCE(129);
+      END_STATE();
+    case 33:
+      if (lookahead == 'a') ADVANCE(130);
+      END_STATE();
+    case 34:
+      if (lookahead == 'a') ADVANCE(131);
+      END_STATE();
+    case 35:
+      if (lookahead == 'a') ADVANCE(225);
+      if (lookahead == 'e') ADVANCE(48);
+      if (lookahead == 'u') ADVANCE(201);
+      END_STATE();
+    case 36:
+      if (lookahead == 'a') ADVANCE(231);
+      END_STATE();
+    case 37:
+      if (lookahead == 'a') ADVANCE(229);
+      END_STATE();
     case 38:
-      if (lookahead == 'a') ADVANCE(207);
+      if (lookahead == 'a') ADVANCE(116);
       END_STATE();
     case 39:
-      if (lookahead == 'a') ADVANCE(210);
+      if (lookahead == 'a') ADVANCE(236);
       END_STATE();
     case 40:
-      if (lookahead == 'a') ADVANCE(215);
+      if (lookahead == 'a') ADVANCE(238);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(216);
+      if (lookahead == 'a') ADVANCE(239);
       END_STATE();
     case 42:
-      if (lookahead == 'a') ADVANCE(217);
+      if (lookahead == 'b') ADVANCE(279);
       END_STATE();
     case 43:
-      if (lookahead == 'b') ADVANCE(114);
+      if (lookahead == 'b') ADVANCE(212);
+      if (lookahead == 'l') ADVANCE(107);
+      if (lookahead == 'n') ADVANCE(165);
+      if (lookahead == 'r') ADVANCE(199);
       END_STATE();
     case 44:
-      if (lookahead == 'b') ADVANCE(189);
-      if (lookahead == 'n') ADVANCE(150);
-      if (lookahead == 'r') ADVANCE(176);
+      if (lookahead == 'b') ADVANCE(212);
+      if (lookahead == 'l') ADVANCE(107);
+      if (lookahead == 'n') ADVANCE(164);
       END_STATE();
     case 45:
-      if (lookahead == 'b') ADVANCE(129);
+      if (lookahead == 'b') ADVANCE(139);
       END_STATE();
     case 46:
       if (lookahead == 'c') ADVANCE(30);
-      if (lookahead == 'e') ADVANCE(173);
-      if (lookahead == 'i') ADVANCE(146);
-      if (lookahead == 't') ADVANCE(174);
+      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == 'i') ADVANCE(160);
+      if (lookahead == 't') ADVANCE(196);
       END_STATE();
     case 47:
-      if (lookahead == 'c') ADVANCE(100);
-      if (lookahead == 'l') ADVANCE(75);
+      if (lookahead == 'c') ADVANCE(30);
+      if (lookahead == 'i') ADVANCE(160);
       END_STATE();
     case 48:
-      if (lookahead == 'c') ADVANCE(198);
+      if (lookahead == 'c') ADVANCE(108);
       END_STATE();
     case 49:
-      if (lookahead == 'c') ADVANCE(200);
+      if (lookahead == 'c') ADVANCE(86);
+      if (lookahead == 't') ADVANCE(92);
       END_STATE();
     case 50:
-      if (lookahead == 'c') ADVANCE(68);
+      if (lookahead == 'c') ADVANCE(221);
       END_STATE();
     case 51:
-      if (lookahead == 'c') ADVANCE(34);
+      if (lookahead == 'c') ADVANCE(77);
       END_STATE();
     case 52:
-      if (lookahead == 'd') ADVANCE(280);
+      if (lookahead == 'c') ADVANCE(34);
       END_STATE();
     case 53:
-      if (lookahead == 'd') ADVANCE(239);
+      if (lookahead == 'c') ADVANCE(237);
       END_STATE();
     case 54:
-      if (lookahead == 'd') ADVANCE(244);
+      if (lookahead == 'd') ADVANCE(323);
       END_STATE();
     case 55:
-      if (lookahead == 'd') ADVANCE(226);
+      if (lookahead == 'd') ADVANCE(42);
       END_STATE();
     case 56:
-      if (lookahead == 'd') ADVANCE(225);
+      if (lookahead == 'd') ADVANCE(289);
       END_STATE();
     case 57:
-      if (lookahead == 'd') ADVANCE(105);
+      if (lookahead == 'd') ADVANCE(287);
       END_STATE();
     case 58:
-      if (lookahead == 'd') ADVANCE(39);
-      if (lookahead == 't') ADVANCE(108);
+      if (lookahead == 'd') ADVANCE(100);
+      if (lookahead == 'n') ADVANCE(241);
+      if (lookahead == 'x') ADVANCE(49);
       END_STATE();
     case 59:
-      if (lookahead == 'e') ADVANCE(172);
+      if (lookahead == 'd') ADVANCE(249);
       END_STATE();
     case 60:
-      if (lookahead == 'e') ADVANCE(377);
+      if (lookahead == 'd') ADVANCE(68);
+      if (lookahead == 'h') ADVANCE(88);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(236);
+      if (lookahead == 'd') ADVANCE(68);
+      if (lookahead == 'h') ADVANCE(88);
+      if (lookahead == 't') ADVANCE(9);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(378);
+      if (lookahead == 'd') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(118);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(300);
+      if (lookahead == 'd') ADVANCE(91);
       END_STATE();
     case 64:
-      if (lookahead == 'e') ADVANCE(233);
+      if (lookahead == 'd') ADVANCE(248);
       END_STATE();
     case 65:
-      if (lookahead == 'e') ADVANCE(241);
+      if (lookahead == 'd') ADVANCE(115);
       END_STATE();
     case 66:
-      if (lookahead == 'e') ADVANCE(294);
+      if (lookahead == 'd') ADVANCE(115);
+      if (lookahead == 's') ADVANCE(122);
       END_STATE();
     case 67:
-      if (lookahead == 'e') ADVANCE(284);
+      if (lookahead == 'e') ADVANCE(194);
       END_STATE();
     case 68:
-      if (lookahead == 'e') ADVANCE(292);
+      if (lookahead == 'e') ADVANCE(251);
       END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(258);
+      if (lookahead == 'e') ADVANCE(489);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(262);
       END_STATE();
     case 71:
-      if (lookahead == 'e') ADVANCE(302);
+      if (lookahead == 'e') ADVANCE(490);
       END_STATE();
     case 72:
-      if (lookahead == 'e') ADVANCE(289);
+      if (lookahead == 'e') ADVANCE(343);
       END_STATE();
     case 73:
-      if (lookahead == 'e') ADVANCE(290);
+      if (lookahead == 'e') ADVANCE(259);
       END_STATE();
     case 74:
-      if (lookahead == 'e') ADVANCE(288);
+      if (lookahead == 'e') ADVANCE(293);
       END_STATE();
     case 75:
-      if (lookahead == 'e') ADVANCE(90);
+      if (lookahead == 'e') ADVANCE(337);
       END_STATE();
     case 76:
-      if (lookahead == 'e') ADVANCE(53);
+      if (lookahead == 'e') ADVANCE(327);
       END_STATE();
     case 77:
-      if (lookahead == 'e') ADVANCE(22);
+      if (lookahead == 'e') ADVANCE(335);
       END_STATE();
     case 78:
-      if (lookahead == 'e') ADVANCE(187);
+      if (lookahead == 'e') ADVANCE(297);
       END_STATE();
     case 79:
-      if (lookahead == 'e') ADVANCE(182);
+      if (lookahead == 'e') ADVANCE(332);
       END_STATE();
     case 80:
-      if (lookahead == 'e') ADVANCE(54);
+      if (lookahead == 'e') ADVANCE(333);
       END_STATE();
     case 81:
-      if (lookahead == 'e') ADVANCE(191);
+      if (lookahead == 'e') ADVANCE(331);
       END_STATE();
     case 82:
-      if (lookahead == 'e') ADVANCE(184);
+      if (lookahead == 'e') ADVANCE(345);
       END_STATE();
     case 83:
-      if (lookahead == 'e') ADVANCE(148);
+      if (lookahead == 'e') ADVANCE(21);
       END_STATE();
     case 84:
-      if (lookahead == 'e') ADVANCE(147);
+      if (lookahead == 'e') ADVANCE(55);
       END_STATE();
     case 85:
-      if (lookahead == 'e') ADVANCE(131);
+      if (lookahead == 'e') ADVANCE(205);
       END_STATE();
     case 86:
-      if (lookahead == 'e') ADVANCE(49);
+      if (lookahead == 'e') ADVANCE(188);
       END_STATE();
     case 87:
-      if (lookahead == 'e') ADVANCE(211);
+      if (lookahead == 'e') ADVANCE(210);
       END_STATE();
     case 88:
-      if (lookahead == 'g') ADVANCE(257);
+      if (lookahead == 'e') ADVANCE(204);
       END_STATE();
     case 89:
-      if (lookahead == 'g') ADVANCE(237);
+      if (lookahead == 'e') ADVANCE(56);
       END_STATE();
     case 90:
-      if (lookahead == 'g') ADVANCE(37);
+      if (lookahead == 'e') ADVANCE(206);
       END_STATE();
     case 91:
-      if (lookahead == 'g') ADVANCE(69);
+      if (lookahead == 'e') ADVANCE(57);
       END_STATE();
     case 92:
-      if (lookahead == 'g') ADVANCE(106);
+      if (lookahead == 'e') ADVANCE(152);
       END_STATE();
     case 93:
-      if (lookahead == 'g') ADVANCE(128);
+      if (lookahead == 'e') ADVANCE(162);
       END_STATE();
     case 94:
-      if (lookahead == 'h') ADVANCE(79);
-      if (lookahead == 't') ADVANCE(5);
+      if (lookahead == 'e') ADVANCE(142);
       END_STATE();
     case 95:
-      if (lookahead == 'i') ADVANCE(92);
-      if (lookahead == 'o') ADVANCE(161);
-      if (lookahead == 'y') ADVANCE(201);
+      if (lookahead == 'e') ADVANCE(167);
       END_STATE();
     case 96:
-      if (lookahead == 'i') ADVANCE(242);
+      if (lookahead == 'e') ADVANCE(228);
       END_STATE();
     case 97:
-      if (lookahead == 'i') ADVANCE(227);
+      if (lookahead == 'f') ADVANCE(301);
       END_STATE();
     case 98:
-      if (lookahead == 'i') ADVANCE(52);
+      if (lookahead == 'g') ADVANCE(274);
       END_STATE();
     case 99:
-      if (lookahead == 'i') ADVANCE(140);
+      if (lookahead == 'g') ADVANCE(281);
       END_STATE();
     case 100:
-      if (lookahead == 'i') ADVANCE(136);
+      if (lookahead == 'g') ADVANCE(84);
       END_STATE();
     case 101:
-      if (lookahead == 'i') ADVANCE(133);
+      if (lookahead == 'g') ADVANCE(113);
       END_STATE();
     case 102:
-      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 'g') ADVANCE(138);
       END_STATE();
     case 103:
-      if (lookahead == 'i') ADVANCE(185);
+      if (lookahead == 'i') ADVANCE(101);
+      if (lookahead == 'o') ADVANCE(176);
+      if (lookahead == 'y') ADVANCE(223);
       END_STATE();
     case 104:
-      if (lookahead == 'i') ADVANCE(208);
+      if (lookahead == 'i') ADVANCE(295);
       END_STATE();
     case 105:
-      if (lookahead == 'i') ADVANCE(151);
+      if (lookahead == 'i') ADVANCE(250);
       END_STATE();
     case 106:
-      if (lookahead == 'i') ADVANCE(152);
+      if (lookahead == 'i') ADVANCE(54);
       END_STATE();
     case 107:
-      if (lookahead == 'i') ADVANCE(162);
+      if (lookahead == 'i') ADVANCE(27);
       END_STATE();
     case 108:
-      if (lookahead == 'i') ADVANCE(134);
+      if (lookahead == 'i') ADVANCE(147);
       END_STATE();
     case 109:
-      if (lookahead == 'i') ADVANCE(153);
+      if (lookahead == 'i') ADVANCE(144);
       END_STATE();
     case 110:
-      if (lookahead == 'i') ADVANCE(163);
+      if (lookahead == 'i') ADVANCE(150);
       END_STATE();
     case 111:
-      if (lookahead == 'i') ADVANCE(135);
+      if (lookahead == 'i') ADVANCE(161);
       END_STATE();
     case 112:
-      if (lookahead == 'i') ADVANCE(164);
+      if (lookahead == 'i') ADVANCE(207);
       END_STATE();
     case 113:
-      if (lookahead == 'i') ADVANCE(165);
+      if (lookahead == 'i') ADVANCE(166);
       END_STATE();
     case 114:
-      if (lookahead == 'j') ADVANCE(86);
+      if (lookahead == 'i') ADVANCE(230);
       END_STATE();
     case 115:
-      if (lookahead == 'k') ADVANCE(254);
+      if (lookahead == 'i') ADVANCE(163);
       END_STATE();
     case 116:
-      if (lookahead == 'l') ADVANCE(13);
+      if (lookahead == 'i') ADVANCE(168);
       END_STATE();
     case 117:
-      if (lookahead == 'l') ADVANCE(262);
+      if (lookahead == 'i') ADVANCE(181);
       END_STATE();
     case 118:
-      if (lookahead == 'l') ADVANCE(379);
+      if (lookahead == 'i') ADVANCE(145);
       END_STATE();
     case 119:
-      if (lookahead == 'l') ADVANCE(276);
+      if (lookahead == 'i') ADVANCE(182);
       END_STATE();
     case 120:
-      if (lookahead == 'l') ADVANCE(240);
+      if (lookahead == 'i') ADVANCE(146);
       END_STATE();
     case 121:
-      if (lookahead == 'l') ADVANCE(19);
+      if (lookahead == 'i') ADVANCE(183);
       END_STATE();
     case 122:
-      if (lookahead == 'l') ADVANCE(192);
+      if (lookahead == 'i') ADVANCE(184);
       END_STATE();
     case 123:
-      if (lookahead == 'l') ADVANCE(31);
+      if (lookahead == 'i') ADVANCE(185);
       END_STATE();
     case 124:
-      if (lookahead == 'l') ADVANCE(157);
-      if (lookahead == 'r') ADVANCE(85);
+      if (lookahead == 'i') ADVANCE(186);
       END_STATE();
     case 125:
-      if (lookahead == 'l') ADVANCE(118);
+      if (lookahead == 'k') ADVANCE(264);
       END_STATE();
     case 126:
-      if (lookahead == 'l') ADVANCE(63);
+      if (lookahead == 'l') ADVANCE(17);
       END_STATE();
     case 127:
-      if (lookahead == 'l') ADVANCE(64);
+      if (lookahead == 'l') ADVANCE(305);
       END_STATE();
     case 128:
-      if (lookahead == 'l') ADVANCE(65);
+      if (lookahead == 'l') ADVANCE(491);
       END_STATE();
     case 129:
-      if (lookahead == 'l') ADVANCE(70);
+      if (lookahead == 'l') ADVANCE(319);
       END_STATE();
     case 130:
-      if (lookahead == 'l') ADVANCE(205);
+      if (lookahead == 'l') ADVANCE(291);
       END_STATE();
     case 131:
-      if (lookahead == 'l') ADVANCE(38);
+      if (lookahead == 'l') ADVANCE(20);
       END_STATE();
     case 132:
-      if (lookahead == 'm') ADVANCE(304);
+      if (lookahead == 'l') ADVANCE(213);
       END_STATE();
     case 133:
-      if (lookahead == 'm') ADVANCE(67);
+      if (lookahead == 'l') ADVANCE(128);
       END_STATE();
     case 134:
-      if (lookahead == 'm') ADVANCE(73);
+      if (lookahead == 'l') ADVANCE(31);
       END_STATE();
     case 135:
-      if (lookahead == 'm') ADVANCE(74);
+      if (lookahead == 'l') ADVANCE(177);
+      if (lookahead == 'r') ADVANCE(94);
       END_STATE();
     case 136:
-      if (lookahead == 'm') ADVANCE(32);
+      if (lookahead == 'l') ADVANCE(72);
       END_STATE();
     case 137:
-      if (lookahead == 'm') ADVANCE(81);
+      if (lookahead == 'l') ADVANCE(73);
       END_STATE();
     case 138:
-      if (lookahead == 'n') ADVANCE(94);
+      if (lookahead == 'l') ADVANCE(74);
       END_STATE();
     case 139:
-      if (lookahead == 'n') ADVANCE(256);
-      if (lookahead == 'p') ADVANCE(204);
+      if (lookahead == 'l') ADVANCE(78);
       END_STATE();
     case 140:
-      if (lookahead == 'n') ADVANCE(115);
+      if (lookahead == 'l') ADVANCE(180);
       END_STATE();
     case 141:
-      if (lookahead == 'n') ADVANCE(278);
+      if (lookahead == 'l') ADVANCE(227);
       END_STATE();
     case 142:
-      if (lookahead == 'n') ADVANCE(286);
+      if (lookahead == 'l') ADVANCE(37);
       END_STATE();
     case 143:
-      if (lookahead == 'n') ADVANCE(249);
+      if (lookahead == 'm') ADVANCE(346);
       END_STATE();
     case 144:
-      if (lookahead == 'n') ADVANCE(291);
+      if (lookahead == 'm') ADVANCE(76);
       END_STATE();
     case 145:
-      if (lookahead == 'n') ADVANCE(219);
-      if (lookahead == 'r') ADVANCE(177);
-      if (lookahead == 'x') ADVANCE(206);
+      if (lookahead == 'm') ADVANCE(80);
       END_STATE();
     case 146:
-      if (lookahead == 'n') ADVANCE(93);
+      if (lookahead == 'm') ADVANCE(81);
       END_STATE();
     case 147:
-      if (lookahead == 'n') ADVANCE(50);
+      if (lookahead == 'm') ADVANCE(32);
       END_STATE();
     case 148:
-      if (lookahead == 'n') ADVANCE(57);
+      if (lookahead == 'n') ADVANCE(61);
       END_STATE();
     case 149:
-      if (lookahead == 'n') ADVANCE(88);
+      if (lookahead == 'n') ADVANCE(283);
+      if (lookahead == 'p') ADVANCE(226);
+      if (lookahead == 'v') ADVANCE(85);
       END_STATE();
     case 150:
-      if (lookahead == 'n') ADVANCE(160);
-      if (lookahead == 'y') ADVANCE(195);
+      if (lookahead == 'n') ADVANCE(125);
       END_STATE();
     case 151:
-      if (lookahead == 'n') ADVANCE(89);
+      if (lookahead == 'n') ADVANCE(321);
       END_STATE();
     case 152:
-      if (lookahead == 'n') ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(66);
       END_STATE();
     case 153:
-      if (lookahead == 'n') ADVANCE(199);
+      if (lookahead == 'n') ADVANCE(329);
       END_STATE();
     case 154:
-      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'n') ADVANCE(276);
       END_STATE();
     case 155:
-      if (lookahead == 'n') ADVANCE(213);
+      if (lookahead == 'n') ADVANCE(280);
       END_STATE();
     case 156:
-      if (lookahead == 'o') ADVANCE(56);
-      if (lookahead == 'u') ADVANCE(130);
+      if (lookahead == 'n') ADVANCE(269);
       END_STATE();
     case 157:
-      if (lookahead == 'o') ADVANCE(51);
+      if (lookahead == 'n') ADVANCE(334);
       END_STATE();
     case 158:
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'n') ADVANCE(60);
       END_STATE();
     case 159:
-      if (lookahead == 'o') ADVANCE(141);
+      if (lookahead == 'n') ADVANCE(53);
       END_STATE();
     case 160:
-      if (lookahead == 'o') ADVANCE(218);
+      if (lookahead == 'n') ADVANCE(102);
       END_STATE();
     case 161:
-      if (lookahead == 'o') ADVANCE(117);
+      if (lookahead == 'n') ADVANCE(98);
       END_STATE();
     case 162:
-      if (lookahead == 'o') ADVANCE(154);
+      if (lookahead == 'n') ADVANCE(51);
       END_STATE();
     case 163:
-      if (lookahead == 'o') ADVANCE(142);
+      if (lookahead == 'n') ADVANCE(99);
       END_STATE();
     case 164:
-      if (lookahead == 'o') ADVANCE(143);
+      if (lookahead == 'n') ADVANCE(175);
       END_STATE();
     case 165:
-      if (lookahead == 'o') ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(175);
+      if (lookahead == 'y') ADVANCE(217);
       END_STATE();
     case 166:
-      if (lookahead == 'o') ADVANCE(169);
+      if (lookahead == 'n') ADVANCE(219);
       END_STATE();
     case 167:
-      if (lookahead == 'p') ADVANCE(61);
+      if (lookahead == 'n') ADVANCE(65);
       END_STATE();
     case 168:
-      if (lookahead == 'p') ADVANCE(126);
+      if (lookahead == 'n') ADVANCE(222);
       END_STATE();
     case 169:
-      if (lookahead == 'p') ADVANCE(82);
+      if (lookahead == 'n') ADVANCE(33);
       END_STATE();
     case 170:
-      if (lookahead == 'p') ADVANCE(66);
+      if (lookahead == 'n') ADVANCE(216);
       END_STATE();
     case 171:
-      if (lookahead == 'p') ADVANCE(71);
+      if (lookahead == 'o') ADVANCE(64);
+      if (lookahead == 'u') ADVANCE(141);
       END_STATE();
     case 172:
-      if (lookahead == 'q') ADVANCE(222);
+      if (lookahead == 'o') ADVANCE(97);
       END_STATE();
     case 173:
-      if (lookahead == 'q') ADVANCE(224);
+      if (lookahead == 'o') ADVANCE(170);
       END_STATE();
     case 174:
-      if (lookahead == 'r') ADVANCE(260);
+      if (lookahead == 'o') ADVANCE(193);
       END_STATE();
     case 175:
-      if (lookahead == 'r') ADVANCE(1);
+      if (lookahead == 'o') ADVANCE(240);
       END_STATE();
     case 176:
-      if (lookahead == 'r') ADVANCE(27);
+      if (lookahead == 'o') ADVANCE(127);
       END_STATE();
     case 177:
-      if (lookahead == 'r') ADVANCE(137);
+      if (lookahead == 'o') ADVANCE(52);
       END_STATE();
     case 178:
-      if (lookahead == 'r') ADVANCE(223);
-      if (lookahead == 'u') ADVANCE(168);
-      if (lookahead == 'y') ADVANCE(167);
+      if (lookahead == 'o') ADVANCE(29);
       END_STATE();
     case 179:
-      if (lookahead == 'r') ADVANCE(40);
+      if (lookahead == 'o') ADVANCE(151);
       END_STATE();
     case 180:
-      if (lookahead == 'r') ADVANCE(166);
+      if (lookahead == 'o') ADVANCE(28);
       END_STATE();
     case 181:
-      if (lookahead == 'r') ADVANCE(24);
+      if (lookahead == 'o') ADVANCE(169);
       END_STATE();
     case 182:
-      if (lookahead == 'r') ADVANCE(104);
+      if (lookahead == 'o') ADVANCE(153);
       END_STATE();
     case 183:
-      if (lookahead == 'r') ADVANCE(36);
+      if (lookahead == 'o') ADVANCE(154);
       END_STATE();
     case 184:
-      if (lookahead == 'r') ADVANCE(203);
+      if (lookahead == 'o') ADVANCE(155);
       END_STATE();
     case 185:
-      if (lookahead == 'r') ADVANCE(76);
+      if (lookahead == 'o') ADVANCE(156);
       END_STATE();
     case 186:
-      if (lookahead == 'r') ADVANCE(42);
+      if (lookahead == 'o') ADVANCE(157);
       END_STATE();
     case 187:
-      if (lookahead == 's') ADVANCE(282);
+      if (lookahead == 'p') ADVANCE(226);
+      if (lookahead == 'v') ADVANCE(85);
       END_STATE();
     case 188:
-      if (lookahead == 's') ADVANCE(159);
+      if (lookahead == 'p') ADVANCE(220);
       END_STATE();
     case 189:
-      if (lookahead == 's') ADVANCE(212);
+      if (lookahead == 'p') ADVANCE(136);
       END_STATE();
     case 190:
-      if (lookahead == 's') ADVANCE(220);
+      if (lookahead == 'p') ADVANCE(70);
       END_STATE();
     case 191:
-      if (lookahead == 's') ADVANCE(193);
+      if (lookahead == 'p') ADVANCE(75);
       END_STATE();
     case 192:
-      if (lookahead == 's') ADVANCE(62);
+      if (lookahead == 'p') ADVANCE(82);
       END_STATE();
     case 193:
-      if (lookahead == 's') ADVANCE(28);
+      if (lookahead == 'p') ADVANCE(90);
       END_STATE();
     case 194:
-      if (lookahead == 's') ADVANCE(102);
-      if (lookahead == 'u') ADVANCE(98);
+      if (lookahead == 'q') ADVANCE(245);
       END_STATE();
     case 195:
-      if (lookahead == 't') ADVANCE(230);
+      if (lookahead == 'q') ADVANCE(247);
+      if (lookahead == 't') ADVANCE(1);
       END_STATE();
     case 196:
-      if (lookahead == 't') ADVANCE(8);
+      if (lookahead == 'r') ADVANCE(303);
       END_STATE();
     case 197:
-      if (lookahead == 't') ADVANCE(274);
+      if (lookahead == 'r') ADVANCE(263);
       END_STATE();
     case 198:
-      if (lookahead == 't') ADVANCE(243);
+      if (lookahead == 'r') ADVANCE(246);
+      if (lookahead == 'u') ADVANCE(189);
+      if (lookahead == 'y') ADVANCE(190);
       END_STATE();
     case 199:
-      if (lookahead == 't') ADVANCE(255);
+      if (lookahead == 'r') ADVANCE(24);
       END_STATE();
     case 200:
-      if (lookahead == 't') ADVANCE(21);
+      if (lookahead == 'r') ADVANCE(174);
       END_STATE();
     case 201:
-      if (lookahead == 't') ADVANCE(78);
+      if (lookahead == 'r') ADVANCE(39);
       END_STATE();
     case 202:
-      if (lookahead == 't') ADVANCE(87);
+      if (lookahead == 'r') ADVANCE(26);
       END_STATE();
     case 203:
-      if (lookahead == 't') ADVANCE(229);
+      if (lookahead == 'r') ADVANCE(38);
       END_STATE();
     case 204:
-      if (lookahead == 't') ADVANCE(107);
+      if (lookahead == 'r') ADVANCE(114);
       END_STATE();
     case 205:
-      if (lookahead == 't') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(140);
       END_STATE();
     case 206:
-      if (lookahead == 't') ADVANCE(83);
+      if (lookahead == 'r') ADVANCE(224);
       END_STATE();
     case 207:
-      if (lookahead == 't') ADVANCE(97);
+      if (lookahead == 'r') ADVANCE(89);
       END_STATE();
     case 208:
-      if (lookahead == 't') ADVANCE(26);
+      if (lookahead == 'r') ADVANCE(41);
       END_STATE();
     case 209:
-      if (lookahead == 't') ADVANCE(80);
+      if (lookahead == 's') ADVANCE(273);
       END_STATE();
     case 210:
-      if (lookahead == 't') ADVANCE(72);
+      if (lookahead == 's') ADVANCE(325);
       END_STATE();
     case 211:
-      if (lookahead == 't') ADVANCE(101);
+      if (lookahead == 's') ADVANCE(179);
       END_STATE();
     case 212:
-      if (lookahead == 't') ADVANCE(181);
+      if (lookahead == 's') ADVANCE(232);
       END_STATE();
     case 213:
-      if (lookahead == 't') ADVANCE(183);
+      if (lookahead == 's') ADVANCE(71);
       END_STATE();
     case 214:
-      if (lookahead == 't') ADVANCE(231);
+      if (lookahead == 's') ADVANCE(111);
       END_STATE();
     case 215:
-      if (lookahead == 't') ADVANCE(110);
+      if (lookahead == 's') ADVANCE(111);
+      if (lookahead == 'u') ADVANCE(106);
       END_STATE();
     case 216:
-      if (lookahead == 't') ADVANCE(112);
+      if (lookahead == 's') ADVANCE(234);
       END_STATE();
     case 217:
-      if (lookahead == 't') ADVANCE(113);
+      if (lookahead == 't') ADVANCE(256);
       END_STATE();
     case 218:
-      if (lookahead == 't') ADVANCE(41);
+      if (lookahead == 't') ADVANCE(12);
       END_STATE();
     case 219:
-      if (lookahead == 'u') ADVANCE(132);
+      if (lookahead == 't') ADVANCE(317);
       END_STATE();
     case 220:
-      if (lookahead == 'u') ADVANCE(43);
+      if (lookahead == 't') ADVANCE(284);
       END_STATE();
     case 221:
-      if (lookahead == 'u') ADVANCE(125);
+      if (lookahead == 't') ADVANCE(285);
       END_STATE();
     case 222:
-      if (lookahead == 'u') ADVANCE(103);
+      if (lookahead == 't') ADVANCE(271);
       END_STATE();
     case 223:
-      if (lookahead == 'u') ADVANCE(60);
+      if (lookahead == 't') ADVANCE(87);
       END_STATE();
     case 224:
-      if (lookahead == 'u') ADVANCE(84);
+      if (lookahead == 't') ADVANCE(254);
       END_STATE();
     case 225:
-      if (lookahead == 'u') ADVANCE(127);
+      if (lookahead == 't') ADVANCE(96);
       END_STATE();
     case 226:
-      if (lookahead == 'u') ADVANCE(186);
+      if (lookahead == 't') ADVANCE(117);
       END_STATE();
     case 227:
-      if (lookahead == 'v') ADVANCE(77);
+      if (lookahead == 't') ADVANCE(104);
       END_STATE();
     case 228:
-      if (lookahead == 'y') ADVANCE(296);
+      if (lookahead == 't') ADVANCE(109);
       END_STATE();
     case 229:
-      if (lookahead == 'y') ADVANCE(252);
+      if (lookahead == 't') ADVANCE(105);
       END_STATE();
     case 230:
-      if (lookahead == 'y') ADVANCE(170);
+      if (lookahead == 't') ADVANCE(25);
       END_STATE();
     case 231:
-      if (lookahead == 'y') ADVANCE(171);
+      if (lookahead == 't') ADVANCE(79);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 't') ADVANCE(202);
       END_STATE();
     case 233:
-      ACCEPT_TOKEN(anon_sym_module);
+      if (lookahead == 't') ADVANCE(95);
       END_STATE();
     case 234:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == 't') ADVANCE(203);
       END_STATE();
     case 235:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == 't') ADVANCE(257);
       END_STATE();
     case 236:
-      ACCEPT_TOKEN(anon_sym_type);
+      if (lookahead == 't') ADVANCE(119);
       END_STATE();
     case 237:
-      ACCEPT_TOKEN(anon_sym_extending);
+      if (lookahead == 't') ADVANCE(121);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == 't') ADVANCE(123);
       END_STATE();
     case 239:
-      ACCEPT_TOKEN(anon_sym_required);
+      if (lookahead == 't') ADVANCE(124);
       END_STATE();
     case 240:
-      ACCEPT_TOKEN(anon_sym_optional);
+      if (lookahead == 't') ADVANCE(40);
       END_STATE();
     case 241:
-      ACCEPT_TOKEN(anon_sym_single);
+      if (lookahead == 'u') ADVANCE(143);
       END_STATE();
     case 242:
-      ACCEPT_TOKEN(anon_sym_multi);
+      if (lookahead == 'u') ADVANCE(159);
       END_STATE();
     case 243:
-      ACCEPT_TOKEN(anon_sym_abstract);
+      if (lookahead == 'u') ADVANCE(141);
       END_STATE();
     case 244:
-      ACCEPT_TOKEN(anon_sym_delegated);
+      if (lookahead == 'u') ADVANCE(133);
       END_STATE();
     case 245:
-      ACCEPT_TOKEN(anon_sym_inheritable);
+      if (lookahead == 'u') ADVANCE(112);
       END_STATE();
     case 246:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      if (lookahead == 'u') ADVANCE(69);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      if (lookahead == '=') ADVANCE(250);
+      if (lookahead == 'u') ADVANCE(93);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(anon_sym___subject__);
+      if (lookahead == 'u') ADVANCE(137);
       END_STATE();
     case 249:
-      ACCEPT_TOKEN(anon_sym_annotation);
+      if (lookahead == 'u') ADVANCE(208);
       END_STATE();
     case 250:
-      ACCEPT_TOKEN(anon_sym_COLON_EQ);
+      if (lookahead == 'v') ADVANCE(83);
       END_STATE();
     case 251:
-      ACCEPT_TOKEN(anon_sym_SEMI);
+      if (lookahead == 'x') ADVANCE(272);
       END_STATE();
     case 252:
-      ACCEPT_TOKEN(anon_sym_property);
+      if (lookahead == 'x') ADVANCE(233);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      if (lookahead == 'y') ADVANCE(339);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(anon_sym_link);
+      if (lookahead == 'y') ADVANCE(268);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(anon_sym_contraint);
+      if (lookahead == 'y') ADVANCE(190);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(anon_sym_on);
+      if (lookahead == 'y') ADVANCE(191);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_using);
+      if (lookahead == 'y') ADVANCE(192);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_errmessage);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(sym_str);
-      if (lookahead == '\'') ADVANCE(259);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(4);
+      ACCEPT_TOKEN(anon_sym_module);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_str);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 261:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(anon_sym_type);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(anon_sym_scalar);
+      END_STATE();
+    case 264:
+      ACCEPT_TOKEN(anon_sym_link);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 266:
+      ACCEPT_TOKEN(anon_sym_COLON_EQ);
+      END_STATE();
+    case 267:
+      ACCEPT_TOKEN(anon_sym_SEMI);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(anon_sym_property);
+      END_STATE();
+    case 269:
+      ACCEPT_TOKEN(anon_sym_annotation);
+      END_STATE();
+    case 270:
+      ACCEPT_TOKEN(anon_sym_annotation);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(anon_sym_constraint);
+      END_STATE();
+    case 272:
+      ACCEPT_TOKEN(anon_sym_index);
+      END_STATE();
+    case 273:
+      ACCEPT_TOKEN(anon_sym_alias);
+      END_STATE();
+    case 274:
+      ACCEPT_TOKEN(anon_sym_using);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(anon_sym_using);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 276:
+      ACCEPT_TOKEN(anon_sym_function);
+      END_STATE();
+    case 277:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 278:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(anon_sym_edgedb);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(anon_sym_extension);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(anon_sym_extending);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(anon_sym_on);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(anon_sym_except);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(anon_sym_abstract);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(anon_sym_abstract);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(anon_sym_overloaded);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(anon_sym_overloaded);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(anon_sym_required);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(anon_sym_required);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(anon_sym_optional);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(anon_sym_optional);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(anon_sym_single);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(anon_sym_single);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(anon_sym_multi);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(anon_sym_multi);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(anon_sym_inheritable);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(anon_sym_inheritable);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      if (lookahead == '=') ADVANCE(266);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(anon_sym_setof);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(sym_str);
+      if (lookahead == '\'') ADVANCE(302);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(8);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(anon_sym_str);
+      END_STATE();
+    case 304:
       ACCEPT_TOKEN(anon_sym_str);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 262:
-      ACCEPT_TOKEN(anon_sym_bool);
-      END_STATE();
-    case 263:
-      ACCEPT_TOKEN(anon_sym_bool);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 264:
-      ACCEPT_TOKEN(anon_sym_int16);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(anon_sym_int16);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 266:
-      ACCEPT_TOKEN(anon_sym_int32);
-      END_STATE();
-    case 267:
-      ACCEPT_TOKEN(anon_sym_int32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 268:
-      ACCEPT_TOKEN(anon_sym_int64);
-      END_STATE();
-    case 269:
-      ACCEPT_TOKEN(anon_sym_int64);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 270:
-      ACCEPT_TOKEN(anon_sym_float32);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(anon_sym_float32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 272:
-      ACCEPT_TOKEN(anon_sym_float64);
-      END_STATE();
-    case 273:
-      ACCEPT_TOKEN(anon_sym_float64);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 274:
-      ACCEPT_TOKEN(anon_sym_bigint);
-      END_STATE();
-    case 275:
-      ACCEPT_TOKEN(anon_sym_bigint);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 276:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      END_STATE();
-    case 277:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 278:
-      ACCEPT_TOKEN(anon_sym_json);
-      END_STATE();
-    case 279:
-      ACCEPT_TOKEN(anon_sym_json);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 280:
-      ACCEPT_TOKEN(anon_sym_uuid);
-      END_STATE();
-    case 281:
-      ACCEPT_TOKEN(anon_sym_uuid);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 282:
-      ACCEPT_TOKEN(anon_sym_bytes);
-      END_STATE();
-    case 283:
-      ACCEPT_TOKEN(anon_sym_bytes);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(anon_sym_datetime);
-      END_STATE();
-    case 285:
-      ACCEPT_TOKEN(anon_sym_datetime);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 286:
-      ACCEPT_TOKEN(anon_sym_duration);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(anon_sym_duration);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
-      if (lookahead == 't') ADVANCE(111);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(anon_sym_sequence);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(anon_sym_sequence);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(anon_sym_anytype);
-      END_STATE();
-    case 295:
-      ACCEPT_TOKEN(anon_sym_anytype);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(anon_sym_array);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(anon_sym_array);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(anon_sym_LT);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(anon_sym_GT);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(anon_sym_tuple);
-      END_STATE();
-    case 301:
-      ACCEPT_TOKEN(anon_sym_tuple);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
-      END_STATE();
-    case 302:
-      ACCEPT_TOKEN(anon_sym_scalartype);
-      END_STATE();
-    case 303:
-      ACCEPT_TOKEN(anon_sym_TODO);
-      END_STATE();
-    case 304:
-      ACCEPT_TOKEN(anon_sym_enum);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(311);
-      if (lookahead == '3') ADVANCE(306);
-      if (lookahead == '6') ADVANCE(309);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_bool);
       END_STATE();
     case 306:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(267);
+      ACCEPT_TOKEN(anon_sym_bool);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(271);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_int16);
       END_STATE();
     case 308:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '3') ADVANCE(307);
-      if (lookahead == '6') ADVANCE(310);
+      ACCEPT_TOKEN(anon_sym_int16);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 309:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(269);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_int32);
       END_STATE();
     case 310:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(273);
+      ACCEPT_TOKEN(anon_sym_int32);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 311:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(265);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_int64);
       END_STATE();
     case 312:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ':') ADVANCE(12);
+      ACCEPT_TOKEN(anon_sym_int64);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(337);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_float32);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(373);
+      ACCEPT_TOKEN(anon_sym_float32);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 315:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(339);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_float64);
       END_STATE();
     case 316:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(364);
+      ACCEPT_TOKEN(anon_sym_float64);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 317:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(367);
-      if (lookahead == 'e') ADVANCE(319);
-      if (lookahead == 'u') ADVANCE(359);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_bigint);
       END_STATE();
     case 318:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(369);
+      ACCEPT_TOKEN(anon_sym_bigint);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 319:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(333);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_decimal);
       END_STATE();
     case 320:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(326);
+      ACCEPT_TOKEN(anon_sym_decimal);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 321:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(281);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_json);
       END_STATE();
     case 322:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(356);
-      if (lookahead == 't') ADVANCE(357);
+      ACCEPT_TOKEN(anon_sym_json);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 323:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(301);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_uuid);
       END_STATE();
     case 324:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(295);
+      ACCEPT_TOKEN(anon_sym_uuid);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 325:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(285);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_bytes);
       END_STATE();
     case 326:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(293);
+      ACCEPT_TOKEN(anon_sym_bytes);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 327:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(360);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_datetime);
       END_STATE();
     case 328:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(348);
+      ACCEPT_TOKEN(anon_sym_datetime);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 329:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(368);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_duration);
       END_STATE();
     case 330:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(336);
+      ACCEPT_TOKEN(anon_sym_duration);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 331:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(330);
-      if (lookahead == 'o') ADVANCE(351);
-      if (lookahead == 'y') ADVANCE(362);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
       END_STATE();
     case 332:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(321);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
+      if (lookahead == 't') ADVANCE(120);
       END_STATE();
     case 333:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(343);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
       END_STATE();
     case 334:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(342);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
       END_STATE();
     case 335:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(352);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_sequence);
       END_STATE();
     case 336:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(349);
+      ACCEPT_TOKEN(anon_sym_sequence);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 337:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(312);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_anytype);
       END_STATE();
     case 338:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(263);
+      ACCEPT_TOKEN(anon_sym_anytype);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 339:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(277);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_array);
       END_STATE();
     case 340:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(353);
+      ACCEPT_TOKEN(anon_sym_array);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 341:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(323);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
     case 342:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(325);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 343:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(315);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_tuple);
       END_STATE();
     case 344:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(375);
-      if (lookahead == 'r') ADVANCE(358);
+      ACCEPT_TOKEN(anon_sym_tuple);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 345:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(279);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_scalartype);
       END_STATE();
     case 346:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(287);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+      ACCEPT_TOKEN(anon_sym_enum);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(363);
+      if (lookahead == ' ') ADVANCE(172);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(320);
+      if (lookahead == ' ') ADVANCE(235);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
     case 349:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '1') ADVANCE(355);
+      if (lookahead == '3') ADVANCE(350);
+      if (lookahead == '6') ADVANCE(353);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(310);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(314);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '3') ADVANCE(351);
+      if (lookahead == '6') ADVANCE(354);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 353:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(312);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 354:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(316);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 355:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '6') ADVANCE(308);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == ':') ADVANCE(16);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(371);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(413);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(379);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(485);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(455);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(374);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(415);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(467);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(416);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(418);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(471);
+      if (lookahead == 'e') ADVANCE(372);
+      if (lookahead == 'u') ADVANCE(456);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(474);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(477);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'b') ADVANCE(463);
+      if (lookahead == 'n') ADVANCE(435);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'b') ADVANCE(421);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 372:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(402);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 373:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(384);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 374:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(469);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 375:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(366);
+      if (lookahead == 'e') ADVANCE(451);
+      if (lookahead == 't') ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 376:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(324);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(290);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(288);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 379:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(392);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 380:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(450);
+      if (lookahead == 't') ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 381:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(344);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(338);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 383:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(328);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(336);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(451);
+      if (lookahead == 't') ADVANCE(453);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(294);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(298);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 388:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(461);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 389:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(377);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 390:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(433);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(460);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(378);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(458);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(452);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(473);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 397:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(412);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(420);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(393);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(397);
+      if (lookahead == 'o') ADVANCE(439);
+      if (lookahead == 'y') ADVANCE(465);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(376);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(425);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 403:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(296);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(424);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(440);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(441);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 407:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(459);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 408:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(444);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 409:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(431);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 410:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(434);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 411:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(475);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(436);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(356);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(306);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(320);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(292);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(445);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(361);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(381);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 420:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(386);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 421:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(387);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 422:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(442);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 423:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(476);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 424:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'm') ADVANCE(383);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'm') ADVANCE(363);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(487);
+      if (lookahead == 'r') ADVANCE(454);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(322);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(330);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 429:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(399);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 430:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(270);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 431:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(398);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 432:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(466);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 433:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(373);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 434:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(396);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 435:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(443);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 436:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(468);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 437:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'n') ADVANCE(365);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 350:
+    case 438:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(345);
+      if (lookahead == 'o') ADVANCE(427);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 351:
+    case 439:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(338);
+      if (lookahead == 'o') ADVANCE(414);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 352:
+    case 440:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(346);
+      if (lookahead == 'o') ADVANCE(437);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 353:
+    case 441:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(316);
+      if (lookahead == 'o') ADVANCE(428);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 354:
+    case 442:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(341);
+      if (lookahead == 'o') ADVANCE(359);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 355:
+    case 443:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(324);
+      if (lookahead == 'o') ADVANCE(479);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 356:
+    case 444:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'q') ADVANCE(372);
+      if (lookahead == 'o') ADVANCE(430);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 357:
+    case 445:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(261);
+      if (lookahead == 'o') ADVANCE(364);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 358:
+    case 446:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'p') ADVANCE(472);
+      if (lookahead == 'v') ADVANCE(391);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 359:
+    case 447:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(318);
+      if (lookahead == 'p') ADVANCE(472);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 360:
+    case 448:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(283);
+      if (lookahead == 'p') ADVANCE(419);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 361:
+    case 449:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(350);
+      if (lookahead == 'p') ADVANCE(382);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 362:
+    case 450:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(327);
+      if (lookahead == 'q') ADVANCE(482);
+      if (lookahead == 't') ADVANCE(347);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 363:
+    case 451:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(305);
+      if (lookahead == 'q') ADVANCE(482);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 364:
+    case 452:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(308);
+      if (lookahead == 'q') ADVANCE(484);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 365:
+    case 453:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(275);
+      if (lookahead == 'r') ADVANCE(304);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 366:
+    case 454:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(374);
+      if (lookahead == 'r') ADVANCE(360);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 367:
+    case 455:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(329);
+      if (lookahead == 'r') ADVANCE(348);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 368:
+    case 456:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(334);
+      if (lookahead == 'r') ADVANCE(368);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 369:
+    case 457:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(335);
+      if (lookahead == 'r') ADVANCE(362);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 370:
+    case 458:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(354);
+      if (lookahead == 'r') ADVANCE(411);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 371:
+    case 459:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(332);
+      if (lookahead == 'r') ADVANCE(389);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 372:
+    case 460:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(328);
+      if (lookahead == 'r') ADVANCE(422);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 373:
+    case 461:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(297);
+      if (lookahead == 's') ADVANCE(326);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 374:
+    case 462:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(355);
+      if (lookahead == 's') ADVANCE(438);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 375:
+    case 463:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(366);
+      if (lookahead == 's') ADVANCE(478);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 376:
+    case 464:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(410);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 465:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(388);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 466:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(349);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 467:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(352);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 468:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(318);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 469:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(286);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 470:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(486);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 471:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(395);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 472:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(405);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 473:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(404);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 474:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(406);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 475:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(357);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 476:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 477:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(408);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 478:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(457);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(369);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(401);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(448);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 482:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(390);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 483:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(423);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 484:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(407);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 485:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(340);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 486:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(449);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 487:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(470);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
+      END_STATE();
+    case 488:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(376);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(488);
       END_STATE();
-    case 377:
+    case 489:
       ACCEPT_TOKEN(sym_true);
       END_STATE();
-    case 378:
+    case 490:
       ACCEPT_TOKEN(sym_false);
       END_STATE();
-    case 379:
+    case 491:
       ACCEPT_TOKEN(sym_null);
       END_STATE();
-    case 380:
+    case 492:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(380);
+          lookahead != '\n') ADVANCE(492);
       END_STATE();
-    case 381:
+    case 493:
       ACCEPT_TOKEN(sym__whitespace);
       END_STATE();
     default:
@@ -2416,87 +3766,398 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 0},
-  [2] = {.lex_state = 2},
-  [3] = {.lex_state = 2},
-  [4] = {.lex_state = 2},
-  [5] = {.lex_state = 2},
-  [6] = {.lex_state = 2},
-  [7] = {.lex_state = 2},
-  [8] = {.lex_state = 2},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 0},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 0},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 0},
+  [2] = {.lex_state = 3},
+  [3] = {.lex_state = 3},
+  [4] = {.lex_state = 5},
+  [5] = {.lex_state = 5},
+  [6] = {.lex_state = 7},
+  [7] = {.lex_state = 7},
+  [8] = {.lex_state = 7},
+  [9] = {.lex_state = 7},
+  [10] = {.lex_state = 7},
+  [11] = {.lex_state = 7},
+  [12] = {.lex_state = 7},
+  [13] = {.lex_state = 7},
+  [14] = {.lex_state = 7},
+  [15] = {.lex_state = 7},
+  [16] = {.lex_state = 7},
+  [17] = {.lex_state = 7},
+  [18] = {.lex_state = 7},
+  [19] = {.lex_state = 7},
   [20] = {.lex_state = 0},
   [21] = {.lex_state = 0},
   [22] = {.lex_state = 0},
-  [23] = {.lex_state = 0},
-  [24] = {.lex_state = 0},
-  [25] = {.lex_state = 0},
-  [26] = {.lex_state = 0},
-  [27] = {.lex_state = 0},
-  [28] = {.lex_state = 0},
-  [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 2},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 0},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 0},
-  [37] = {.lex_state = 0},
-  [38] = {.lex_state = 0},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
-  [41] = {.lex_state = 0},
-  [42] = {.lex_state = 0},
-  [43] = {.lex_state = 0},
-  [44] = {.lex_state = 0},
+  [23] = {.lex_state = 4},
+  [24] = {.lex_state = 4},
+  [25] = {.lex_state = 4},
+  [26] = {.lex_state = 4},
+  [27] = {.lex_state = 4},
+  [28] = {.lex_state = 4},
+  [29] = {.lex_state = 4},
+  [30] = {.lex_state = 4},
+  [31] = {.lex_state = 4},
+  [32] = {.lex_state = 4},
+  [33] = {.lex_state = 4},
+  [34] = {.lex_state = 4},
+  [35] = {.lex_state = 4},
+  [36] = {.lex_state = 4},
+  [37] = {.lex_state = 4},
+  [38] = {.lex_state = 4},
+  [39] = {.lex_state = 4},
+  [40] = {.lex_state = 4},
+  [41] = {.lex_state = 4},
+  [42] = {.lex_state = 4},
+  [43] = {.lex_state = 4},
+  [44] = {.lex_state = 4},
   [45] = {.lex_state = 0},
   [46] = {.lex_state = 0},
   [47] = {.lex_state = 0},
-  [48] = {.lex_state = 0},
-  [49] = {.lex_state = 0},
-  [50] = {.lex_state = 0},
+  [48] = {.lex_state = 4},
+  [49] = {.lex_state = 4},
+  [50] = {.lex_state = 4},
   [51] = {.lex_state = 0},
   [52] = {.lex_state = 0},
-  [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 0},
-  [56] = {.lex_state = 0},
+  [53] = {.lex_state = 4},
+  [54] = {.lex_state = 4},
+  [55] = {.lex_state = 4},
+  [56] = {.lex_state = 4},
   [57] = {.lex_state = 0},
   [58] = {.lex_state = 0},
-  [59] = {.lex_state = 3},
+  [59] = {.lex_state = 0},
   [60] = {.lex_state = 0},
   [61] = {.lex_state = 0},
-  [62] = {.lex_state = 3},
-  [63] = {.lex_state = 3},
-  [64] = {.lex_state = 3},
-  [65] = {.lex_state = 3},
+  [62] = {.lex_state = 0},
+  [63] = {.lex_state = 0},
+  [64] = {.lex_state = 0},
+  [65] = {.lex_state = 0},
   [66] = {.lex_state = 0},
   [67] = {.lex_state = 0},
   [68] = {.lex_state = 0},
-  [69] = {.lex_state = 3},
-  [70] = {.lex_state = 3},
+  [69] = {.lex_state = 0},
+  [70] = {.lex_state = 0},
   [71] = {.lex_state = 0},
   [72] = {.lex_state = 0},
-  [73] = {.lex_state = 3},
+  [73] = {.lex_state = 6},
   [74] = {.lex_state = 0},
-  [75] = {.lex_state = 3},
-  [76] = {.lex_state = 3},
-  [77] = {.lex_state = 0},
-  [78] = {.lex_state = 2},
-  [79] = {.lex_state = 3},
-  [80] = {.lex_state = 3},
+  [75] = {.lex_state = 0},
+  [76] = {.lex_state = 6},
+  [77] = {.lex_state = 6},
+  [78] = {.lex_state = 0},
+  [79] = {.lex_state = 0},
+  [80] = {.lex_state = 6},
   [81] = {.lex_state = 0},
-  [82] = {.lex_state = 0},
+  [82] = {.lex_state = 6},
+  [83] = {.lex_state = 0},
+  [84] = {.lex_state = 0},
+  [85] = {.lex_state = 6},
+  [86] = {.lex_state = 0},
+  [87] = {.lex_state = 0},
+  [88] = {.lex_state = 0},
+  [89] = {.lex_state = 0},
+  [90] = {.lex_state = 6},
+  [91] = {.lex_state = 6},
+  [92] = {.lex_state = 6},
+  [93] = {.lex_state = 6},
+  [94] = {.lex_state = 6},
+  [95] = {.lex_state = 0},
+  [96] = {.lex_state = 0},
+  [97] = {.lex_state = 0},
+  [98] = {.lex_state = 0},
+  [99] = {.lex_state = 0},
+  [100] = {.lex_state = 0},
+  [101] = {.lex_state = 0},
+  [102] = {.lex_state = 0},
+  [103] = {.lex_state = 0},
+  [104] = {.lex_state = 0},
+  [105] = {.lex_state = 0},
+  [106] = {.lex_state = 0},
+  [107] = {.lex_state = 0},
+  [108] = {.lex_state = 0},
+  [109] = {.lex_state = 6},
+  [110] = {.lex_state = 6},
+  [111] = {.lex_state = 6},
+  [112] = {.lex_state = 0},
+  [113] = {.lex_state = 6},
+  [114] = {.lex_state = 0},
+  [115] = {.lex_state = 6},
+  [116] = {.lex_state = 6},
+  [117] = {.lex_state = 0},
+  [118] = {.lex_state = 6},
+  [119] = {.lex_state = 0},
+  [120] = {.lex_state = 0},
+  [121] = {.lex_state = 0},
+  [122] = {.lex_state = 0},
+  [123] = {.lex_state = 0},
+  [124] = {.lex_state = 6},
+  [125] = {.lex_state = 0},
+  [126] = {.lex_state = 6},
+  [127] = {.lex_state = 0},
+  [128] = {.lex_state = 0},
+  [129] = {.lex_state = 0},
+  [130] = {.lex_state = 6},
+  [131] = {.lex_state = 0},
+  [132] = {.lex_state = 0},
+  [133] = {.lex_state = 0},
+  [134] = {.lex_state = 0},
+  [135] = {.lex_state = 0},
+  [136] = {.lex_state = 0},
+  [137] = {.lex_state = 0},
+  [138] = {.lex_state = 6},
+  [139] = {.lex_state = 6},
+  [140] = {.lex_state = 0},
+  [141] = {.lex_state = 0},
+  [142] = {.lex_state = 6},
+  [143] = {.lex_state = 6},
+  [144] = {.lex_state = 0},
+  [145] = {.lex_state = 6},
+  [146] = {.lex_state = 0},
+  [147] = {.lex_state = 0},
+  [148] = {.lex_state = 0},
+  [149] = {.lex_state = 6},
+  [150] = {.lex_state = 6},
+  [151] = {.lex_state = 0},
+  [152] = {.lex_state = 0},
+  [153] = {.lex_state = 0},
+  [154] = {.lex_state = 0},
+  [155] = {.lex_state = 6},
+  [156] = {.lex_state = 0},
+  [157] = {.lex_state = 6},
+  [158] = {.lex_state = 0},
+  [159] = {.lex_state = 6},
+  [160] = {.lex_state = 0},
+  [161] = {.lex_state = 6},
+  [162] = {.lex_state = 0},
+  [163] = {.lex_state = 0},
+  [164] = {.lex_state = 0},
+  [165] = {.lex_state = 0},
+  [166] = {.lex_state = 0},
+  [167] = {.lex_state = 0},
+  [168] = {.lex_state = 0},
+  [169] = {.lex_state = 0},
+  [170] = {.lex_state = 0},
+  [171] = {.lex_state = 0},
+  [172] = {.lex_state = 0},
+  [173] = {.lex_state = 0},
+  [174] = {.lex_state = 0},
+  [175] = {.lex_state = 0},
+  [176] = {.lex_state = 0},
+  [177] = {.lex_state = 0},
+  [178] = {.lex_state = 0},
+  [179] = {.lex_state = 0},
+  [180] = {.lex_state = 0},
+  [181] = {.lex_state = 4},
+  [182] = {.lex_state = 4},
+  [183] = {.lex_state = 4},
+  [184] = {.lex_state = 0},
+  [185] = {.lex_state = 4},
+  [186] = {.lex_state = 0},
+  [187] = {.lex_state = 0},
+  [188] = {.lex_state = 0},
+  [189] = {.lex_state = 0},
+  [190] = {.lex_state = 0},
+  [191] = {.lex_state = 0},
+  [192] = {.lex_state = 0},
+  [193] = {.lex_state = 0},
+  [194] = {.lex_state = 0},
+  [195] = {.lex_state = 0},
+  [196] = {.lex_state = 0},
+  [197] = {.lex_state = 0},
+  [198] = {.lex_state = 0},
+  [199] = {.lex_state = 0},
+  [200] = {.lex_state = 0},
+  [201] = {.lex_state = 0},
+  [202] = {.lex_state = 0},
+  [203] = {.lex_state = 6},
+  [204] = {.lex_state = 0},
+  [205] = {.lex_state = 6},
+  [206] = {.lex_state = 6},
+  [207] = {.lex_state = 6},
+  [208] = {.lex_state = 6},
+  [209] = {.lex_state = 6},
+  [210] = {.lex_state = 6},
+  [211] = {.lex_state = 6},
+  [212] = {.lex_state = 6},
+  [213] = {.lex_state = 0},
+  [214] = {.lex_state = 0},
+  [215] = {.lex_state = 0},
+  [216] = {.lex_state = 0},
+  [217] = {.lex_state = 0},
+  [218] = {.lex_state = 0},
+  [219] = {.lex_state = 0},
+  [220] = {.lex_state = 0},
+  [221] = {.lex_state = 0},
+  [222] = {.lex_state = 0},
+  [223] = {.lex_state = 0},
+  [224] = {.lex_state = 0},
+  [225] = {.lex_state = 0},
+  [226] = {.lex_state = 0},
+  [227] = {.lex_state = 0},
+  [228] = {.lex_state = 0},
+  [229] = {.lex_state = 0},
+  [230] = {.lex_state = 0},
+  [231] = {.lex_state = 0},
+  [232] = {.lex_state = 0},
+  [233] = {.lex_state = 0},
+  [234] = {.lex_state = 0},
+  [235] = {.lex_state = 0},
+  [236] = {.lex_state = 0},
+  [237] = {.lex_state = 0},
+  [238] = {.lex_state = 0},
+  [239] = {.lex_state = 0},
+  [240] = {.lex_state = 3},
+  [241] = {.lex_state = 0},
+  [242] = {.lex_state = 0},
+  [243] = {.lex_state = 2},
+  [244] = {.lex_state = 2},
+  [245] = {.lex_state = 2},
+  [246] = {.lex_state = 0},
+  [247] = {.lex_state = 2},
+  [248] = {.lex_state = 2},
+  [249] = {.lex_state = 2},
+  [250] = {.lex_state = 2},
+  [251] = {.lex_state = 0},
+  [252] = {.lex_state = 2},
+  [253] = {.lex_state = 0},
+  [254] = {.lex_state = 0},
+  [255] = {.lex_state = 0},
+  [256] = {.lex_state = 3},
+  [257] = {.lex_state = 2},
+  [258] = {.lex_state = 0},
+  [259] = {.lex_state = 0},
+  [260] = {.lex_state = 2},
+  [261] = {.lex_state = 2},
+  [262] = {.lex_state = 2},
+  [263] = {.lex_state = 2},
+  [264] = {.lex_state = 2},
+  [265] = {.lex_state = 0},
+  [266] = {.lex_state = 2},
+  [267] = {.lex_state = 3},
+  [268] = {.lex_state = 0},
+  [269] = {.lex_state = 2},
+  [270] = {.lex_state = 0},
+  [271] = {.lex_state = 2},
+  [272] = {.lex_state = 2},
+  [273] = {.lex_state = 2},
+  [274] = {.lex_state = 0},
+  [275] = {.lex_state = 2},
+  [276] = {.lex_state = 2},
+  [277] = {.lex_state = 0},
+  [278] = {.lex_state = 0},
+  [279] = {.lex_state = 0},
+  [280] = {.lex_state = 0},
+  [281] = {.lex_state = 2},
+  [282] = {.lex_state = 2},
+  [283] = {.lex_state = 2},
+  [284] = {.lex_state = 2},
+  [285] = {.lex_state = 0},
+  [286] = {.lex_state = 0},
+  [287] = {.lex_state = 2},
+  [288] = {.lex_state = 0},
+  [289] = {.lex_state = 2},
+  [290] = {.lex_state = 0},
+  [291] = {.lex_state = 0},
+  [292] = {.lex_state = 5},
+  [293] = {.lex_state = 0},
+  [294] = {.lex_state = 0},
+  [295] = {.lex_state = 0},
+  [296] = {.lex_state = 0},
+  [297] = {.lex_state = 0},
+  [298] = {.lex_state = 0},
+  [299] = {.lex_state = 0},
+  [300] = {.lex_state = 0},
+  [301] = {.lex_state = 0},
+  [302] = {.lex_state = 0},
+  [303] = {.lex_state = 2},
+  [304] = {.lex_state = 0},
+  [305] = {.lex_state = 0},
+  [306] = {.lex_state = 0},
+  [307] = {.lex_state = 0},
+  [308] = {.lex_state = 0},
+  [309] = {.lex_state = 0},
+  [310] = {.lex_state = 2},
+  [311] = {.lex_state = 0},
+  [312] = {.lex_state = 0},
+  [313] = {.lex_state = 0},
+  [314] = {.lex_state = 0},
+  [315] = {.lex_state = 0},
+  [316] = {.lex_state = 0},
+  [317] = {.lex_state = 0},
+  [318] = {.lex_state = 2},
+  [319] = {.lex_state = 0},
+  [320] = {.lex_state = 2},
+  [321] = {.lex_state = 0},
+  [322] = {.lex_state = 2},
+  [323] = {.lex_state = 0},
+  [324] = {.lex_state = 0},
+  [325] = {.lex_state = 2},
+  [326] = {.lex_state = 0},
+  [327] = {.lex_state = 5},
+  [328] = {.lex_state = 0},
+  [329] = {.lex_state = 0},
+  [330] = {.lex_state = 2},
+  [331] = {.lex_state = 0},
+  [332] = {.lex_state = 2},
+  [333] = {.lex_state = 2},
+  [334] = {.lex_state = 2},
+  [335] = {.lex_state = 0},
+  [336] = {.lex_state = 0},
+  [337] = {.lex_state = 0},
+  [338] = {.lex_state = 2},
+  [339] = {.lex_state = 0},
+  [340] = {.lex_state = 0},
+  [341] = {.lex_state = 0},
+  [342] = {.lex_state = 0},
+  [343] = {.lex_state = 0},
+  [344] = {.lex_state = 0},
+  [345] = {.lex_state = 2},
+  [346] = {.lex_state = 2},
+  [347] = {.lex_state = 0},
+  [348] = {.lex_state = 0},
+  [349] = {.lex_state = 3},
+  [350] = {.lex_state = 0},
+  [351] = {.lex_state = 0},
+  [352] = {.lex_state = 2},
+  [353] = {.lex_state = 2},
+  [354] = {.lex_state = 0},
+  [355] = {.lex_state = 0},
+  [356] = {.lex_state = 0},
+  [357] = {.lex_state = 2},
+  [358] = {.lex_state = 0},
+  [359] = {.lex_state = 0},
+  [360] = {.lex_state = 0},
+  [361] = {.lex_state = 0},
+  [362] = {.lex_state = 0},
+  [363] = {.lex_state = 0},
+  [364] = {.lex_state = 0},
+  [365] = {.lex_state = 2},
+  [366] = {.lex_state = 0},
+  [367] = {.lex_state = 0},
+  [368] = {.lex_state = 0},
+  [369] = {.lex_state = 0},
+  [370] = {.lex_state = 0},
+  [371] = {.lex_state = 0},
+  [372] = {.lex_state = 0},
+  [373] = {.lex_state = 0},
+  [374] = {.lex_state = 2},
+  [375] = {.lex_state = 0},
+  [376] = {.lex_state = 0},
+  [377] = {.lex_state = 0},
+  [378] = {.lex_state = 0},
+  [379] = {.lex_state = 2},
+  [380] = {.lex_state = 0},
+  [381] = {.lex_state = 2},
+  [382] = {.lex_state = 0},
+  [383] = {.lex_state = 0},
+  [384] = {.lex_state = 0},
+  [385] = {.lex_state = 0},
+  [386] = {.lex_state = 0},
+  [387] = {.lex_state = 0},
+  [388] = {.lex_state = 0},
+  [389] = {.lex_state = 2},
+  [390] = {.lex_state = 2},
+  [391] = {.lex_state = 2},
+  [392] = {.lex_state = 0},
+  [393] = {.lex_state = 2},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -2506,27 +4167,35 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_type] = ACTIONS(1),
+    [anon_sym_scalar] = ACTIONS(1),
+    [anon_sym_link] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
+    [anon_sym_COLON_EQ] = ACTIONS(1),
+    [anon_sym_SEMI] = ACTIONS(1),
+    [anon_sym_property] = ACTIONS(1),
+    [anon_sym_annotation] = ACTIONS(1),
+    [anon_sym_constraint] = ACTIONS(1),
+    [anon_sym_index] = ACTIONS(1),
+    [anon_sym_alias] = ACTIONS(1),
+    [anon_sym_using] = ACTIONS(1),
+    [anon_sym_function] = ACTIONS(1),
+    [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
+    [anon_sym_edgedb] = ACTIONS(1),
+    [anon_sym_extension] = ACTIONS(1),
     [anon_sym_extending] = ACTIONS(1),
     [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_on] = ACTIONS(1),
+    [anon_sym_except] = ACTIONS(1),
+    [anon_sym_abstract] = ACTIONS(1),
+    [anon_sym_overloaded] = ACTIONS(1),
     [anon_sym_required] = ACTIONS(1),
     [anon_sym_optional] = ACTIONS(1),
     [anon_sym_single] = ACTIONS(1),
     [anon_sym_multi] = ACTIONS(1),
-    [anon_sym_abstract] = ACTIONS(1),
-    [anon_sym_delegated] = ACTIONS(1),
     [anon_sym_inheritable] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
-    [anon_sym___subject__] = ACTIONS(1),
-    [anon_sym_annotation] = ACTIONS(1),
-    [anon_sym_COLON_EQ] = ACTIONS(1),
-    [anon_sym_SEMI] = ACTIONS(1),
-    [anon_sym_property] = ACTIONS(1),
-    [anon_sym_DASH_GT] = ACTIONS(1),
-    [anon_sym_link] = ACTIONS(1),
-    [anon_sym_contraint] = ACTIONS(1),
-    [anon_sym_on] = ACTIONS(1),
-    [anon_sym_using] = ACTIONS(1),
-    [anon_sym_errmessage] = ACTIONS(1),
+    [anon_sym_setof] = ACTIONS(1),
     [sym_str] = ACTIONS(1),
     [anon_sym_str] = ACTIONS(1),
     [anon_sym_bool] = ACTIONS(1),
@@ -2552,8 +4221,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
     [anon_sym_tuple] = ACTIONS(1),
-    [anon_sym_scalartype] = ACTIONS(1),
-    [anon_sym_TODO] = ACTIONS(1),
     [anon_sym_enum] = ACTIONS(1),
     [sym_true] = ACTIONS(1),
     [sym_false] = ACTIONS(1),
@@ -2562,9 +4229,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__whitespace] = ACTIONS(3),
   },
   [1] = {
-    [sym_source_file] = STATE(81),
-    [sym_module] = STATE(29),
-    [aux_sym_source_file_repeat1] = STATE(29),
+    [sym_source_file] = STATE(360),
+    [sym_module] = STATE(236),
+    [aux_sym_source_file_repeat1] = STATE(236),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_module] = ACTIONS(7),
     [sym_comment] = ACTIONS(3),
@@ -2573,1042 +4240,7068 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 8,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(33), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [48] = 9,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
+  [0] = 11,
+    ACTIONS(9), 1,
+      anon_sym_optional,
+    ACTIONS(11), 1,
+      anon_sym_setof,
     ACTIONS(17), 1,
-      sym_identifier,
-    STATE(36), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 17,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [98] = 8,
-    ACTIONS(13), 1,
       anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(61), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [146] = 8,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(71), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [194] = 8,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(68), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [242] = 8,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(51), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [290] = 8,
-    ACTIONS(13), 1,
-      anon_sym_array,
-    ACTIONS(15), 1,
-      anon_sym_tuple,
-    STATE(57), 1,
-      sym_type,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(44), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(11), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(43), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(9), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [338] = 7,
     ACTIONS(19), 1,
-      anon_sym_RBRACE,
-    ACTIONS(24), 1,
-      anon_sym_property,
-    ACTIONS(27), 1,
-      anon_sym_link,
+      anon_sym_tuple,
+    STATE(234), 1,
+      sym_returnspec,
+    STATE(285), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(16), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    STATE(9), 3,
-      sym_property,
-      sym_link,
-      aux_sym_declarations_repeat1,
-    ACTIONS(21), 7,
-      anon_sym_required,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [57] = 11,
+    ACTIONS(9), 1,
       anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [370] = 7,
-    ACTIONS(30), 1,
-      anon_sym_RBRACE,
-    ACTIONS(34), 1,
-      anon_sym_property,
-    ACTIONS(36), 1,
-      anon_sym_link,
+    ACTIONS(11), 1,
+      anon_sym_setof,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(233), 1,
+      sym_returnspec,
+    STATE(285), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(16), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    STATE(9), 3,
-      sym_property,
-      sym_link,
-      aux_sym_declarations_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [402] = 7,
-    ACTIONS(34), 1,
-      anon_sym_property,
-    ACTIONS(36), 1,
-      anon_sym_link,
-    ACTIONS(38), 1,
-      anon_sym_RBRACE,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [114] = 9,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    ACTIONS(21), 1,
+      anon_sym_scalartype,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(16), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    STATE(10), 3,
-      sym_property,
-      sym_link,
-      aux_sym_declarations_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [434] = 6,
-    ACTIONS(40), 1,
-      anon_sym_RBRACE,
-    ACTIONS(42), 1,
-      anon_sym_type,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    STATE(36), 2,
+      sym_enum,
+      sym_type,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [166] = 9,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    ACTIONS(21), 1,
+      anon_sym_scalartype,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(13), 2,
-      sym_object_type,
-      aux_sym_schema_declarations_repeat1,
-    STATE(20), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [462] = 6,
-    ACTIONS(42), 1,
-      anon_sym_type,
-    ACTIONS(44), 1,
-      anon_sym_RBRACE,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    STATE(39), 2,
+      sym_enum,
+      sym_type,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [218] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(295), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(14), 2,
-      sym_object_type,
-      aux_sym_schema_declarations_repeat1,
-    STATE(20), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [490] = 6,
-    ACTIONS(46), 1,
-      anon_sym_RBRACE,
-    ACTIONS(48), 1,
-      anon_sym_type,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [266] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(54), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(14), 2,
-      sym_object_type,
-      aux_sym_schema_declarations_repeat1,
-    STATE(20), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(51), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [518] = 4,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [314] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(53), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(15), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(54), 3,
-      anon_sym_type,
-      anon_sym_property,
-      anon_sym_link,
-    ACTIONS(56), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [541] = 5,
-    ACTIONS(59), 1,
-      anon_sym_property,
-    ACTIONS(61), 1,
-      anon_sym_link,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [362] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(55), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(15), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [565] = 2,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [410] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(382), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(63), 10,
-      anon_sym_RBRACE,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-      anon_sym_property,
-      anon_sym_link,
-  [582] = 2,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [458] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(48), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(65), 10,
-      anon_sym_RBRACE,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-      anon_sym_property,
-      anon_sym_link,
-  [599] = 2,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [506] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(280), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(67), 10,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-      anon_sym_property,
-      anon_sym_link,
-  [616] = 4,
-    ACTIONS(69), 1,
-      anon_sym_type,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [554] = 9,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    ACTIONS(23), 1,
+      sym_identifier,
+    STATE(265), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(15), 2,
-      sym_modifier,
-      aux_sym_object_type_repeat1,
-    ACTIONS(32), 7,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [637] = 2,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 17,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [604] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(50), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(71), 10,
-      anon_sym_RBRACE,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-      anon_sym_property,
-      anon_sym_link,
-  [654] = 2,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [652] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(274), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(73), 10,
-      anon_sym_RBRACE,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-      anon_sym_property,
-      anon_sym_link,
-  [671] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(75), 9,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [687] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(77), 9,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [703] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(79), 9,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [719] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(81), 9,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [735] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(83), 9,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_abstract,
-      anon_sym_delegated,
-      anon_sym_inheritable,
-  [751] = 5,
-    ACTIONS(85), 1,
-      anon_sym_LBRACE,
-    ACTIONS(87), 1,
-      anon_sym_extending,
-    STATE(27), 1,
-      sym_declarations,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [700] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
     STATE(49), 1,
-      sym_extends,
+      sym_type,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [768] = 4,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [748] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(56), 1,
+      sym_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [796] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(44), 1,
+      sym_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [844] = 8,
+    ACTIONS(17), 1,
+      anon_sym_array,
+    ACTIONS(19), 1,
+      anon_sym_tuple,
+    STATE(302), 1,
+      sym_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(32), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(15), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(27), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(13), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [892] = 14,
+    ACTIONS(25), 1,
+      anon_sym_RBRACE,
+    ACTIONS(27), 1,
+      anon_sym_type,
+    ACTIONS(29), 1,
+      anon_sym_scalar,
+    ACTIONS(31), 1,
+      anon_sym_link,
+    ACTIONS(33), 1,
+      anon_sym_property,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(37), 1,
+      anon_sym_constraint,
+    ACTIONS(39), 1,
+      anon_sym_alias,
+    ACTIONS(41), 1,
+      anon_sym_function,
+    STATE(187), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(199), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(22), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [950] = 14,
+    ACTIONS(45), 1,
+      anon_sym_RBRACE,
+    ACTIONS(47), 1,
+      anon_sym_type,
+    ACTIONS(50), 1,
+      anon_sym_scalar,
+    ACTIONS(53), 1,
+      anon_sym_link,
+    ACTIONS(56), 1,
+      anon_sym_property,
+    ACTIONS(59), 1,
+      anon_sym_annotation,
+    ACTIONS(62), 1,
+      anon_sym_constraint,
+    ACTIONS(65), 1,
+      anon_sym_alias,
+    ACTIONS(68), 1,
+      anon_sym_function,
+    STATE(187), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(199), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(71), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(21), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [1008] = 14,
+    ACTIONS(27), 1,
+      anon_sym_type,
+    ACTIONS(29), 1,
+      anon_sym_scalar,
+    ACTIONS(31), 1,
+      anon_sym_link,
+    ACTIONS(33), 1,
+      anon_sym_property,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(37), 1,
+      anon_sym_constraint,
+    ACTIONS(39), 1,
+      anon_sym_alias,
+    ACTIONS(41), 1,
+      anon_sym_function,
+    ACTIONS(74), 1,
+      anon_sym_RBRACE,
+    STATE(187), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(199), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(21), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [1066] = 9,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(80), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(82), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(84), 1,
+      anon_sym_SEMI,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    STATE(38), 1,
+      sym_extending,
+    STATE(66), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(78), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1111] = 9,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(90), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(92), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(94), 1,
+      anon_sym_SEMI,
+    STATE(40), 1,
+      sym_extending,
+    STATE(63), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(88), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1156] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(96), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1187] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(98), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1218] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(100), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1249] = 9,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(104), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(106), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(108), 1,
+      anon_sym_SEMI,
+    STATE(43), 1,
+      sym_extending,
+    STATE(86), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(102), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1294] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(110), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1325] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(112), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1356] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(114), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1387] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(116), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [1418] = 9,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(120), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(122), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(124), 1,
+      anon_sym_SEMI,
+    STATE(42), 1,
+      sym_extending,
+    STATE(84), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(118), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1463] = 4,
+    ACTIONS(128), 1,
+      anon_sym_COMMA,
+    STATE(34), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(126), 21,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1497] = 4,
+    ACTIONS(133), 1,
+      anon_sym_COMMA,
+    STATE(34), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(131), 21,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1531] = 4,
+    ACTIONS(133), 1,
+      anon_sym_COMMA,
+    STATE(35), 1,
+      aux_sym_extending_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(135), 21,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1565] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(137), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1594] = 7,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(141), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(143), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(145), 1,
+      anon_sym_SEMI,
+    STATE(100), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(139), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1633] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(147), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1662] = 7,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(151), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(153), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(155), 1,
+      anon_sym_SEMI,
+    STATE(97), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(149), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1701] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(157), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1730] = 7,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(161), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(163), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(165), 1,
+      anon_sym_SEMI,
+    STATE(60), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(159), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1769] = 7,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(169), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(171), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(173), 1,
+      anon_sym_SEMI,
+    STATE(71), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(167), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1808] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(177), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(179), 1,
+      anon_sym_SEMI,
+    STATE(89), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(175), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1844] = 11,
+    ACTIONS(181), 1,
+      anon_sym_RBRACE,
+    ACTIONS(183), 1,
+      anon_sym_link,
+    ACTIONS(186), 1,
+      anon_sym_property,
+    ACTIONS(189), 1,
+      anon_sym_annotation,
+    ACTIONS(192), 1,
+      anon_sym_constraint,
+    ACTIONS(195), 1,
+      anon_sym_index,
+    STATE(204), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(213), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(45), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(198), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1890] = 11,
+    ACTIONS(31), 1,
+      anon_sym_link,
+    ACTIONS(33), 1,
+      anon_sym_property,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(37), 1,
+      anon_sym_constraint,
+    ACTIONS(201), 1,
+      anon_sym_RBRACE,
+    ACTIONS(203), 1,
+      anon_sym_index,
+    STATE(204), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(213), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(51), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [1936] = 4,
+    ACTIONS(207), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(304), 1,
+      sym__scalar_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(205), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [1968] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(211), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(213), 1,
+      anon_sym_SEMI,
+    STATE(65), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(209), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2004] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(217), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(219), 1,
+      anon_sym_SEMI,
+    STATE(67), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(215), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2040] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(223), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(225), 1,
+      anon_sym_SEMI,
+    STATE(70), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(221), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2076] = 11,
+    ACTIONS(31), 1,
+      anon_sym_link,
+    ACTIONS(33), 1,
+      anon_sym_property,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(37), 1,
+      anon_sym_constraint,
+    ACTIONS(203), 1,
+      anon_sym_index,
+    ACTIONS(227), 1,
+      anon_sym_RBRACE,
+    STATE(204), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(213), 1,
+      sym_modifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(45), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2122] = 4,
+    ACTIONS(231), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(255), 1,
+      sym__scalar_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(229), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [2154] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(235), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(237), 1,
+      anon_sym_SEMI,
+    STATE(72), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(233), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2190] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(241), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(243), 1,
+      anon_sym_SEMI,
+    STATE(61), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(239), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2226] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(247), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(249), 1,
+      anon_sym_SEMI,
+    STATE(74), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(245), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2262] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(253), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(255), 1,
+      anon_sym_SEMI,
+    STATE(88), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(251), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2298] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    STATE(96), 1,
+      sym_extending,
+    STATE(172), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(257), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2333] = 6,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    STATE(62), 1,
+      sym_extending,
+    STATE(180), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(259), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2368] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(261), 19,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2394] = 3,
+    ACTIONS(249), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(245), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2421] = 3,
+    ACTIONS(255), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(251), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2448] = 4,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    STATE(162), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(263), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2477] = 3,
+    ACTIONS(155), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(149), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2504] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(265), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2529] = 3,
+    ACTIONS(269), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(267), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2556] = 3,
+    ACTIONS(145), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(139), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2583] = 3,
+    ACTIONS(273), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(271), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2610] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(275), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2635] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(277), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2660] = 3,
+    ACTIONS(219), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(215), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2687] = 3,
+    ACTIONS(243), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(239), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2714] = 3,
+    ACTIONS(213), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(209), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2741] = 8,
+    ACTIONS(279), 1,
+      anon_sym_RBRACE,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2778] = 3,
+    ACTIONS(179), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(175), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2805] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(289), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2830] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(291), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(73), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2867] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(291), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2904] = 3,
+    ACTIONS(295), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(293), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2931] = 3,
+    ACTIONS(299), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(297), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2958] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(301), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(77), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2995] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(303), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3020] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(305), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3057] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(307), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3082] = 3,
+    ACTIONS(165), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(159), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3109] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(309), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(90), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3146] = 3,
+    ACTIONS(173), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(167), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3173] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(311), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3198] = 3,
+    ACTIONS(315), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(313), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3225] = 3,
+    ACTIONS(319), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(317), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3252] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(321), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3289] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(323), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(82), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3326] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(323), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3363] = 8,
+    ACTIONS(325), 1,
+      anon_sym_RBRACE,
+    ACTIONS(327), 1,
+      anon_sym_annotation,
+    ACTIONS(330), 1,
+      anon_sym_using,
+    ACTIONS(336), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(93), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(333), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3400] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(283), 1,
+      anon_sym_using,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(321), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(92), 5,
+      sym_annotation,
+      sym_using,
+      sym_uselang,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3437] = 3,
+    ACTIONS(341), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(339), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3464] = 4,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    STATE(166), 1,
+      sym_declarations,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(343), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3493] = 3,
+    ACTIONS(237), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(233), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3520] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(345), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3545] = 3,
+    ACTIONS(349), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(347), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3572] = 3,
+    ACTIONS(225), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(221), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3599] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(351), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3623] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(353), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3647] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(239), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3671] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(233), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3695] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(149), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3719] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(347), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3743] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(355), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3767] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(339), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3791] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(357), 1,
+      anon_sym_RBRACE,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3827] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(361), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(126), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3863] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(361), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3899] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(363), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3923] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(357), 1,
+      anon_sym_RBRACE,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(139), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3959] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(365), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3983] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(367), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(159), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4019] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(367), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4055] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(369), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4079] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(371), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4115] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(373), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4139] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(375), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4163] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(377), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4187] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(245), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4211] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(317), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4235] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(379), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(116), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4271] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(381), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4295] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(383), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4331] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(313), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4355] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(385), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4379] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(221), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4403] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(387), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4439] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(167), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4463] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(139), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4487] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(389), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4511] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(267), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4535] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(391), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4559] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(159), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4583] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(393), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4607] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(395), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(149), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4643] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(395), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4679] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(271), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4703] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(397), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4727] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(399), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4763] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(387), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(111), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4799] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(401), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4823] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(399), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(118), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4859] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(297), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4883] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(403), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4907] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(293), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4931] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(405), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4967] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(405), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(142), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5003] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(407), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5027] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(209), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5051] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(409), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5075] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(175), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5099] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(411), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(109), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5135] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(215), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5159] = 8,
+    ACTIONS(413), 1,
+      anon_sym_RBRACE,
+    ACTIONS(415), 1,
+      anon_sym_annotation,
+    ACTIONS(418), 1,
+      anon_sym_using,
+    ACTIONS(424), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(421), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5195] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(251), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5219] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(427), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5255] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(429), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5279] = 8,
+    ACTIONS(281), 1,
+      anon_sym_annotation,
+    ACTIONS(287), 1,
+      sym_identifier,
+    ACTIONS(359), 1,
+      anon_sym_using,
+    ACTIONS(427), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(217), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(130), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(285), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5315] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(431), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5338] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(433), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5361] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(435), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5384] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(437), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5407] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(439), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5430] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(441), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5453] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(443), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5476] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(445), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5499] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(447), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5522] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(449), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5545] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(343), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5568] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(451), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5591] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(453), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5614] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(455), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5637] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(457), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5660] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(459), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5683] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(461), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5706] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(463), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5729] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(263), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5752] = 7,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(465), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(467), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(193), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5783] = 7,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(469), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(471), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(196), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5814] = 7,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(473), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(475), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(198), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5845] = 6,
+    ACTIONS(479), 1,
+      anon_sym_annotation,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(477), 2,
+      anon_sym_RBRACE,
+      anon_sym_SEMI,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(482), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5874] = 7,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(485), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(487), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(194), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5905] = 4,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(186), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(489), 4,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+    ACTIONS(491), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5929] = 7,
+    ACTIONS(494), 1,
+      anon_sym_scalar,
+    ACTIONS(496), 1,
+      anon_sym_link,
+    ACTIONS(498), 1,
+      anon_sym_property,
+    ACTIONS(500), 1,
+      anon_sym_annotation,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(186), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5959] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(502), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5979] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(504), 13,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5999] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(506), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6027] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(506), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(192), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6055] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(508), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6083] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(510), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6111] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(512), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6139] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(514), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6159] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(516), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6187] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(518), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6207] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(520), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(184), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6235] = 4,
+    ACTIONS(522), 1,
+      anon_sym_type,
+    ACTIONS(526), 1,
+      anon_sym_constraint,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(524), 11,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6259] = 6,
+    ACTIONS(35), 1,
+      anon_sym_annotation,
+    ACTIONS(528), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(190), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(214), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6287] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(530), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6307] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(532), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6327] = 3,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(534), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_SEMI,
+    ACTIONS(536), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6349] = 6,
+    ACTIONS(496), 1,
+      anon_sym_link,
+    ACTIONS(498), 1,
+      anon_sym_property,
+    ACTIONS(500), 1,
+      anon_sym_annotation,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(186), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6376] = 3,
+    ACTIONS(289), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(538), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6396] = 3,
+    ACTIONS(265), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(540), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6416] = 3,
+    ACTIONS(277), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(542), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6436] = 3,
+    ACTIONS(544), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(546), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6456] = 3,
+    ACTIONS(307), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(548), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6476] = 3,
+    ACTIONS(345), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(550), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6496] = 3,
+    ACTIONS(275), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(552), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6516] = 3,
+    ACTIONS(554), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(556), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [6536] = 3,
+    ACTIONS(526), 1,
+      anon_sym_constraint,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(524), 10,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6556] = 4,
+    ACTIONS(500), 1,
+      anon_sym_annotation,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(186), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6577] = 11,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(558), 1,
+      anon_sym_LBRACE,
+    ACTIONS(560), 1,
+      anon_sym_SEMI,
+    ACTIONS(562), 1,
+      anon_sym_LPAREN,
+    ACTIONS(564), 1,
+      anon_sym_on,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    STATE(218), 1,
+      sym_argspec,
+    STATE(222), 1,
+      sym_on,
+    STATE(230), 1,
+      sym_except,
+    STATE(290), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6612] = 11,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(562), 1,
+      anon_sym_LPAREN,
+    ACTIONS(564), 1,
+      anon_sym_on,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(568), 1,
+      anon_sym_LBRACE,
+    ACTIONS(570), 1,
+      anon_sym_SEMI,
+    STATE(219), 1,
+      sym_argspec,
+    STATE(224), 1,
+      sym_on,
+    STATE(242), 1,
+      sym_except,
+    STATE(298), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6647] = 4,
+    ACTIONS(572), 1,
+      anon_sym_annotation,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(186), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(43), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6668] = 9,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(564), 1,
+      anon_sym_on,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(574), 1,
+      anon_sym_LBRACE,
+    ACTIONS(576), 1,
+      anon_sym_SEMI,
+    STATE(225), 1,
+      sym_on,
+    STATE(231), 1,
+      sym_except,
+    STATE(291), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6697] = 9,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(564), 1,
+      anon_sym_on,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(578), 1,
+      anon_sym_LBRACE,
+    ACTIONS(580), 1,
+      anon_sym_SEMI,
+    STATE(223), 1,
+      sym_on,
+    STATE(238), 1,
+      sym_except,
+    STATE(311), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6726] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(582), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [6739] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(584), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [6752] = 7,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(574), 1,
+      anon_sym_LBRACE,
+    ACTIONS(576), 1,
+      anon_sym_SEMI,
+    STATE(231), 1,
+      sym_except,
+    STATE(291), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6775] = 7,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(586), 1,
+      anon_sym_LBRACE,
+    ACTIONS(588), 1,
+      anon_sym_SEMI,
+    STATE(228), 1,
+      sym_except,
+    STATE(294), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6798] = 7,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(578), 1,
+      anon_sym_LBRACE,
+    ACTIONS(580), 1,
+      anon_sym_SEMI,
+    STATE(238), 1,
+      sym_except,
+    STATE(311), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6821] = 7,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(590), 1,
+      anon_sym_LBRACE,
+    ACTIONS(592), 1,
+      anon_sym_SEMI,
+    STATE(239), 1,
+      sym_except,
+    STATE(288), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6844] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(594), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [6857] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(596), 6,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [6870] = 5,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(598), 1,
+      anon_sym_LBRACE,
+    ACTIONS(600), 1,
+      anon_sym_SEMI,
+    STATE(306), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6887] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(602), 4,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_except,
+  [6898] = 5,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(574), 1,
+      anon_sym_LBRACE,
+    ACTIONS(576), 1,
+      anon_sym_SEMI,
+    STATE(291), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6915] = 5,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(590), 1,
+      anon_sym_LBRACE,
+    ACTIONS(592), 1,
+      anon_sym_SEMI,
+    STATE(288), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6932] = 5,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    STATE(177), 1,
+      sym_declarations,
+    STATE(301), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6949] = 5,
+    ACTIONS(604), 1,
+      anon_sym_LBRACE,
+    ACTIONS(606), 1,
+      anon_sym_SEMI,
+    ACTIONS(608), 1,
+      anon_sym_using,
+    STATE(300), 1,
+      sym_uselang,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6966] = 5,
+    ACTIONS(610), 1,
+      anon_sym_LBRACE,
+    ACTIONS(612), 1,
+      anon_sym_SEMI,
+    ACTIONS(614), 1,
+      anon_sym_using,
+    STATE(309), 1,
+      sym_uselang,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [6983] = 5,
+    ACTIONS(566), 1,
+      anon_sym_except,
+    ACTIONS(616), 1,
+      anon_sym_LBRACE,
+    ACTIONS(618), 1,
+      anon_sym_SEMI,
+    STATE(293), 1,
+      sym_except,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7000] = 4,
     ACTIONS(7), 1,
       anon_sym_module,
-    ACTIONS(89), 1,
+    ACTIONS(620), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(30), 2,
+    STATE(241), 2,
       sym_module,
       aux_sym_source_file_repeat1,
-  [783] = 4,
-    ACTIONS(91), 1,
+  [7015] = 5,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    STATE(175), 1,
+      sym_declarations,
+    STATE(297), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7032] = 5,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(586), 1,
+      anon_sym_LBRACE,
+    ACTIONS(588), 1,
+      anon_sym_SEMI,
+    STATE(294), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7049] = 5,
+    ACTIONS(86), 1,
+      anon_sym_extending,
+    ACTIONS(622), 1,
+      anon_sym_LBRACE,
+    ACTIONS(624), 1,
+      anon_sym_SEMI,
+    STATE(314), 1,
+      sym_extending,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7066] = 5,
+    ACTIONS(626), 1,
+      anon_sym_RPAREN,
+    ACTIONS(628), 1,
+      anon_sym_COMMA,
+    ACTIONS(630), 1,
+      anon_sym_COLON,
+    STATE(246), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7083] = 4,
+    ACTIONS(632), 1,
       ts_builtin_sym_end,
-    ACTIONS(93), 1,
+    ACTIONS(634), 1,
       anon_sym_module,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    STATE(30), 2,
+    STATE(241), 2,
       sym_module,
       aux_sym_source_file_repeat1,
-  [798] = 5,
-    ACTIONS(85), 1,
-      anon_sym_LBRACE,
-    ACTIONS(87), 1,
+  [7098] = 5,
+    ACTIONS(86), 1,
       anon_sym_extending,
-    STATE(26), 1,
-      sym_declarations,
-    STATE(50), 1,
-      sym_extends,
+    ACTIONS(578), 1,
+      anon_sym_LBRACE,
+    ACTIONS(580), 1,
+      anon_sym_SEMI,
+    STATE(311), 1,
+      sym_extending,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [815] = 3,
-    ACTIONS(98), 1,
+  [7115] = 3,
+    STATE(377), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7127] = 3,
+    STATE(380), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7139] = 3,
+    STATE(88), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7151] = 4,
+    ACTIONS(628), 1,
+      anon_sym_COMMA,
+    ACTIONS(639), 1,
+      anon_sym_RPAREN,
+    STATE(254), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7165] = 3,
+    STATE(72), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7177] = 3,
+    STATE(89), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7189] = 3,
+    STATE(67), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7201] = 3,
+    STATE(70), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7213] = 4,
+    ACTIONS(641), 1,
+      anon_sym_COMMA,
+    ACTIONS(644), 1,
+      anon_sym_GT,
+    STATE(251), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7227] = 3,
+    STATE(65), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7239] = 4,
+    ACTIONS(646), 1,
+      anon_sym_COMMA,
+    ACTIONS(648), 1,
+      anon_sym_GT,
+    STATE(279), 1,
+      aux_sym__named_tuple_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7253] = 4,
+    ACTIONS(650), 1,
+      anon_sym_RPAREN,
+    ACTIONS(652), 1,
+      anon_sym_COMMA,
+    STATE(254), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7267] = 4,
+    ACTIONS(628), 1,
+      anon_sym_COMMA,
+    ACTIONS(655), 1,
+      anon_sym_RPAREN,
+    STATE(268), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7281] = 3,
+    ACTIONS(657), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(96), 2,
+    ACTIONS(650), 2,
+      anon_sym_RPAREN,
       anon_sym_COMMA,
-      anon_sym_GT,
-  [827] = 4,
-    ACTIONS(100), 1,
-      anon_sym_COMMA,
-    ACTIONS(102), 1,
-      anon_sym_GT,
-    STATE(45), 1,
-      aux_sym__named_tuple_repeat1,
+  [7293] = 3,
+    STATE(369), 1,
+      sym_expr,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [841] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(104), 3,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7305] = 4,
+    ACTIONS(659), 1,
       anon_sym_COMMA,
-      anon_sym_SEMI,
+    ACTIONS(661), 1,
       anon_sym_GT,
-  [851] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(106), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_GT,
-  [861] = 4,
-    ACTIONS(108), 1,
-      anon_sym_COMMA,
-    ACTIONS(110), 1,
-      anon_sym_GT,
-    STATE(38), 1,
+    STATE(278), 1,
       aux_sym__tuple_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [875] = 4,
-    ACTIONS(112), 1,
+  [7319] = 4,
+    ACTIONS(663), 1,
       anon_sym_COMMA,
-    ACTIONS(115), 1,
+    ACTIONS(665), 1,
       anon_sym_GT,
-    STATE(37), 1,
+    STATE(277), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7333] = 3,
+    STATE(100), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7345] = 3,
+    STATE(378), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7357] = 3,
+    STATE(354), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7369] = 3,
+    STATE(79), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7381] = 3,
+    STATE(78), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7393] = 4,
+    ACTIONS(659), 1,
+      anon_sym_COMMA,
+    ACTIONS(667), 1,
+      anon_sym_GT,
+    STATE(258), 1,
       aux_sym__tuple_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [889] = 4,
-    ACTIONS(108), 1,
+  [7407] = 3,
+    STATE(376), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7419] = 3,
+    ACTIONS(669), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(100), 2,
       anon_sym_COMMA,
-    ACTIONS(117), 1,
       anon_sym_GT,
-    STATE(37), 1,
+  [7431] = 4,
+    ACTIONS(628), 1,
+      anon_sym_COMMA,
+    ACTIONS(671), 1,
+      anon_sym_RPAREN,
+    STATE(254), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7445] = 3,
+    STATE(74), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7457] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(673), 3,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_extending,
+  [7467] = 3,
+    STATE(97), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7479] = 3,
+    STATE(388), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7491] = 3,
+    STATE(336), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7503] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(675), 3,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_using,
+  [7513] = 3,
+    STATE(385), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7525] = 3,
+    STATE(60), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7537] = 4,
+    ACTIONS(663), 1,
+      anon_sym_COMMA,
+    ACTIONS(677), 1,
+      anon_sym_GT,
+    STATE(251), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7551] = 4,
+    ACTIONS(679), 1,
+      anon_sym_COMMA,
+    ACTIONS(682), 1,
+      anon_sym_GT,
+    STATE(278), 1,
       aux_sym__tuple_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [903] = 4,
-    ACTIONS(119), 1,
-      anon_sym_LBRACE,
-    ACTIONS(121), 1,
+  [7565] = 4,
+    ACTIONS(684), 1,
       anon_sym_COMMA,
-    STATE(42), 1,
-      aux_sym_extends_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [917] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(123), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
+    ACTIONS(687), 1,
       anon_sym_GT,
-  [927] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(125), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_GT,
-  [937] = 4,
-    ACTIONS(127), 1,
-      anon_sym_LBRACE,
-    ACTIONS(129), 1,
-      anon_sym_COMMA,
-    STATE(42), 1,
-      aux_sym_extends_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [951] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(96), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_GT,
-  [961] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(132), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_GT,
-  [971] = 4,
-    ACTIONS(100), 1,
-      anon_sym_COMMA,
-    ACTIONS(134), 1,
-      anon_sym_GT,
-    STATE(48), 1,
+    STATE(279), 1,
       aux_sym__named_tuple_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [985] = 4,
-    ACTIONS(121), 1,
+  [7579] = 4,
+    ACTIONS(646), 1,
       anon_sym_COMMA,
-    ACTIONS(136), 1,
-      anon_sym_LBRACE,
-    STATE(39), 1,
-      aux_sym_extends_repeat1,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [999] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(138), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
+    ACTIONS(689), 1,
       anon_sym_GT,
-  [1009] = 4,
-    ACTIONS(140), 1,
-      anon_sym_COMMA,
-    ACTIONS(143), 1,
-      anon_sym_GT,
-    STATE(48), 1,
+    STATE(253), 1,
       aux_sym__named_tuple_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1023] = 3,
-    ACTIONS(85), 1,
+  [7593] = 3,
+    STATE(386), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7605] = 3,
+    STATE(61), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7617] = 3,
+    STATE(71), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7629] = 3,
+    STATE(99), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7641] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(691), 3,
       anon_sym_LBRACE,
-    STATE(26), 1,
+      anon_sym_SEMI,
+      anon_sym_using,
+  [7651] = 4,
+    ACTIONS(562), 1,
+      anon_sym_LPAREN,
+    ACTIONS(693), 1,
+      anon_sym_RPAREN,
+    STATE(370), 1,
+      sym_argspec,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7665] = 3,
+    STATE(95), 1,
+      sym_expr,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(637), 2,
+      sym_str,
+      sym_identifier,
+  [7677] = 3,
+    ACTIONS(622), 1,
+      anon_sym_LBRACE,
+    ACTIONS(624), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7688] = 3,
+    ACTIONS(695), 1,
+      anon_sym_LPAREN,
+    ACTIONS(697), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7699] = 3,
+    ACTIONS(574), 1,
+      anon_sym_LBRACE,
+    ACTIONS(576), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7710] = 3,
+    ACTIONS(590), 1,
+      anon_sym_LBRACE,
+    ACTIONS(592), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7721] = 3,
+    ACTIONS(699), 1,
+      anon_sym_LBRACE,
+    ACTIONS(701), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7732] = 3,
+    ACTIONS(703), 1,
+      anon_sym_LBRACE,
+    ACTIONS(705), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7743] = 3,
+    ACTIONS(598), 1,
+      anon_sym_LBRACE,
+    ACTIONS(600), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7754] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(682), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [7763] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(707), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [7772] = 3,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    STATE(179), 1,
       sym_declarations,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1034] = 3,
-    ACTIONS(85), 1,
+  [7783] = 3,
+    ACTIONS(578), 1,
       anon_sym_LBRACE,
-    STATE(25), 1,
+    ACTIONS(580), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7794] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(709), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [7803] = 3,
+    ACTIONS(610), 1,
+      anon_sym_LBRACE,
+    ACTIONS(612), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7814] = 3,
+    ACTIONS(76), 1,
+      anon_sym_LBRACE,
+    STATE(174), 1,
       sym_declarations,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1045] = 2,
+  [7825] = 2,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(145), 2,
+    ACTIONS(711), 2,
       anon_sym_COMMA,
       anon_sym_GT,
-  [1054] = 3,
-    ACTIONS(147), 1,
+  [7834] = 3,
+    ACTIONS(697), 1,
+      sym_identifier,
+    ACTIONS(713), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7845] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(715), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [7854] = 3,
+    ACTIONS(717), 1,
       anon_sym_LBRACE,
-    STATE(54), 1,
+    ACTIONS(719), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7865] = 3,
+    ACTIONS(721), 1,
+      anon_sym_LBRACE,
+    ACTIONS(723), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7876] = 3,
+    ACTIONS(725), 1,
+      anon_sym_LBRACE,
+    ACTIONS(727), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7887] = 3,
+    ACTIONS(564), 1,
+      anon_sym_on,
+    STATE(235), 1,
+      sym_on,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7898] = 3,
+    ACTIONS(729), 1,
+      anon_sym_LBRACE,
+    ACTIONS(731), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7909] = 3,
+    ACTIONS(697), 1,
+      sym_identifier,
+    ACTIONS(733), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7920] = 3,
+    ACTIONS(586), 1,
+      anon_sym_LBRACE,
+    ACTIONS(588), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [7931] = 2,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(644), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [7940] = 3,
+    ACTIONS(735), 1,
+      anon_sym_LBRACE,
+    STATE(299), 1,
       sym_schema_declarations,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1065] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(127), 2,
+  [7951] = 3,
+    ACTIONS(737), 1,
       anon_sym_LBRACE,
-      anon_sym_COMMA,
-  [1074] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(149), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [1083] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(151), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [1092] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(153), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [1101] = 2,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(115), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [1110] = 2,
-    ACTIONS(155), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1118] = 2,
-    ACTIONS(157), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1126] = 2,
-    ACTIONS(159), 1,
+    ACTIONS(739), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1134] = 2,
-    ACTIONS(161), 1,
-      anon_sym_GT,
+  [7962] = 2,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1142] = 2,
-    ACTIONS(163), 1,
-      sym_identifier,
+    ACTIONS(741), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [7971] = 2,
+    ACTIONS(743), 1,
+      anon_sym_edgedb,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1150] = 2,
-    ACTIONS(165), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1158] = 2,
-    ACTIONS(167), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1166] = 2,
-    ACTIONS(169), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1174] = 2,
-    ACTIONS(171), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1182] = 2,
-    ACTIONS(173), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1190] = 2,
-    ACTIONS(175), 1,
+  [7979] = 2,
+    ACTIONS(727), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1198] = 2,
-    ACTIONS(177), 1,
+  [7987] = 2,
+    ACTIONS(745), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1206] = 2,
-    ACTIONS(179), 1,
+  [7995] = 2,
+    ACTIONS(747), 1,
+      anon_sym_edgedb,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8003] = 2,
+    ACTIONS(749), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1214] = 2,
-    ACTIONS(181), 1,
+  [8011] = 2,
+    ACTIONS(751), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1222] = 2,
-    ACTIONS(183), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(3), 2,
-      sym_comment,
-      sym__whitespace,
-  [1230] = 2,
-    ACTIONS(185), 1,
+  [8019] = 2,
+    ACTIONS(753), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1238] = 2,
-    ACTIONS(187), 1,
+  [8027] = 2,
+    ACTIONS(755), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8035] = 2,
+    ACTIONS(757), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1246] = 2,
-    ACTIONS(189), 1,
+  [8043] = 2,
+    ACTIONS(759), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1254] = 2,
-    ACTIONS(191), 1,
+  [8051] = 2,
+    ACTIONS(761), 1,
+      anon_sym_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8059] = 2,
+    ACTIONS(763), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8067] = 2,
+    ACTIONS(733), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8075] = 2,
+    ACTIONS(588), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8083] = 2,
+    ACTIONS(765), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1262] = 2,
-    ACTIONS(193), 1,
+  [8091] = 2,
+    ACTIONS(767), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8099] = 2,
+    ACTIONS(769), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8107] = 2,
+    ACTIONS(771), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8115] = 2,
+    ACTIONS(773), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8123] = 2,
+    ACTIONS(775), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8131] = 2,
+    ACTIONS(777), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8139] = 2,
+    ACTIONS(779), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8147] = 2,
+    ACTIONS(781), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8155] = 2,
+    ACTIONS(783), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8163] = 2,
+    ACTIONS(785), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8171] = 2,
+    ACTIONS(787), 1,
+      anon_sym_enum,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8179] = 2,
+    ACTIONS(789), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1270] = 2,
-    ACTIONS(195), 1,
+  [8187] = 2,
+    ACTIONS(791), 1,
+      anon_sym_LT,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8195] = 2,
+    ACTIONS(793), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8203] = 2,
+    ACTIONS(795), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8211] = 2,
+    ACTIONS(797), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8219] = 2,
+    ACTIONS(799), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8227] = 2,
+    ACTIONS(592), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8235] = 2,
+    ACTIONS(801), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1278] = 2,
-    ACTIONS(197), 1,
+  [8243] = 2,
+    ACTIONS(600), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8251] = 2,
+    ACTIONS(624), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8259] = 2,
+    ACTIONS(803), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1286] = 2,
-    ACTIONS(199), 1,
+  [8267] = 2,
+    ACTIONS(805), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1294] = 2,
-    ACTIONS(201), 1,
+  [8275] = 2,
+    ACTIONS(807), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8283] = 2,
+    ACTIONS(731), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8291] = 2,
+    ACTIONS(809), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8299] = 2,
+    ACTIONS(811), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8307] = 2,
+    ACTIONS(813), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8315] = 2,
+    ACTIONS(815), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8323] = 2,
+    ACTIONS(817), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-  [1302] = 2,
-    ACTIONS(203), 1,
+  [8331] = 2,
+    ACTIONS(819), 1,
       anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8339] = 2,
+    ACTIONS(821), 1,
+      anon_sym_using,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8347] = 2,
+    ACTIONS(823), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8355] = 2,
+    ACTIONS(719), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8363] = 2,
+    ACTIONS(825), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8371] = 2,
+    ACTIONS(827), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8379] = 2,
+    ACTIONS(829), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8387] = 2,
+    ACTIONS(723), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8395] = 2,
+    ACTIONS(831), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8403] = 2,
+    ACTIONS(833), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8411] = 2,
+    ACTIONS(835), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8419] = 2,
+    ACTIONS(837), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8427] = 2,
+    ACTIONS(839), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8435] = 2,
+    ACTIONS(841), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8443] = 2,
+    ACTIONS(843), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8451] = 2,
+    ACTIONS(845), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8459] = 2,
+    ACTIONS(847), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8467] = 2,
+    ACTIONS(849), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8475] = 2,
+    ACTIONS(851), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8483] = 2,
+    ACTIONS(853), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8491] = 2,
+    ACTIONS(855), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8499] = 2,
+    ACTIONS(857), 1,
+      anon_sym_GT,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8507] = 2,
+    ACTIONS(739), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8515] = 2,
+    ACTIONS(859), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8523] = 2,
+    ACTIONS(861), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8531] = 2,
+    ACTIONS(863), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8539] = 2,
+    ACTIONS(865), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8547] = 2,
+    ACTIONS(867), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8555] = 2,
+    ACTIONS(869), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8563] = 2,
+    ACTIONS(871), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8571] = 2,
+    ACTIONS(873), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8579] = 2,
+    ACTIONS(875), 1,
+      anon_sym_type,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+  [8587] = 2,
+    ACTIONS(877), 1,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
@@ -3616,86 +11309,397 @@ static const uint16_t ts_small_parse_table[] = {
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 48,
-  [SMALL_STATE(4)] = 98,
-  [SMALL_STATE(5)] = 146,
-  [SMALL_STATE(6)] = 194,
-  [SMALL_STATE(7)] = 242,
-  [SMALL_STATE(8)] = 290,
-  [SMALL_STATE(9)] = 338,
-  [SMALL_STATE(10)] = 370,
-  [SMALL_STATE(11)] = 402,
-  [SMALL_STATE(12)] = 434,
-  [SMALL_STATE(13)] = 462,
-  [SMALL_STATE(14)] = 490,
-  [SMALL_STATE(15)] = 518,
-  [SMALL_STATE(16)] = 541,
-  [SMALL_STATE(17)] = 565,
-  [SMALL_STATE(18)] = 582,
-  [SMALL_STATE(19)] = 599,
-  [SMALL_STATE(20)] = 616,
-  [SMALL_STATE(21)] = 637,
-  [SMALL_STATE(22)] = 654,
-  [SMALL_STATE(23)] = 671,
-  [SMALL_STATE(24)] = 687,
-  [SMALL_STATE(25)] = 703,
-  [SMALL_STATE(26)] = 719,
-  [SMALL_STATE(27)] = 735,
-  [SMALL_STATE(28)] = 751,
-  [SMALL_STATE(29)] = 768,
-  [SMALL_STATE(30)] = 783,
-  [SMALL_STATE(31)] = 798,
-  [SMALL_STATE(32)] = 815,
-  [SMALL_STATE(33)] = 827,
-  [SMALL_STATE(34)] = 841,
-  [SMALL_STATE(35)] = 851,
-  [SMALL_STATE(36)] = 861,
-  [SMALL_STATE(37)] = 875,
-  [SMALL_STATE(38)] = 889,
-  [SMALL_STATE(39)] = 903,
-  [SMALL_STATE(40)] = 917,
-  [SMALL_STATE(41)] = 927,
-  [SMALL_STATE(42)] = 937,
-  [SMALL_STATE(43)] = 951,
-  [SMALL_STATE(44)] = 961,
-  [SMALL_STATE(45)] = 971,
-  [SMALL_STATE(46)] = 985,
-  [SMALL_STATE(47)] = 999,
-  [SMALL_STATE(48)] = 1009,
-  [SMALL_STATE(49)] = 1023,
-  [SMALL_STATE(50)] = 1034,
-  [SMALL_STATE(51)] = 1045,
-  [SMALL_STATE(52)] = 1054,
-  [SMALL_STATE(53)] = 1065,
-  [SMALL_STATE(54)] = 1074,
-  [SMALL_STATE(55)] = 1083,
-  [SMALL_STATE(56)] = 1092,
-  [SMALL_STATE(57)] = 1101,
-  [SMALL_STATE(58)] = 1110,
-  [SMALL_STATE(59)] = 1118,
-  [SMALL_STATE(60)] = 1126,
-  [SMALL_STATE(61)] = 1134,
-  [SMALL_STATE(62)] = 1142,
-  [SMALL_STATE(63)] = 1150,
-  [SMALL_STATE(64)] = 1158,
-  [SMALL_STATE(65)] = 1166,
-  [SMALL_STATE(66)] = 1174,
-  [SMALL_STATE(67)] = 1182,
-  [SMALL_STATE(68)] = 1190,
-  [SMALL_STATE(69)] = 1198,
-  [SMALL_STATE(70)] = 1206,
-  [SMALL_STATE(71)] = 1214,
-  [SMALL_STATE(72)] = 1222,
-  [SMALL_STATE(73)] = 1230,
-  [SMALL_STATE(74)] = 1238,
-  [SMALL_STATE(75)] = 1246,
-  [SMALL_STATE(76)] = 1254,
-  [SMALL_STATE(77)] = 1262,
-  [SMALL_STATE(78)] = 1270,
-  [SMALL_STATE(79)] = 1278,
-  [SMALL_STATE(80)] = 1286,
-  [SMALL_STATE(81)] = 1294,
-  [SMALL_STATE(82)] = 1302,
+  [SMALL_STATE(3)] = 57,
+  [SMALL_STATE(4)] = 114,
+  [SMALL_STATE(5)] = 166,
+  [SMALL_STATE(6)] = 218,
+  [SMALL_STATE(7)] = 266,
+  [SMALL_STATE(8)] = 314,
+  [SMALL_STATE(9)] = 362,
+  [SMALL_STATE(10)] = 410,
+  [SMALL_STATE(11)] = 458,
+  [SMALL_STATE(12)] = 506,
+  [SMALL_STATE(13)] = 554,
+  [SMALL_STATE(14)] = 604,
+  [SMALL_STATE(15)] = 652,
+  [SMALL_STATE(16)] = 700,
+  [SMALL_STATE(17)] = 748,
+  [SMALL_STATE(18)] = 796,
+  [SMALL_STATE(19)] = 844,
+  [SMALL_STATE(20)] = 892,
+  [SMALL_STATE(21)] = 950,
+  [SMALL_STATE(22)] = 1008,
+  [SMALL_STATE(23)] = 1066,
+  [SMALL_STATE(24)] = 1111,
+  [SMALL_STATE(25)] = 1156,
+  [SMALL_STATE(26)] = 1187,
+  [SMALL_STATE(27)] = 1218,
+  [SMALL_STATE(28)] = 1249,
+  [SMALL_STATE(29)] = 1294,
+  [SMALL_STATE(30)] = 1325,
+  [SMALL_STATE(31)] = 1356,
+  [SMALL_STATE(32)] = 1387,
+  [SMALL_STATE(33)] = 1418,
+  [SMALL_STATE(34)] = 1463,
+  [SMALL_STATE(35)] = 1497,
+  [SMALL_STATE(36)] = 1531,
+  [SMALL_STATE(37)] = 1565,
+  [SMALL_STATE(38)] = 1594,
+  [SMALL_STATE(39)] = 1633,
+  [SMALL_STATE(40)] = 1662,
+  [SMALL_STATE(41)] = 1701,
+  [SMALL_STATE(42)] = 1730,
+  [SMALL_STATE(43)] = 1769,
+  [SMALL_STATE(44)] = 1808,
+  [SMALL_STATE(45)] = 1844,
+  [SMALL_STATE(46)] = 1890,
+  [SMALL_STATE(47)] = 1936,
+  [SMALL_STATE(48)] = 1968,
+  [SMALL_STATE(49)] = 2004,
+  [SMALL_STATE(50)] = 2040,
+  [SMALL_STATE(51)] = 2076,
+  [SMALL_STATE(52)] = 2122,
+  [SMALL_STATE(53)] = 2154,
+  [SMALL_STATE(54)] = 2190,
+  [SMALL_STATE(55)] = 2226,
+  [SMALL_STATE(56)] = 2262,
+  [SMALL_STATE(57)] = 2298,
+  [SMALL_STATE(58)] = 2333,
+  [SMALL_STATE(59)] = 2368,
+  [SMALL_STATE(60)] = 2394,
+  [SMALL_STATE(61)] = 2421,
+  [SMALL_STATE(62)] = 2448,
+  [SMALL_STATE(63)] = 2477,
+  [SMALL_STATE(64)] = 2504,
+  [SMALL_STATE(65)] = 2529,
+  [SMALL_STATE(66)] = 2556,
+  [SMALL_STATE(67)] = 2583,
+  [SMALL_STATE(68)] = 2610,
+  [SMALL_STATE(69)] = 2635,
+  [SMALL_STATE(70)] = 2660,
+  [SMALL_STATE(71)] = 2687,
+  [SMALL_STATE(72)] = 2714,
+  [SMALL_STATE(73)] = 2741,
+  [SMALL_STATE(74)] = 2778,
+  [SMALL_STATE(75)] = 2805,
+  [SMALL_STATE(76)] = 2830,
+  [SMALL_STATE(77)] = 2867,
+  [SMALL_STATE(78)] = 2904,
+  [SMALL_STATE(79)] = 2931,
+  [SMALL_STATE(80)] = 2958,
+  [SMALL_STATE(81)] = 2995,
+  [SMALL_STATE(82)] = 3020,
+  [SMALL_STATE(83)] = 3057,
+  [SMALL_STATE(84)] = 3082,
+  [SMALL_STATE(85)] = 3109,
+  [SMALL_STATE(86)] = 3146,
+  [SMALL_STATE(87)] = 3173,
+  [SMALL_STATE(88)] = 3198,
+  [SMALL_STATE(89)] = 3225,
+  [SMALL_STATE(90)] = 3252,
+  [SMALL_STATE(91)] = 3289,
+  [SMALL_STATE(92)] = 3326,
+  [SMALL_STATE(93)] = 3363,
+  [SMALL_STATE(94)] = 3400,
+  [SMALL_STATE(95)] = 3437,
+  [SMALL_STATE(96)] = 3464,
+  [SMALL_STATE(97)] = 3493,
+  [SMALL_STATE(98)] = 3520,
+  [SMALL_STATE(99)] = 3545,
+  [SMALL_STATE(100)] = 3572,
+  [SMALL_STATE(101)] = 3599,
+  [SMALL_STATE(102)] = 3623,
+  [SMALL_STATE(103)] = 3647,
+  [SMALL_STATE(104)] = 3671,
+  [SMALL_STATE(105)] = 3695,
+  [SMALL_STATE(106)] = 3719,
+  [SMALL_STATE(107)] = 3743,
+  [SMALL_STATE(108)] = 3767,
+  [SMALL_STATE(109)] = 3791,
+  [SMALL_STATE(110)] = 3827,
+  [SMALL_STATE(111)] = 3863,
+  [SMALL_STATE(112)] = 3899,
+  [SMALL_STATE(113)] = 3923,
+  [SMALL_STATE(114)] = 3959,
+  [SMALL_STATE(115)] = 3983,
+  [SMALL_STATE(116)] = 4019,
+  [SMALL_STATE(117)] = 4055,
+  [SMALL_STATE(118)] = 4079,
+  [SMALL_STATE(119)] = 4115,
+  [SMALL_STATE(120)] = 4139,
+  [SMALL_STATE(121)] = 4163,
+  [SMALL_STATE(122)] = 4187,
+  [SMALL_STATE(123)] = 4211,
+  [SMALL_STATE(124)] = 4235,
+  [SMALL_STATE(125)] = 4271,
+  [SMALL_STATE(126)] = 4295,
+  [SMALL_STATE(127)] = 4331,
+  [SMALL_STATE(128)] = 4355,
+  [SMALL_STATE(129)] = 4379,
+  [SMALL_STATE(130)] = 4403,
+  [SMALL_STATE(131)] = 4439,
+  [SMALL_STATE(132)] = 4463,
+  [SMALL_STATE(133)] = 4487,
+  [SMALL_STATE(134)] = 4511,
+  [SMALL_STATE(135)] = 4535,
+  [SMALL_STATE(136)] = 4559,
+  [SMALL_STATE(137)] = 4583,
+  [SMALL_STATE(138)] = 4607,
+  [SMALL_STATE(139)] = 4643,
+  [SMALL_STATE(140)] = 4679,
+  [SMALL_STATE(141)] = 4703,
+  [SMALL_STATE(142)] = 4727,
+  [SMALL_STATE(143)] = 4763,
+  [SMALL_STATE(144)] = 4799,
+  [SMALL_STATE(145)] = 4823,
+  [SMALL_STATE(146)] = 4859,
+  [SMALL_STATE(147)] = 4883,
+  [SMALL_STATE(148)] = 4907,
+  [SMALL_STATE(149)] = 4931,
+  [SMALL_STATE(150)] = 4967,
+  [SMALL_STATE(151)] = 5003,
+  [SMALL_STATE(152)] = 5027,
+  [SMALL_STATE(153)] = 5051,
+  [SMALL_STATE(154)] = 5075,
+  [SMALL_STATE(155)] = 5099,
+  [SMALL_STATE(156)] = 5135,
+  [SMALL_STATE(157)] = 5159,
+  [SMALL_STATE(158)] = 5195,
+  [SMALL_STATE(159)] = 5219,
+  [SMALL_STATE(160)] = 5255,
+  [SMALL_STATE(161)] = 5279,
+  [SMALL_STATE(162)] = 5315,
+  [SMALL_STATE(163)] = 5338,
+  [SMALL_STATE(164)] = 5361,
+  [SMALL_STATE(165)] = 5384,
+  [SMALL_STATE(166)] = 5407,
+  [SMALL_STATE(167)] = 5430,
+  [SMALL_STATE(168)] = 5453,
+  [SMALL_STATE(169)] = 5476,
+  [SMALL_STATE(170)] = 5499,
+  [SMALL_STATE(171)] = 5522,
+  [SMALL_STATE(172)] = 5545,
+  [SMALL_STATE(173)] = 5568,
+  [SMALL_STATE(174)] = 5591,
+  [SMALL_STATE(175)] = 5614,
+  [SMALL_STATE(176)] = 5637,
+  [SMALL_STATE(177)] = 5660,
+  [SMALL_STATE(178)] = 5683,
+  [SMALL_STATE(179)] = 5706,
+  [SMALL_STATE(180)] = 5729,
+  [SMALL_STATE(181)] = 5752,
+  [SMALL_STATE(182)] = 5783,
+  [SMALL_STATE(183)] = 5814,
+  [SMALL_STATE(184)] = 5845,
+  [SMALL_STATE(185)] = 5874,
+  [SMALL_STATE(186)] = 5905,
+  [SMALL_STATE(187)] = 5929,
+  [SMALL_STATE(188)] = 5959,
+  [SMALL_STATE(189)] = 5979,
+  [SMALL_STATE(190)] = 5999,
+  [SMALL_STATE(191)] = 6027,
+  [SMALL_STATE(192)] = 6055,
+  [SMALL_STATE(193)] = 6083,
+  [SMALL_STATE(194)] = 6111,
+  [SMALL_STATE(195)] = 6139,
+  [SMALL_STATE(196)] = 6159,
+  [SMALL_STATE(197)] = 6187,
+  [SMALL_STATE(198)] = 6207,
+  [SMALL_STATE(199)] = 6235,
+  [SMALL_STATE(200)] = 6259,
+  [SMALL_STATE(201)] = 6287,
+  [SMALL_STATE(202)] = 6307,
+  [SMALL_STATE(203)] = 6327,
+  [SMALL_STATE(204)] = 6349,
+  [SMALL_STATE(205)] = 6376,
+  [SMALL_STATE(206)] = 6396,
+  [SMALL_STATE(207)] = 6416,
+  [SMALL_STATE(208)] = 6436,
+  [SMALL_STATE(209)] = 6456,
+  [SMALL_STATE(210)] = 6476,
+  [SMALL_STATE(211)] = 6496,
+  [SMALL_STATE(212)] = 6516,
+  [SMALL_STATE(213)] = 6536,
+  [SMALL_STATE(214)] = 6556,
+  [SMALL_STATE(215)] = 6577,
+  [SMALL_STATE(216)] = 6612,
+  [SMALL_STATE(217)] = 6647,
+  [SMALL_STATE(218)] = 6668,
+  [SMALL_STATE(219)] = 6697,
+  [SMALL_STATE(220)] = 6726,
+  [SMALL_STATE(221)] = 6739,
+  [SMALL_STATE(222)] = 6752,
+  [SMALL_STATE(223)] = 6775,
+  [SMALL_STATE(224)] = 6798,
+  [SMALL_STATE(225)] = 6821,
+  [SMALL_STATE(226)] = 6844,
+  [SMALL_STATE(227)] = 6857,
+  [SMALL_STATE(228)] = 6870,
+  [SMALL_STATE(229)] = 6887,
+  [SMALL_STATE(230)] = 6898,
+  [SMALL_STATE(231)] = 6915,
+  [SMALL_STATE(232)] = 6932,
+  [SMALL_STATE(233)] = 6949,
+  [SMALL_STATE(234)] = 6966,
+  [SMALL_STATE(235)] = 6983,
+  [SMALL_STATE(236)] = 7000,
+  [SMALL_STATE(237)] = 7015,
+  [SMALL_STATE(238)] = 7032,
+  [SMALL_STATE(239)] = 7049,
+  [SMALL_STATE(240)] = 7066,
+  [SMALL_STATE(241)] = 7083,
+  [SMALL_STATE(242)] = 7098,
+  [SMALL_STATE(243)] = 7115,
+  [SMALL_STATE(244)] = 7127,
+  [SMALL_STATE(245)] = 7139,
+  [SMALL_STATE(246)] = 7151,
+  [SMALL_STATE(247)] = 7165,
+  [SMALL_STATE(248)] = 7177,
+  [SMALL_STATE(249)] = 7189,
+  [SMALL_STATE(250)] = 7201,
+  [SMALL_STATE(251)] = 7213,
+  [SMALL_STATE(252)] = 7227,
+  [SMALL_STATE(253)] = 7239,
+  [SMALL_STATE(254)] = 7253,
+  [SMALL_STATE(255)] = 7267,
+  [SMALL_STATE(256)] = 7281,
+  [SMALL_STATE(257)] = 7293,
+  [SMALL_STATE(258)] = 7305,
+  [SMALL_STATE(259)] = 7319,
+  [SMALL_STATE(260)] = 7333,
+  [SMALL_STATE(261)] = 7345,
+  [SMALL_STATE(262)] = 7357,
+  [SMALL_STATE(263)] = 7369,
+  [SMALL_STATE(264)] = 7381,
+  [SMALL_STATE(265)] = 7393,
+  [SMALL_STATE(266)] = 7407,
+  [SMALL_STATE(267)] = 7419,
+  [SMALL_STATE(268)] = 7431,
+  [SMALL_STATE(269)] = 7445,
+  [SMALL_STATE(270)] = 7457,
+  [SMALL_STATE(271)] = 7467,
+  [SMALL_STATE(272)] = 7479,
+  [SMALL_STATE(273)] = 7491,
+  [SMALL_STATE(274)] = 7503,
+  [SMALL_STATE(275)] = 7513,
+  [SMALL_STATE(276)] = 7525,
+  [SMALL_STATE(277)] = 7537,
+  [SMALL_STATE(278)] = 7551,
+  [SMALL_STATE(279)] = 7565,
+  [SMALL_STATE(280)] = 7579,
+  [SMALL_STATE(281)] = 7593,
+  [SMALL_STATE(282)] = 7605,
+  [SMALL_STATE(283)] = 7617,
+  [SMALL_STATE(284)] = 7629,
+  [SMALL_STATE(285)] = 7641,
+  [SMALL_STATE(286)] = 7651,
+  [SMALL_STATE(287)] = 7665,
+  [SMALL_STATE(288)] = 7677,
+  [SMALL_STATE(289)] = 7688,
+  [SMALL_STATE(290)] = 7699,
+  [SMALL_STATE(291)] = 7710,
+  [SMALL_STATE(292)] = 7721,
+  [SMALL_STATE(293)] = 7732,
+  [SMALL_STATE(294)] = 7743,
+  [SMALL_STATE(295)] = 7754,
+  [SMALL_STATE(296)] = 7763,
+  [SMALL_STATE(297)] = 7772,
+  [SMALL_STATE(298)] = 7783,
+  [SMALL_STATE(299)] = 7794,
+  [SMALL_STATE(300)] = 7803,
+  [SMALL_STATE(301)] = 7814,
+  [SMALL_STATE(302)] = 7825,
+  [SMALL_STATE(303)] = 7834,
+  [SMALL_STATE(304)] = 7845,
+  [SMALL_STATE(305)] = 7854,
+  [SMALL_STATE(306)] = 7865,
+  [SMALL_STATE(307)] = 7876,
+  [SMALL_STATE(308)] = 7887,
+  [SMALL_STATE(309)] = 7898,
+  [SMALL_STATE(310)] = 7909,
+  [SMALL_STATE(311)] = 7920,
+  [SMALL_STATE(312)] = 7931,
+  [SMALL_STATE(313)] = 7940,
+  [SMALL_STATE(314)] = 7951,
+  [SMALL_STATE(315)] = 7962,
+  [SMALL_STATE(316)] = 7971,
+  [SMALL_STATE(317)] = 7979,
+  [SMALL_STATE(318)] = 7987,
+  [SMALL_STATE(319)] = 7995,
+  [SMALL_STATE(320)] = 8003,
+  [SMALL_STATE(321)] = 8011,
+  [SMALL_STATE(322)] = 8019,
+  [SMALL_STATE(323)] = 8027,
+  [SMALL_STATE(324)] = 8035,
+  [SMALL_STATE(325)] = 8043,
+  [SMALL_STATE(326)] = 8051,
+  [SMALL_STATE(327)] = 8059,
+  [SMALL_STATE(328)] = 8067,
+  [SMALL_STATE(329)] = 8075,
+  [SMALL_STATE(330)] = 8083,
+  [SMALL_STATE(331)] = 8091,
+  [SMALL_STATE(332)] = 8099,
+  [SMALL_STATE(333)] = 8107,
+  [SMALL_STATE(334)] = 8115,
+  [SMALL_STATE(335)] = 8123,
+  [SMALL_STATE(336)] = 8131,
+  [SMALL_STATE(337)] = 8139,
+  [SMALL_STATE(338)] = 8147,
+  [SMALL_STATE(339)] = 8155,
+  [SMALL_STATE(340)] = 8163,
+  [SMALL_STATE(341)] = 8171,
+  [SMALL_STATE(342)] = 8179,
+  [SMALL_STATE(343)] = 8187,
+  [SMALL_STATE(344)] = 8195,
+  [SMALL_STATE(345)] = 8203,
+  [SMALL_STATE(346)] = 8211,
+  [SMALL_STATE(347)] = 8219,
+  [SMALL_STATE(348)] = 8227,
+  [SMALL_STATE(349)] = 8235,
+  [SMALL_STATE(350)] = 8243,
+  [SMALL_STATE(351)] = 8251,
+  [SMALL_STATE(352)] = 8259,
+  [SMALL_STATE(353)] = 8267,
+  [SMALL_STATE(354)] = 8275,
+  [SMALL_STATE(355)] = 8283,
+  [SMALL_STATE(356)] = 8291,
+  [SMALL_STATE(357)] = 8299,
+  [SMALL_STATE(358)] = 8307,
+  [SMALL_STATE(359)] = 8315,
+  [SMALL_STATE(360)] = 8323,
+  [SMALL_STATE(361)] = 8331,
+  [SMALL_STATE(362)] = 8339,
+  [SMALL_STATE(363)] = 8347,
+  [SMALL_STATE(364)] = 8355,
+  [SMALL_STATE(365)] = 8363,
+  [SMALL_STATE(366)] = 8371,
+  [SMALL_STATE(367)] = 8379,
+  [SMALL_STATE(368)] = 8387,
+  [SMALL_STATE(369)] = 8395,
+  [SMALL_STATE(370)] = 8403,
+  [SMALL_STATE(371)] = 8411,
+  [SMALL_STATE(372)] = 8419,
+  [SMALL_STATE(373)] = 8427,
+  [SMALL_STATE(374)] = 8435,
+  [SMALL_STATE(375)] = 8443,
+  [SMALL_STATE(376)] = 8451,
+  [SMALL_STATE(377)] = 8459,
+  [SMALL_STATE(378)] = 8467,
+  [SMALL_STATE(379)] = 8475,
+  [SMALL_STATE(380)] = 8483,
+  [SMALL_STATE(381)] = 8491,
+  [SMALL_STATE(382)] = 8499,
+  [SMALL_STATE(383)] = 8507,
+  [SMALL_STATE(384)] = 8515,
+  [SMALL_STATE(385)] = 8523,
+  [SMALL_STATE(386)] = 8531,
+  [SMALL_STATE(387)] = 8539,
+  [SMALL_STATE(388)] = 8547,
+  [SMALL_STATE(389)] = 8555,
+  [SMALL_STATE(390)] = 8563,
+  [SMALL_STATE(391)] = 8571,
+  [SMALL_STATE(392)] = 8579,
+  [SMALL_STATE(393)] = 8587,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -3703,100 +11707,426 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
-  [21] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(19),
-  [24] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(70),
-  [27] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(69),
-  [30] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [32] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [34] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [36] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [38] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [40] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [42] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [44] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [46] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2),
-  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(76),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(19),
-  [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_object_type_repeat1, 2),
-  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_object_type_repeat1, 2), SHIFT_REPEAT(19),
-  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
-  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6),
-  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3),
-  [85] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
-  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(62),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(8),
-  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extends, 3),
-  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
-  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extends_repeat1, 2),
-  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extends_repeat1, 2), SHIFT_REPEAT(63),
-  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extends, 2),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
-  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(75),
-  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
-  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [201] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(357),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(267),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(320),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(338),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(345),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(393),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2),
+  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(320),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(326),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(330),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(333),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(334),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(338),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(345),
+  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(393),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(189),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 2, .production_id = 1),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [86] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 2, .production_id = 1),
+  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
+  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
+  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
+  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 2),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
+  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 2),
+  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6),
+  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6), SHIFT_REPEAT(5),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 3, .production_id = 5),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 2, .production_id = 3),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 5),
+  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 1),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 3),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 1),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 6),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 2),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 2),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 2),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
+  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(330),
+  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(333),
+  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(334),
+  [192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(338),
+  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(308),
+  [198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(189),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
+  [207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(304),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 1),
+  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 1),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
+  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 1),
+  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [231] = {.entry = {.count = 1, .reusable = false}}, SHIFT(255),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 1),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
+  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 2),
+  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 2),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 2),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
+  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 3, .production_id = 2),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 4),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expr, 1),
+  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 4),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 1),
+  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 1),
+  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
+  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(389),
+  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(310),
+  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
+  [287] = {.entry = {.count = 1, .reusable = false}}, SHIFT(327),
+  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
+  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 1),
+  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 1),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
+  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [307] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
+  [311] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
+  [313] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 2),
+  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 2),
+  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(317),
+  [325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_repeat1, 2),
+  [327] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(389),
+  [330] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(310),
+  [333] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(189),
+  [336] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(327),
+  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 2),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 2),
+  [345] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 8, .production_id = 2),
+  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 2),
+  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 2),
+  [355] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 2),
+  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
+  [359] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
+  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 2),
+  [365] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 1),
+  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
+  [369] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 2),
+  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
+  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 1),
+  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 8, .production_id = 1),
+  [377] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 1),
+  [379] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
+  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 2),
+  [383] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 9, .production_id = 2),
+  [387] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
+  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 1),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 9, .production_id = 2),
+  [393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 1),
+  [395] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 1),
+  [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 1),
+  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 11, .production_id = 2),
+  [405] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 2),
+  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 3, .production_id = 1),
+  [411] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
+  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_constraint_repeat1, 2),
+  [415] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(389),
+  [418] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(328),
+  [421] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(189),
+  [424] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(327),
+  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
+  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 1),
+  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 6, .production_id = 4),
+  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 7, .production_id = 1),
+  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 14, .production_id = 1),
+  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 7, .production_id = 1),
+  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 2),
+  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 12, .production_id = 1),
+  [443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 11, .production_id = 1),
+  [445] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 10, .production_id = 1),
+  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 9, .production_id = 1),
+  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 13, .production_id = 1),
+  [451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 15, .production_id = 1),
+  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5, .production_id = 2),
+  [455] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3, .production_id = 1),
+  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 5, .production_id = 1),
+  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 2),
+  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 8, .production_id = 1),
+  [463] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 1),
+  [465] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
+  [467] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [469] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
+  [471] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [473] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
+  [475] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [477] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2),
+  [479] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(334),
+  [482] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(189),
+  [485] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
+  [487] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
+  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2),
+  [491] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2), SHIFT_REPEAT(189),
+  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
+  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
+  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
+  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 5),
+  [504] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
+  [506] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
+  [508] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
+  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
+  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 4),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 6),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 1),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
+  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(335),
+  [530] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 3),
+  [532] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 7),
+  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uselang, 2, .production_id = 8),
+  [536] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_uselang, 2, .production_id = 8),
+  [538] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [540] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [542] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [544] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [546] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [550] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [552] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 5),
+  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 5),
+  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
+  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
+  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
+  [568] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [570] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
+  [574] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [576] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 6),
+  [584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 4),
+  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 3),
+  [596] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 5),
+  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_on, 4),
+  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
+  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
+  [616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
+  [622] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [624] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [626] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
+  [628] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [630] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [632] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
+  [634] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(357),
+  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
+  [641] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2), SHIFT_REPEAT(379),
+  [644] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2),
+  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(332),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [650] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2),
+  [652] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2), SHIFT_REPEAT(353),
+  [655] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
+  [657] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [659] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [661] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [663] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
+  [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [667] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [669] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
+  [673] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except, 4),
+  [675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 2),
+  [677] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [679] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(6),
+  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
+  [684] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(332),
+  [687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
+  [689] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 1),
+  [693] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [695] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
+  [697] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [699] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [701] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [703] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [705] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [707] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
+  [709] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
+  [711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
+  [713] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
+  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 4),
+  [717] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [719] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [721] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [723] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [725] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [727] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [729] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [731] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [733] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
+  [735] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [737] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [739] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [741] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
+  [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
+  [745] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [747] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
+  [749] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
+  [751] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [753] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [755] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [757] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
+  [759] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [761] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
+  [763] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [767] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
+  [771] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [773] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [775] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [777] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [779] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [781] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [783] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
+  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
+  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [791] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [793] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [795] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
+  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
+  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
+  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
+  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [817] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
+  [823] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [827] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [829] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
+  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
+  [837] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
+  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
+  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [853] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
+  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
+  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [859] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
+  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
+  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [875] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
+  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -14,15 +14,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 426
+#define STATE_COUNT 402
 #define LARGE_STATE_COUNT 2
 #define SYMBOL_COUNT 133
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 86
-#define EXTERNAL_TOKEN_COUNT 0
+#define TOKEN_COUNT 87
+#define EXTERNAL_TOKEN_COUNT 1
 #define FIELD_COUNT 6
-#define MAX_ALIAS_SEQUENCE_LENGTH 15
-#define PRODUCTION_ID_COUNT 10
+#define MAX_ALIAS_SEQUENCE_LENGTH 11
+#define PRODUCTION_ID_COUNT 11
 
 enum {
   anon_sym_module = 1,
@@ -41,91 +41,91 @@ enum {
   anon_sym_alias = 14,
   anon_sym_using = 15,
   anon_sym_function = 16,
-  anon_sym_LPAREN = 17,
-  anon_sym_RPAREN = 18,
-  anon_sym_edgedb = 19,
-  anon_sym_extension = 20,
-  anon_sym_extending = 21,
-  anon_sym_COMMA = 22,
-  anon_sym_on = 23,
-  anon_sym_except = 24,
-  anon_sym_abstract = 25,
-  anon_sym_overloaded = 26,
-  anon_sym_required = 27,
-  anon_sym_optional = 28,
-  anon_sym_single = 29,
-  anon_sym_multi = 30,
-  anon_sym_inheritable = 31,
-  anon_sym_COLON = 32,
-  anon_sym_setof = 33,
-  anon_sym_global = 34,
-  anon_sym_AMP_AMP = 35,
-  anon_sym_PIPE_PIPE = 36,
-  anon_sym_GT_GT = 37,
-  anon_sym_LT_LT = 38,
-  anon_sym_AMP = 39,
-  anon_sym_CARET = 40,
-  anon_sym_PIPE = 41,
-  anon_sym_PLUS = 42,
-  anon_sym_DASH = 43,
-  anon_sym_STAR = 44,
-  anon_sym_SLASH = 45,
-  anon_sym_PERCENT = 46,
-  anon_sym_LT = 47,
-  anon_sym_LT_EQ = 48,
-  anon_sym_EQ = 49,
-  anon_sym_BANG_EQ = 50,
-  anon_sym_GT_EQ = 51,
-  anon_sym_GT = 52,
-  anon_sym_SQUOTE = 53,
-  sym_unescaped_single_string_fragment = 54,
-  sym_escape_sequence = 55,
-  anon_sym_str = 56,
-  anon_sym_bool = 57,
-  anon_sym_int16 = 58,
-  anon_sym_int32 = 59,
-  anon_sym_int64 = 60,
-  anon_sym_float32 = 61,
-  anon_sym_float64 = 62,
-  anon_sym_bigint = 63,
-  anon_sym_decimal = 64,
-  anon_sym_json = 65,
-  anon_sym_uuid = 66,
-  anon_sym_bytes = 67,
-  anon_sym_datetime = 68,
-  anon_sym_duration = 69,
-  anon_sym_cal_COLON_COLONlocal_datetime = 70,
-  anon_sym_cal_COLON_COLONlocal_date = 71,
-  anon_sym_cal_COLON_COLONlocal_time = 72,
-  anon_sym_cal_COLON_COLONrelative_duration = 73,
-  anon_sym_sequence = 74,
-  anon_sym_anytype = 75,
-  anon_sym_array = 76,
-  anon_sym_tuple = 77,
-  anon_sym_scalartype = 78,
-  anon_sym_enum = 79,
-  sym_identifier = 80,
-  sym_true = 81,
-  sym_false = 82,
-  sym_null = 83,
+  anon_sym_extension = 17,
+  anon_sym_extending = 18,
+  anon_sym_COMMA = 19,
+  anon_sym_LPAREN = 20,
+  anon_sym_RPAREN = 21,
+  anon_sym_on = 22,
+  anon_sym_except = 23,
+  anon_sym_abstract = 24,
+  anon_sym_overloaded = 25,
+  anon_sym_required = 26,
+  anon_sym_optional = 27,
+  anon_sym_single = 28,
+  anon_sym_multi = 29,
+  anon_sym_inheritable = 30,
+  anon_sym_COLON = 31,
+  anon_sym_setof = 32,
+  anon_sym_global = 33,
+  anon_sym_AMP_AMP = 34,
+  anon_sym_PIPE_PIPE = 35,
+  anon_sym_GT_GT = 36,
+  anon_sym_LT_LT = 37,
+  anon_sym_AMP = 38,
+  anon_sym_CARET = 39,
+  anon_sym_PIPE = 40,
+  anon_sym_PLUS = 41,
+  anon_sym_DASH = 42,
+  anon_sym_STAR = 43,
+  anon_sym_SLASH = 44,
+  anon_sym_PERCENT = 45,
+  anon_sym_LT = 46,
+  anon_sym_LT_EQ = 47,
+  anon_sym_EQ = 48,
+  anon_sym_BANG_EQ = 49,
+  anon_sym_GT_EQ = 50,
+  anon_sym_GT = 51,
+  anon_sym_SQUOTE = 52,
+  sym_unescaped_single_string_fragment = 53,
+  sym_escape_sequence = 54,
+  anon_sym_str = 55,
+  anon_sym_bool = 56,
+  anon_sym_int16 = 57,
+  anon_sym_int32 = 58,
+  anon_sym_int64 = 59,
+  anon_sym_float32 = 60,
+  anon_sym_float64 = 61,
+  anon_sym_bigint = 62,
+  anon_sym_decimal = 63,
+  anon_sym_json = 64,
+  anon_sym_uuid = 65,
+  anon_sym_bytes = 66,
+  anon_sym_datetime = 67,
+  anon_sym_duration = 68,
+  anon_sym_cal_COLON_COLONlocal_datetime = 69,
+  anon_sym_cal_COLON_COLONlocal_date = 70,
+  anon_sym_cal_COLON_COLONlocal_time = 71,
+  anon_sym_cal_COLON_COLONrelative_duration = 72,
+  anon_sym_sequence = 73,
+  anon_sym_anytype = 74,
+  anon_sym_array = 75,
+  anon_sym_tuple = 76,
+  anon_sym_scalartype = 77,
+  anon_sym_enum = 78,
+  sym_identifier = 79,
+  sym_true = 80,
+  sym_false = 81,
+  sym_null = 82,
+  sym_number = 83,
   sym_comment = 84,
   sym__whitespace = 85,
-  sym_source_file = 86,
-  sym_module = 87,
-  sym_schema_declarations = 88,
-  sym_object_type = 89,
-  sym_declarations = 90,
-  sym_scalar_type_def = 91,
-  sym_link = 92,
-  sym_property = 93,
-  sym_annotation = 94,
-  sym_constraint = 95,
-  sym_index = 96,
-  sym_alias = 97,
-  sym_function = 98,
-  sym_extending = 99,
-  sym_using = 100,
-  sym_uselang = 101,
+  sym__edgeql_chars = 86,
+  sym_source_file = 87,
+  sym_module = 88,
+  sym_schema_declarations = 89,
+  sym_object_type = 90,
+  sym_declarations = 91,
+  sym_scalar_type_def = 92,
+  sym_link = 93,
+  sym_property = 94,
+  sym_annotation = 95,
+  sym_constraint = 96,
+  sym_index = 97,
+  sym_alias = 98,
+  sym_function = 99,
+  sym_extending = 100,
+  sym_using = 101,
   sym_on = 102,
   sym_except = 103,
   sym_computed = 104,
@@ -177,12 +177,11 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_alias] = "alias",
   [anon_sym_using] = "using",
   [anon_sym_function] = "function",
-  [anon_sym_LPAREN] = "(",
-  [anon_sym_RPAREN] = ")",
-  [anon_sym_edgedb] = "edgedb",
   [anon_sym_extension] = "extension",
   [anon_sym_extending] = "extending",
   [anon_sym_COMMA] = ",",
+  [anon_sym_LPAREN] = "(",
+  [anon_sym_RPAREN] = ")",
   [anon_sym_on] = "on",
   [anon_sym_except] = "except",
   [anon_sym_abstract] = "abstract",
@@ -244,8 +243,10 @@ static const char * const ts_symbol_names[] = {
   [sym_true] = "true",
   [sym_false] = "false",
   [sym_null] = "null",
+  [sym_number] = "number",
   [sym_comment] = "comment",
   [sym__whitespace] = "_whitespace",
+  [sym__edgeql_chars] = "edgeql_fragment",
   [sym_source_file] = "source_file",
   [sym_module] = "module",
   [sym_schema_declarations] = "schema_declarations",
@@ -261,7 +262,6 @@ static const char * const ts_symbol_names[] = {
   [sym_function] = "function",
   [sym_extending] = "extending",
   [sym_using] = "using",
-  [sym_uselang] = "uselang",
   [sym_on] = "on",
   [sym_except] = "except",
   [sym_computed] = "computed",
@@ -313,12 +313,11 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_alias] = anon_sym_alias,
   [anon_sym_using] = anon_sym_using,
   [anon_sym_function] = anon_sym_function,
-  [anon_sym_LPAREN] = anon_sym_LPAREN,
-  [anon_sym_RPAREN] = anon_sym_RPAREN,
-  [anon_sym_edgedb] = anon_sym_edgedb,
   [anon_sym_extension] = anon_sym_extension,
   [anon_sym_extending] = anon_sym_extending,
   [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
   [anon_sym_on] = anon_sym_on,
   [anon_sym_except] = anon_sym_except,
   [anon_sym_abstract] = anon_sym_abstract,
@@ -380,8 +379,10 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_true] = sym_true,
   [sym_false] = sym_false,
   [sym_null] = sym_null,
+  [sym_number] = sym_number,
   [sym_comment] = sym_comment,
   [sym__whitespace] = sym__whitespace,
+  [sym__edgeql_chars] = sym__edgeql_chars,
   [sym_source_file] = sym_source_file,
   [sym_module] = sym_module,
   [sym_schema_declarations] = sym_schema_declarations,
@@ -397,7 +398,6 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_function] = sym_function,
   [sym_extending] = sym_extending,
   [sym_using] = sym_using,
-  [sym_uselang] = sym_uselang,
   [sym_on] = sym_on,
   [sym_except] = sym_except,
   [sym_computed] = sym_computed,
@@ -500,18 +500,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_LPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_RPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_edgedb] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_extension] = {
     .visible = true,
     .named = false,
@@ -521,6 +509,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RPAREN] = {
     .visible = true,
     .named = false,
   },
@@ -768,12 +764,20 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_number] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_comment] = {
     .visible = true,
     .named = true,
   },
   [sym__whitespace] = {
     .visible = false,
+    .named = true,
+  },
+  [sym__edgeql_chars] = {
+    .visible = true,
     .named = true,
   },
   [sym_source_file] = {
@@ -833,10 +837,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [sym_using] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_uselang] = {
     .visible = true,
     .named = true,
   },
@@ -1024,6 +1024,9 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
+  [10] = {
+    [2] = sym__edgeql_chars,
+  },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
@@ -1122,15 +1125,15 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [88] = 88,
   [89] = 89,
   [90] = 90,
-  [91] = 91,
+  [91] = 90,
   [92] = 92,
   [93] = 93,
   [94] = 94,
   [95] = 95,
   [96] = 96,
-  [97] = 89,
+  [97] = 97,
   [98] = 98,
-  [99] = 98,
+  [99] = 88,
   [100] = 100,
   [101] = 101,
   [102] = 102,
@@ -1234,8 +1237,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [200] = 200,
   [201] = 201,
   [202] = 202,
-  [203] = 203,
-  [204] = 204,
+  [203] = 202,
+  [204] = 201,
   [205] = 205,
   [206] = 206,
   [207] = 207,
@@ -1244,22 +1247,22 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [210] = 210,
   [211] = 211,
   [212] = 212,
-  [213] = 212,
+  [213] = 213,
   [214] = 214,
   [215] = 215,
-  [216] = 214,
-  [217] = 217,
+  [216] = 216,
+  [217] = 215,
   [218] = 218,
   [219] = 219,
   [220] = 220,
-  [221] = 221,
+  [221] = 219,
   [222] = 222,
   [223] = 223,
   [224] = 224,
   [225] = 225,
   [226] = 226,
-  [227] = 226,
-  [228] = 224,
+  [227] = 227,
+  [228] = 228,
   [229] = 229,
   [230] = 230,
   [231] = 231,
@@ -1268,9 +1271,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [234] = 234,
   [235] = 235,
   [236] = 236,
-  [237] = 113,
+  [237] = 237,
   [238] = 238,
-  [239] = 239,
+  [239] = 227,
   [240] = 240,
   [241] = 241,
   [242] = 242,
@@ -1283,37 +1286,37 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [249] = 249,
   [250] = 250,
   [251] = 251,
-  [252] = 119,
+  [252] = 226,
   [253] = 253,
-  [254] = 240,
+  [254] = 254,
   [255] = 255,
   [256] = 256,
   [257] = 257,
-  [258] = 258,
-  [259] = 259,
-  [260] = 109,
-  [261] = 134,
-  [262] = 262,
-  [263] = 116,
-  [264] = 264,
-  [265] = 265,
-  [266] = 266,
+  [258] = 111,
+  [259] = 100,
+  [260] = 260,
+  [261] = 112,
+  [262] = 191,
+  [263] = 188,
+  [264] = 104,
+  [265] = 123,
+  [266] = 110,
   [267] = 267,
   [268] = 268,
   [269] = 269,
-  [270] = 249,
-  [271] = 271,
+  [270] = 270,
+  [271] = 270,
   [272] = 272,
   [273] = 273,
   [274] = 274,
   [275] = 275,
   [276] = 276,
-  [277] = 132,
+  [277] = 277,
   [278] = 278,
   [279] = 279,
   [280] = 280,
   [281] = 281,
-  [282] = 280,
+  [282] = 282,
   [283] = 283,
   [284] = 284,
   [285] = 285,
@@ -1357,8 +1360,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [323] = 323,
   [324] = 324,
   [325] = 325,
-  [326] = 326,
-  [327] = 327,
+  [326] = 318,
+  [327] = 323,
   [328] = 328,
   [329] = 329,
   [330] = 330,
@@ -1368,7 +1371,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [334] = 334,
   [335] = 335,
   [336] = 336,
-  [337] = 337,
+  [337] = 322,
   [338] = 338,
   [339] = 339,
   [340] = 340,
@@ -1422,41 +1425,17 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [388] = 388,
   [389] = 389,
   [390] = 390,
-  [391] = 391,
-  [392] = 392,
-  [393] = 393,
+  [391] = 352,
+  [392] = 346,
+  [393] = 360,
   [394] = 394,
   [395] = 395,
   [396] = 396,
   [397] = 397,
   [398] = 398,
-  [399] = 399,
-  [400] = 400,
+  [399] = 362,
+  [400] = 373,
   [401] = 401,
-  [402] = 402,
-  [403] = 403,
-  [404] = 404,
-  [405] = 405,
-  [406] = 406,
-  [407] = 407,
-  [408] = 408,
-  [409] = 409,
-  [410] = 410,
-  [411] = 411,
-  [412] = 412,
-  [413] = 413,
-  [414] = 414,
-  [415] = 415,
-  [416] = 416,
-  [417] = 417,
-  [418] = 418,
-  [419] = 419,
-  [420] = 420,
-  [421] = 360,
-  [422] = 385,
-  [423] = 423,
-  [424] = 424,
-  [425] = 425,
 };
 
 static inline bool sym_identifier_character_set_1(int32_t c) {
@@ -1554,204 +1533,207 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(254);
-      if (lookahead == '!') ADVANCE(329);
-      if (lookahead == '#') ADVANCE(317);
-      if (lookahead == '%') ADVANCE(494);
-      if (lookahead == '&') ADVANCE(319);
-      if (lookahead == '\'') ADVANCE(316);
-      if (lookahead == '(') ADVANCE(494);
-      if (lookahead == ')') ADVANCE(494);
-      if (lookahead == '*') ADVANCE(494);
-      if (lookahead == '+') ADVANCE(494);
-      if (lookahead == ',') ADVANCE(494);
-      if (lookahead == '-') ADVANCE(330);
-      if (lookahead == '/') ADVANCE(494);
-      if (lookahead == ':') ADVANCE(329);
-      if (lookahead == ';') ADVANCE(494);
-      if (lookahead == '<') ADVANCE(327);
-      if (lookahead == '=') ADVANCE(494);
-      if (lookahead == '>') ADVANCE(328);
-      if (lookahead == '\\') ADVANCE(225);
-      if (lookahead == '^') ADVANCE(494);
-      if (lookahead == 'a') ADVANCE(351);
-      if (lookahead == 'b') ADVANCE(391);
-      if (lookahead == 'c') ADVANCE(333);
-      if (lookahead == 'd') ADVANCE(345);
-      if (lookahead == 'e') ADVANCE(362);
-      if (lookahead == 'f') ADVANCE(335);
-      if (lookahead == 'g') ADVANCE(409);
-      if (lookahead == 'i') ADVANCE(422);
-      if (lookahead == 'j') ADVANCE(463);
-      if (lookahead == 'l') ADVANCE(397);
-      if (lookahead == 'm') ADVANCE(433);
-      if (lookahead == 'n') ADVANCE(483);
-      if (lookahead == 'o') ADVANCE(420);
-      if (lookahead == 'p') ADVANCE(454);
-      if (lookahead == 'r') ADVANCE(371);
-      if (lookahead == 's') ADVANCE(354);
-      if (lookahead == 't') ADVANCE(451);
-      if (lookahead == 'u') ADVANCE(465);
-      if (lookahead == '{') ADVANCE(494);
-      if (lookahead == '|') ADVANCE(493);
-      if (lookahead == '}') ADVANCE(494);
+      if (eof) ADVANCE(257);
+      if (lookahead == '!') ADVANCE(333);
+      if (lookahead == '#') ADVANCE(319);
+      if (lookahead == '%') ADVANCE(509);
+      if (lookahead == '&') ADVANCE(321);
+      if (lookahead == '\'') ADVANCE(318);
+      if (lookahead == '(') ADVANCE(509);
+      if (lookahead == ')') ADVANCE(509);
+      if (lookahead == '*') ADVANCE(509);
+      if (lookahead == '+') ADVANCE(509);
+      if (lookahead == ',') ADVANCE(509);
+      if (lookahead == '-') ADVANCE(334);
+      if (lookahead == '.') ADVANCE(505);
+      if (lookahead == '/') ADVANCE(509);
+      if (lookahead == '0') ADVANCE(322);
+      if (lookahead == ':') ADVANCE(333);
+      if (lookahead == ';') ADVANCE(509);
+      if (lookahead == '<') ADVANCE(331);
+      if (lookahead == '=') ADVANCE(509);
+      if (lookahead == '>') ADVANCE(332);
+      if (lookahead == '\\') ADVANCE(220);
+      if (lookahead == '^') ADVANCE(509);
+      if (lookahead == 'a') ADVANCE(359);
+      if (lookahead == 'b') ADVANCE(395);
+      if (lookahead == 'c') ADVANCE(342);
+      if (lookahead == 'd') ADVANCE(354);
+      if (lookahead == 'e') ADVANCE(429);
+      if (lookahead == 'f') ADVANCE(345);
+      if (lookahead == 'g') ADVANCE(413);
+      if (lookahead == 'i') ADVANCE(426);
+      if (lookahead == 'j') ADVANCE(468);
+      if (lookahead == 'l') ADVANCE(401);
+      if (lookahead == 'm') ADVANCE(438);
+      if (lookahead == 'n') ADVANCE(488);
+      if (lookahead == 'o') ADVANCE(424);
+      if (lookahead == 'p') ADVANCE(459);
+      if (lookahead == 'r') ADVANCE(377);
+      if (lookahead == 's') ADVANCE(362);
+      if (lookahead == 't') ADVANCE(456);
+      if (lookahead == 'u') ADVANCE(470);
+      if (lookahead == '{') ADVANCE(509);
+      if (lookahead == '|') ADVANCE(498);
+      if (lookahead == '}') ADVANCE(509);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(494);
-      if (lookahead != 0) ADVANCE(494);
+          lookahead == ' ') ADVANCE(509);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(323);
+      if (lookahead != 0) ADVANCE(509);
       END_STATE();
     case 1:
-      if (lookahead == '#') ADVANCE(317);
-      if (lookahead == '\'') ADVANCE(316);
-      if (lookahead == '\\') ADVANCE(225);
+      if (lookahead == '#') ADVANCE(319);
+      if (lookahead == '\'') ADVANCE(318);
+      if (lookahead == '\\') ADVANCE(220);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(494);
-      if (lookahead != 0) ADVANCE(494);
+          lookahead == ' ') ADVANCE(509);
+      if (lookahead != 0) ADVANCE(509);
       END_STATE();
     case 2:
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '\'') ADVANCE(316);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == ')') ADVANCE(274);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '\'') ADVANCE(318);
+      if (lookahead == '(') ADVANCE(278);
+      if (lookahead == ')') ADVANCE(279);
       if (lookahead == '.') ADVANCE(21);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'f') ADVANCE(558);
-      if (lookahead == 'g') ADVANCE(619);
-      if (lookahead == 'n') ADVANCE(689);
-      if (lookahead == 't') ADVANCE(662);
+      if (lookahead == '0') ADVANCE(714);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'f') ADVANCE(573);
+      if (lookahead == 'g') ADVANCE(634);
+      if (lookahead == 'n') ADVANCE(704);
+      if (lookahead == 't') ADVANCE(677);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(715);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(709);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == '\\') ADVANCE(231);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '(') ADVANCE(278);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == '\\') ADVANCE(226);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(709);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '#') ADVANCE(723);
       if (lookahead == ',') ADVANCE(277);
       if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ':') ADVANCE(294);
-      if (lookahead == '>') ADVANCE(314);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(627);
-      if (lookahead == 'b') ADVANCE(596);
-      if (lookahead == 'c') ADVANCE(549);
-      if (lookahead == 'd') ADVANCE(560);
-      if (lookahead == 'f') ADVANCE(615);
-      if (lookahead == 'i') ADVANCE(633);
-      if (lookahead == 'j') ADVANCE(665);
-      if (lookahead == 'o') ADVANCE(649);
-      if (lookahead == 's') ADVANCE(574);
-      if (lookahead == 't') ADVANCE(685);
-      if (lookahead == 'u') ADVANCE(684);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == ':') ADVANCE(296);
+      if (lookahead == '>') ADVANCE(316);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(642);
+      if (lookahead == 'b') ADVANCE(611);
+      if (lookahead == 'c') ADVANCE(564);
+      if (lookahead == 'd') ADVANCE(575);
+      if (lookahead == 'f') ADVANCE(630);
+      if (lookahead == 'i') ADVANCE(648);
+      if (lookahead == 'j') ADVANCE(680);
+      if (lookahead == 'o') ADVANCE(664);
+      if (lookahead == 's') ADVANCE(589);
+      if (lookahead == 't') ADVANCE(700);
+      if (lookahead == 'u') ADVANCE(699);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(709);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(698);
+      if (lookahead == '#') ADVANCE(723);
       if (lookahead == ',') ADVANCE(277);
       if (lookahead == '-') ADVANCE(20);
       if (lookahead == ':') ADVANCE(19);
-      if (lookahead == ';') ADVANCE(263);
-      if (lookahead == '>') ADVANCE(314);
+      if (lookahead == ';') ADVANCE(266);
+      if (lookahead == '>') ADVANCE(316);
       if (lookahead == 'a') ADVANCE(44);
-      if (lookahead == 'c') ADVANCE(162);
-      if (lookahead == 'e') ADVANCE(236);
-      if (lookahead == 'f') ADVANCE(228);
-      if (lookahead == 'i') ADVANCE(147);
-      if (lookahead == 'l') ADVANCE(105);
-      if (lookahead == 'm') ADVANCE(227);
-      if (lookahead == 'o') ADVANCE(175);
-      if (lookahead == 'p') ADVANCE(186);
-      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == 'c') ADVANCE(159);
+      if (lookahead == 'e') ADVANCE(230);
+      if (lookahead == 'f') ADVANCE(223);
+      if (lookahead == 'i') ADVANCE(144);
+      if (lookahead == 'l') ADVANCE(101);
+      if (lookahead == 'm') ADVANCE(222);
+      if (lookahead == 'o') ADVANCE(137);
+      if (lookahead == 'p') ADVANCE(182);
+      if (lookahead == 'r') ADVANCE(64);
       if (lookahead == 's') ADVANCE(47);
-      if (lookahead == 't') ADVANCE(237);
-      if (lookahead == 'u') ADVANCE(198);
-      if (lookahead == '{') ADVANCE(256);
-      if (lookahead == '}') ADVANCE(257);
+      if (lookahead == 't') ADVANCE(232);
+      if (lookahead == 'u') ADVANCE(194);
+      if (lookahead == '{') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(260);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
+          lookahead == ' ') ADVANCE(724);
       END_STATE();
     case 6:
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '.') ADVANCE(22);
       if (lookahead == ':') ADVANCE(19);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(627);
-      if (lookahead == 'b') ADVANCE(596);
-      if (lookahead == 'c') ADVANCE(549);
-      if (lookahead == 'd') ADVANCE(560);
-      if (lookahead == 'f') ADVANCE(615);
-      if (lookahead == 'i') ADVANCE(633);
-      if (lookahead == 'j') ADVANCE(665);
-      if (lookahead == 's') ADVANCE(569);
-      if (lookahead == 't') ADVANCE(685);
-      if (lookahead == 'u') ADVANCE(684);
-      if (lookahead == '{') ADVANCE(256);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(642);
+      if (lookahead == 'b') ADVANCE(611);
+      if (lookahead == 'c') ADVANCE(564);
+      if (lookahead == 'd') ADVANCE(575);
+      if (lookahead == 'f') ADVANCE(630);
+      if (lookahead == 'i') ADVANCE(648);
+      if (lookahead == 'j') ADVANCE(680);
+      if (lookahead == 's') ADVANCE(584);
+      if (lookahead == 't') ADVANCE(700);
+      if (lookahead == 'u') ADVANCE(699);
+      if (lookahead == '{') ADVANCE(259);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_2(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (!sym_identifier_character_set_2(lookahead)) ADVANCE(709);
       END_STATE();
     case 7:
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ';') ADVANCE(263);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(563);
-      if (lookahead == 'i') ADVANCE(630);
-      if (lookahead == 'm') ADVANCE(687);
-      if (lookahead == 'o') ADVANCE(648);
-      if (lookahead == 'r') ADVANCE(590);
-      if (lookahead == 's') ADVANCE(605);
-      if (lookahead == 'u') ADVANCE(668);
-      if (lookahead == '{') ADVANCE(256);
-      if (lookahead == '}') ADVANCE(257);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(642);
+      if (lookahead == 'b') ADVANCE(611);
+      if (lookahead == 'c') ADVANCE(564);
+      if (lookahead == 'd') ADVANCE(575);
+      if (lookahead == 'f') ADVANCE(630);
+      if (lookahead == 'i') ADVANCE(648);
+      if (lookahead == 'j') ADVANCE(680);
+      if (lookahead == 's') ADVANCE(594);
+      if (lookahead == 't') ADVANCE(700);
+      if (lookahead == 'u') ADVANCE(699);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_2(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(709);
       END_STATE();
     case 8:
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(627);
-      if (lookahead == 'b') ADVANCE(596);
-      if (lookahead == 'c') ADVANCE(549);
-      if (lookahead == 'd') ADVANCE(560);
-      if (lookahead == 'f') ADVANCE(615);
-      if (lookahead == 'i') ADVANCE(633);
-      if (lookahead == 'j') ADVANCE(665);
-      if (lookahead == 's') ADVANCE(579);
-      if (lookahead == 't') ADVANCE(685);
-      if (lookahead == 'u') ADVANCE(684);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(578);
+      if (lookahead == 'i') ADVANCE(645);
+      if (lookahead == 'm') ADVANCE(702);
+      if (lookahead == 'o') ADVANCE(663);
+      if (lookahead == 'r') ADVANCE(605);
+      if (lookahead == 's') ADVANCE(620);
+      if (lookahead == 'u') ADVANCE(683);
+      if (lookahead == '}') ADVANCE(260);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(694);
+          lookahead == ' ') ADVANCE(724);
+      if (!sym_identifier_character_set_1(lookahead)) ADVANCE(709);
       END_STATE();
     case 9:
       if (lookahead == '1') ADVANCE(15);
@@ -1759,907 +1741,914 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '6') ADVANCE(13);
       END_STATE();
     case 10:
-      if (lookahead == '2') ADVANCE(504);
+      if (lookahead == '2') ADVANCE(519);
       END_STATE();
     case 11:
-      if (lookahead == '2') ADVANCE(508);
+      if (lookahead == '2') ADVANCE(523);
       END_STATE();
     case 12:
       if (lookahead == '3') ADVANCE(11);
       if (lookahead == '6') ADVANCE(14);
       END_STATE();
     case 13:
-      if (lookahead == '4') ADVANCE(506);
+      if (lookahead == '4') ADVANCE(521);
       END_STATE();
     case 14:
-      if (lookahead == '4') ADVANCE(510);
+      if (lookahead == '4') ADVANCE(525);
       END_STATE();
     case 15:
-      if (lookahead == '6') ADVANCE(502);
+      if (lookahead == '6') ADVANCE(517);
       END_STATE();
     case 16:
-      if (lookahead == ':') ADVANCE(127);
+      if (lookahead == ':') ADVANCE(123);
       END_STATE();
     case 17:
       if (lookahead == ':') ADVANCE(16);
       END_STATE();
     case 18:
-      if (lookahead == '=') ADVANCE(312);
+      if (lookahead == '=') ADVANCE(314);
       END_STATE();
     case 19:
-      if (lookahead == '=') ADVANCE(262);
+      if (lookahead == '=') ADVANCE(265);
       END_STATE();
     case 20:
-      if (lookahead == '>') ADVANCE(261);
+      if (lookahead == '>') ADVANCE(264);
       END_STATE();
     case 21:
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_3(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(721);
+      if (!sym_identifier_character_set_3(lookahead)) ADVANCE(709);
       END_STATE();
     case 22:
-      if (lookahead == '_') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_3(lookahead)) ADVANCE(709);
       END_STATE();
     case 23:
-      if (lookahead == '_') ADVANCE(60);
+      if (lookahead == '_') ADVANCE(61);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(120);
-      if (lookahead == 'o') ADVANCE(159);
+      if (lookahead == '_') ADVANCE(58);
       END_STATE();
     case 25:
-      if (lookahead == 'a') ADVANCE(45);
+      if (lookahead == 'a') ADVANCE(116);
+      if (lookahead == 'o') ADVANCE(156);
       END_STATE();
     case 26:
-      if (lookahead == 'a') ADVANCE(194);
+      if (lookahead == 'a') ADVANCE(45);
       END_STATE();
     case 27:
-      if (lookahead == 'a') ADVANCE(50);
+      if (lookahead == 'a') ADVANCE(190);
       END_STATE();
     case 28:
-      if (lookahead == 'a') ADVANCE(126);
+      if (lookahead == 'a') ADVANCE(50);
       END_STATE();
     case 29:
-      if (lookahead == 'a') ADVANCE(64);
-      END_STATE();
-    case 30:
-      if (lookahead == 'a') ADVANCE(201);
-      END_STATE();
-    case 31:
       if (lookahead == 'a') ADVANCE(122);
       END_STATE();
+    case 30:
+      if (lookahead == 'a') ADVANCE(62);
+      END_STATE();
+    case 31:
+      if (lookahead == 'a') ADVANCE(197);
+      END_STATE();
     case 32:
-      if (lookahead == 'a') ADVANCE(184);
+      if (lookahead == 'a') ADVANCE(118);
       END_STATE();
     case 33:
-      if (lookahead == 'a') ADVANCE(123);
+      if (lookahead == 'a') ADVANCE(180);
       END_STATE();
     case 34:
-      if (lookahead == 'a') ADVANCE(124);
+      if (lookahead == 'a') ADVANCE(119);
       END_STATE();
     case 35:
-      if (lookahead == 'a') ADVANCE(208);
-      if (lookahead == 'e') ADVANCE(48);
-      if (lookahead == 'u') ADVANCE(185);
+      if (lookahead == 'a') ADVANCE(120);
       END_STATE();
     case 36:
-      if (lookahead == 'a') ADVANCE(215);
+      if (lookahead == 'a') ADVANCE(204);
+      if (lookahead == 'e') ADVANCE(48);
+      if (lookahead == 'u') ADVANCE(181);
       END_STATE();
     case 37:
-      if (lookahead == 'a') ADVANCE(214);
+      if (lookahead == 'a') ADVANCE(210);
       END_STATE();
     case 38:
-      if (lookahead == 'a') ADVANCE(111);
+      if (lookahead == 'a') ADVANCE(209);
       END_STATE();
     case 39:
-      if (lookahead == 'a') ADVANCE(219);
+      if (lookahead == 'a') ADVANCE(107);
       END_STATE();
     case 40:
-      if (lookahead == 'a') ADVANCE(222);
+      if (lookahead == 'a') ADVANCE(214);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(223);
+      if (lookahead == 'a') ADVANCE(217);
       END_STATE();
     case 42:
-      if (lookahead == 'b') ADVANCE(275);
+      if (lookahead == 'a') ADVANCE(218);
       END_STATE();
     case 43:
-      if (lookahead == 'b') ADVANCE(197);
-      if (lookahead == 'l') ADVANCE(102);
-      if (lookahead == 'n') ADVANCE(155);
+      if (lookahead == 'b') ADVANCE(193);
+      if (lookahead == 'l') ADVANCE(98);
+      if (lookahead == 'n') ADVANCE(152);
       END_STATE();
     case 44:
-      if (lookahead == 'b') ADVANCE(197);
-      if (lookahead == 'l') ADVANCE(102);
-      if (lookahead == 'n') ADVANCE(154);
+      if (lookahead == 'b') ADVANCE(193);
+      if (lookahead == 'l') ADVANCE(98);
+      if (lookahead == 'n') ADVANCE(151);
       END_STATE();
     case 45:
-      if (lookahead == 'b') ADVANCE(130);
+      if (lookahead == 'b') ADVANCE(126);
       END_STATE();
     case 46:
-      if (lookahead == 'c') ADVANCE(28);
-      if (lookahead == 'e') ADVANCE(182);
-      if (lookahead == 'i') ADVANCE(149);
-      if (lookahead == 't') ADVANCE(183);
+      if (lookahead == 'c') ADVANCE(29);
+      if (lookahead == 'e') ADVANCE(178);
+      if (lookahead == 'i') ADVANCE(145);
+      if (lookahead == 't') ADVANCE(179);
       END_STATE();
     case 47:
-      if (lookahead == 'c') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(149);
+      if (lookahead == 'c') ADVANCE(29);
+      if (lookahead == 'i') ADVANCE(145);
       END_STATE();
     case 48:
-      if (lookahead == 'c') ADVANCE(103);
+      if (lookahead == 'c') ADVANCE(99);
       END_STATE();
     case 49:
-      if (lookahead == 'c') ADVANCE(79);
-      if (lookahead == 't') ADVANCE(89);
+      if (lookahead == 'c') ADVANCE(77);
+      if (lookahead == 't') ADVANCE(86);
       END_STATE();
     case 50:
-      if (lookahead == 'c') ADVANCE(204);
+      if (lookahead == 'c') ADVANCE(200);
       END_STATE();
     case 51:
-      if (lookahead == 'c') ADVANCE(73);
+      if (lookahead == 'c') ADVANCE(71);
       END_STATE();
     case 52:
-      if (lookahead == 'c') ADVANCE(34);
+      if (lookahead == 'c') ADVANCE(35);
       END_STATE();
     case 53:
-      if (lookahead == 'c') ADVANCE(221);
+      if (lookahead == 'c') ADVANCE(216);
       END_STATE();
     case 54:
-      if (lookahead == 'd') ADVANCE(518);
+      if (lookahead == 'd') ADVANCE(533);
       END_STATE();
     case 55:
-      if (lookahead == 'd') ADVANCE(42);
+      if (lookahead == 'd') ADVANCE(286);
       END_STATE();
     case 56:
       if (lookahead == 'd') ADVANCE(284);
       END_STATE();
     case 57:
-      if (lookahead == 'd') ADVANCE(282);
+      if (lookahead == 'd') ADVANCE(224);
       END_STATE();
     case 58:
-      if (lookahead == 'd') ADVANCE(95);
-      if (lookahead == 'n') ADVANCE(226);
-      if (lookahead == 'x') ADVANCE(49);
+      if (lookahead == 'd') ADVANCE(228);
       END_STATE();
     case 59:
-      if (lookahead == 'd') ADVANCE(229);
+      if (lookahead == 'd') ADVANCE(65);
+      if (lookahead == 'h') ADVANCE(81);
       END_STATE();
     case 60:
-      if (lookahead == 'd') ADVANCE(233);
-      END_STATE();
-    case 61:
-      if (lookahead == 'd') ADVANCE(67);
-      if (lookahead == 'h') ADVANCE(84);
-      END_STATE();
-    case 62:
-      if (lookahead == 'd') ADVANCE(67);
-      if (lookahead == 'h') ADVANCE(84);
+      if (lookahead == 'd') ADVANCE(65);
+      if (lookahead == 'h') ADVANCE(81);
       if (lookahead == 't') ADVANCE(9);
       END_STATE();
+    case 61:
+      if (lookahead == 'd') ADVANCE(37);
+      if (lookahead == 't') ADVANCE(109);
+      END_STATE();
+    case 62:
+      if (lookahead == 'd') ADVANCE(84);
+      END_STATE();
     case 63:
-      if (lookahead == 'd') ADVANCE(36);
-      if (lookahead == 't') ADVANCE(113);
+      if (lookahead == 'd') ADVANCE(106);
       END_STATE();
     case 64:
-      if (lookahead == 'd') ADVANCE(87);
+      if (lookahead == 'e') ADVANCE(177);
       END_STATE();
     case 65:
-      if (lookahead == 'd') ADVANCE(110);
+      if (lookahead == 'e') ADVANCE(231);
       END_STATE();
     case 66:
-      if (lookahead == 'e') ADVANCE(181);
+      if (lookahead == 'e') ADVANCE(261);
       END_STATE();
     case 67:
-      if (lookahead == 'e') ADVANCE(235);
-      END_STATE();
-    case 68:
       if (lookahead == 'e') ADVANCE(258);
       END_STATE();
+    case 68:
+      if (lookahead == 'e') ADVANCE(290);
+      END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(255);
+      if (lookahead == 'e') ADVANCE(547);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(288);
+      if (lookahead == 'e') ADVANCE(537);
       END_STATE();
     case 71:
-      if (lookahead == 'e') ADVANCE(532);
+      if (lookahead == 'e') ADVANCE(545);
       END_STATE();
     case 72:
-      if (lookahead == 'e') ADVANCE(522);
+      if (lookahead == 'e') ADVANCE(294);
       END_STATE();
     case 73:
-      if (lookahead == 'e') ADVANCE(530);
+      if (lookahead == 'e') ADVANCE(542);
       END_STATE();
     case 74:
-      if (lookahead == 'e') ADVANCE(292);
+      if (lookahead == 'e') ADVANCE(543);
       END_STATE();
     case 75:
-      if (lookahead == 'e') ADVANCE(527);
+      if (lookahead == 'e') ADVANCE(541);
       END_STATE();
     case 76:
-      if (lookahead == 'e') ADVANCE(528);
+      if (lookahead == 'e') ADVANCE(551);
       END_STATE();
     case 77:
-      if (lookahead == 'e') ADVANCE(526);
+      if (lookahead == 'e') ADVANCE(173);
       END_STATE();
     case 78:
-      if (lookahead == 'e') ADVANCE(536);
+      if (lookahead == 'e') ADVANCE(24);
       END_STATE();
     case 79:
-      if (lookahead == 'e') ADVANCE(176);
+      if (lookahead == 'e') ADVANCE(191);
       END_STATE();
     case 80:
-      if (lookahead == 'e') ADVANCE(23);
+      if (lookahead == 'e') ADVANCE(183);
       END_STATE();
     case 81:
-      if (lookahead == 'e') ADVANCE(55);
+      if (lookahead == 'e') ADVANCE(186);
       END_STATE();
     case 82:
-      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == 'e') ADVANCE(55);
       END_STATE();
     case 83:
       if (lookahead == 'e') ADVANCE(187);
       END_STATE();
     case 84:
-      if (lookahead == 'e') ADVANCE(190);
-      END_STATE();
-    case 85:
-      if (lookahead == 'e') ADVANCE(191);
-      END_STATE();
-    case 86:
       if (lookahead == 'e') ADVANCE(56);
       END_STATE();
+    case 85:
+      if (lookahead == 'e') ADVANCE(129);
+      END_STATE();
+    case 86:
+      if (lookahead == 'e') ADVANCE(148);
+      END_STATE();
     case 87:
-      if (lookahead == 'e') ADVANCE(57);
+      if (lookahead == 'e') ADVANCE(150);
       END_STATE();
     case 88:
-      if (lookahead == 'e') ADVANCE(133);
+      if (lookahead == 'e') ADVANCE(207);
       END_STATE();
     case 89:
-      if (lookahead == 'e') ADVANCE(152);
+      if (lookahead == 'f') ADVANCE(297);
       END_STATE();
     case 90:
-      if (lookahead == 'e') ADVANCE(151);
+      if (lookahead == 'g') ADVANCE(273);
       END_STATE();
     case 91:
-      if (lookahead == 'e') ADVANCE(212);
-      END_STATE();
-    case 92:
-      if (lookahead == 'f') ADVANCE(295);
-      END_STATE();
-    case 93:
-      if (lookahead == 'g') ADVANCE(270);
-      END_STATE();
-    case 94:
       if (lookahead == 'g') ADVANCE(276);
       END_STATE();
+    case 92:
+      if (lookahead == 'g') ADVANCE(125);
+      END_STATE();
+    case 93:
+      if (lookahead == 'g') ADVANCE(104);
+      END_STATE();
+    case 94:
+      if (lookahead == 'i') ADVANCE(93);
+      if (lookahead == 'o') ADVANCE(160);
+      if (lookahead == 'y') ADVANCE(203);
+      END_STATE();
     case 95:
-      if (lookahead == 'g') ADVANCE(81);
+      if (lookahead == 'i') ADVANCE(292);
       END_STATE();
     case 96:
-      if (lookahead == 'g') ADVANCE(129);
+      if (lookahead == 'i') ADVANCE(229);
       END_STATE();
     case 97:
-      if (lookahead == 'g') ADVANCE(108);
-      END_STATE();
-    case 98:
-      if (lookahead == 'i') ADVANCE(97);
-      if (lookahead == 'o') ADVANCE(163);
-      if (lookahead == 'y') ADVANCE(207);
-      END_STATE();
-    case 99:
-      if (lookahead == 'i') ADVANCE(290);
-      END_STATE();
-    case 100:
-      if (lookahead == 'i') ADVANCE(234);
-      END_STATE();
-    case 101:
       if (lookahead == 'i') ADVANCE(54);
       END_STATE();
-    case 102:
-      if (lookahead == 'i') ADVANCE(26);
+    case 98:
+      if (lookahead == 'i') ADVANCE(27);
       END_STATE();
-    case 103:
+    case 99:
+      if (lookahead == 'i') ADVANCE(134);
+      END_STATE();
+    case 100:
+      if (lookahead == 'i') ADVANCE(131);
+      END_STATE();
+    case 101:
       if (lookahead == 'i') ADVANCE(138);
       END_STATE();
+    case 102:
+      if (lookahead == 'i') ADVANCE(147);
+      END_STATE();
+    case 103:
+      if (lookahead == 'i') ADVANCE(188);
+      END_STATE();
     case 104:
-      if (lookahead == 'i') ADVANCE(135);
-      END_STATE();
-    case 105:
-      if (lookahead == 'i') ADVANCE(141);
-      END_STATE();
-    case 106:
-      if (lookahead == 'i') ADVANCE(150);
-      END_STATE();
-    case 107:
-      if (lookahead == 'i') ADVANCE(192);
-      END_STATE();
-    case 108:
-      if (lookahead == 'i') ADVANCE(156);
-      END_STATE();
-    case 109:
-      if (lookahead == 'i') ADVANCE(213);
-      END_STATE();
-    case 110:
       if (lookahead == 'i') ADVANCE(153);
       END_STATE();
+    case 105:
+      if (lookahead == 'i') ADVANCE(208);
+      END_STATE();
+    case 106:
+      if (lookahead == 'i') ADVANCE(149);
+      END_STATE();
+    case 107:
+      if (lookahead == 'i') ADVANCE(154);
+      END_STATE();
+    case 108:
+      if (lookahead == 'i') ADVANCE(166);
+      END_STATE();
+    case 109:
+      if (lookahead == 'i') ADVANCE(132);
+      END_STATE();
+    case 110:
+      if (lookahead == 'i') ADVANCE(167);
+      END_STATE();
     case 111:
-      if (lookahead == 'i') ADVANCE(157);
+      if (lookahead == 'i') ADVANCE(133);
       END_STATE();
     case 112:
-      if (lookahead == 'i') ADVANCE(169);
+      if (lookahead == 'i') ADVANCE(168);
       END_STATE();
     case 113:
-      if (lookahead == 'i') ADVANCE(136);
+      if (lookahead == 'i') ADVANCE(169);
       END_STATE();
     case 114:
       if (lookahead == 'i') ADVANCE(170);
       END_STATE();
     case 115:
-      if (lookahead == 'i') ADVANCE(137);
+      if (lookahead == 'k') ADVANCE(263);
       END_STATE();
     case 116:
-      if (lookahead == 'i') ADVANCE(171);
-      END_STATE();
-    case 117:
-      if (lookahead == 'i') ADVANCE(172);
-      END_STATE();
-    case 118:
-      if (lookahead == 'i') ADVANCE(173);
-      END_STATE();
-    case 119:
-      if (lookahead == 'k') ADVANCE(260);
-      END_STATE();
-    case 120:
       if (lookahead == 'l') ADVANCE(17);
       END_STATE();
+    case 117:
+      if (lookahead == 'l') ADVANCE(515);
+      END_STATE();
+    case 118:
+      if (lookahead == 'l') ADVANCE(529);
+      END_STATE();
+    case 119:
+      if (lookahead == 'l') ADVANCE(288);
+      END_STATE();
+    case 120:
+      if (lookahead == 'l') ADVANCE(23);
+      END_STATE();
     case 121:
-      if (lookahead == 'l') ADVANCE(500);
+      if (lookahead == 'l') ADVANCE(161);
+      if (lookahead == 'u') ADVANCE(146);
       END_STATE();
     case 122:
-      if (lookahead == 'l') ADVANCE(514);
+      if (lookahead == 'l') ADVANCE(33);
       END_STATE();
     case 123:
-      if (lookahead == 'l') ADVANCE(286);
+      if (lookahead == 'l') ADVANCE(163);
+      if (lookahead == 'r') ADVANCE(85);
       END_STATE();
     case 124:
-      if (lookahead == 'l') ADVANCE(22);
+      if (lookahead == 'l') ADVANCE(67);
       END_STATE();
     case 125:
-      if (lookahead == 'l') ADVANCE(164);
-      if (lookahead == 'u') ADVANCE(148);
+      if (lookahead == 'l') ADVANCE(68);
       END_STATE();
     case 126:
-      if (lookahead == 'l') ADVANCE(32);
+      if (lookahead == 'l') ADVANCE(72);
       END_STATE();
     case 127:
-      if (lookahead == 'l') ADVANCE(166);
-      if (lookahead == 'r') ADVANCE(88);
+      if (lookahead == 'l') ADVANCE(165);
       END_STATE();
     case 128:
-      if (lookahead == 'l') ADVANCE(69);
+      if (lookahead == 'l') ADVANCE(206);
       END_STATE();
     case 129:
-      if (lookahead == 'l') ADVANCE(70);
+      if (lookahead == 'l') ADVANCE(38);
       END_STATE();
     case 130:
-      if (lookahead == 'l') ADVANCE(74);
+      if (lookahead == 'm') ADVANCE(552);
       END_STATE();
     case 131:
-      if (lookahead == 'l') ADVANCE(168);
+      if (lookahead == 'm') ADVANCE(70);
       END_STATE();
     case 132:
-      if (lookahead == 'l') ADVANCE(210);
+      if (lookahead == 'm') ADVANCE(74);
       END_STATE();
     case 133:
-      if (lookahead == 'l') ADVANCE(37);
+      if (lookahead == 'm') ADVANCE(75);
       END_STATE();
     case 134:
-      if (lookahead == 'm') ADVANCE(537);
+      if (lookahead == 'm') ADVANCE(32);
       END_STATE();
     case 135:
-      if (lookahead == 'm') ADVANCE(72);
+      if (lookahead == 'n') ADVANCE(221);
+      if (lookahead == 'x') ADVANCE(49);
       END_STATE();
     case 136:
-      if (lookahead == 'm') ADVANCE(76);
+      if (lookahead == 'n') ADVANCE(60);
       END_STATE();
     case 137:
-      if (lookahead == 'm') ADVANCE(77);
+      if (lookahead == 'n') ADVANCE(280);
+      if (lookahead == 'p') ADVANCE(205);
+      if (lookahead == 'v') ADVANCE(80);
       END_STATE();
     case 138:
-      if (lookahead == 'm') ADVANCE(31);
+      if (lookahead == 'n') ADVANCE(115);
       END_STATE();
     case 139:
-      if (lookahead == 'n') ADVANCE(62);
+      if (lookahead == 'n') ADVANCE(531);
       END_STATE();
     case 140:
-      if (lookahead == 'n') ADVANCE(278);
-      if (lookahead == 'p') ADVANCE(209);
-      if (lookahead == 'v') ADVANCE(83);
+      if (lookahead == 'n') ADVANCE(539);
       END_STATE();
     case 141:
-      if (lookahead == 'n') ADVANCE(119);
+      if (lookahead == 'n') ADVANCE(275);
       END_STATE();
     case 142:
-      if (lookahead == 'n') ADVANCE(516);
+      if (lookahead == 'n') ADVANCE(268);
       END_STATE();
     case 143:
-      if (lookahead == 'n') ADVANCE(524);
+      if (lookahead == 'n') ADVANCE(544);
       END_STATE();
     case 144:
-      if (lookahead == 'n') ADVANCE(272);
+      if (lookahead == 'n') ADVANCE(59);
       END_STATE();
     case 145:
-      if (lookahead == 'n') ADVANCE(265);
+      if (lookahead == 'n') ADVANCE(92);
       END_STATE();
     case 146:
-      if (lookahead == 'n') ADVANCE(529);
-      END_STATE();
-    case 147:
-      if (lookahead == 'n') ADVANCE(61);
-      END_STATE();
-    case 148:
       if (lookahead == 'n') ADVANCE(53);
       END_STATE();
+    case 147:
+      if (lookahead == 'n') ADVANCE(90);
+      END_STATE();
+    case 148:
+      if (lookahead == 'n') ADVANCE(63);
+      END_STATE();
     case 149:
-      if (lookahead == 'n') ADVANCE(96);
+      if (lookahead == 'n') ADVANCE(91);
       END_STATE();
     case 150:
-      if (lookahead == 'n') ADVANCE(93);
-      END_STATE();
-    case 151:
       if (lookahead == 'n') ADVANCE(51);
       END_STATE();
+    case 151:
+      if (lookahead == 'n') ADVANCE(162);
+      END_STATE();
     case 152:
-      if (lookahead == 'n') ADVANCE(65);
+      if (lookahead == 'n') ADVANCE(162);
+      if (lookahead == 'y') ADVANCE(213);
       END_STATE();
     case 153:
-      if (lookahead == 'n') ADVANCE(94);
+      if (lookahead == 'n') ADVANCE(198);
       END_STATE();
     case 154:
-      if (lookahead == 'n') ADVANCE(165);
+      if (lookahead == 'n') ADVANCE(201);
       END_STATE();
     case 155:
-      if (lookahead == 'n') ADVANCE(165);
-      if (lookahead == 'y') ADVANCE(218);
+      if (lookahead == 'n') ADVANCE(34);
       END_STATE();
     case 156:
-      if (lookahead == 'n') ADVANCE(202);
+      if (lookahead == 'n') ADVANCE(196);
       END_STATE();
     case 157:
-      if (lookahead == 'n') ADVANCE(205);
+      if (lookahead == 'o') ADVANCE(57);
+      if (lookahead == 'u') ADVANCE(128);
       END_STATE();
     case 158:
-      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'o') ADVANCE(89);
       END_STATE();
     case 159:
-      if (lookahead == 'n') ADVANCE(200);
+      if (lookahead == 'o') ADVANCE(156);
       END_STATE();
     case 160:
-      if (lookahead == 'o') ADVANCE(59);
-      if (lookahead == 'u') ADVANCE(132);
+      if (lookahead == 'o') ADVANCE(117);
       END_STATE();
     case 161:
-      if (lookahead == 'o') ADVANCE(92);
+      if (lookahead == 'o') ADVANCE(31);
       END_STATE();
     case 162:
-      if (lookahead == 'o') ADVANCE(159);
+      if (lookahead == 'o') ADVANCE(219);
       END_STATE();
     case 163:
-      if (lookahead == 'o') ADVANCE(121);
-      END_STATE();
-    case 164:
-      if (lookahead == 'o') ADVANCE(30);
-      END_STATE();
-    case 165:
-      if (lookahead == 'o') ADVANCE(224);
-      END_STATE();
-    case 166:
       if (lookahead == 'o') ADVANCE(52);
       END_STATE();
+    case 164:
+      if (lookahead == 'o') ADVANCE(139);
+      END_STATE();
+    case 165:
+      if (lookahead == 'o') ADVANCE(30);
+      END_STATE();
+    case 166:
+      if (lookahead == 'o') ADVANCE(155);
+      END_STATE();
     case 167:
-      if (lookahead == 'o') ADVANCE(142);
+      if (lookahead == 'o') ADVANCE(140);
       END_STATE();
     case 168:
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'o') ADVANCE(141);
       END_STATE();
     case 169:
-      if (lookahead == 'o') ADVANCE(158);
+      if (lookahead == 'o') ADVANCE(142);
       END_STATE();
     case 170:
       if (lookahead == 'o') ADVANCE(143);
       END_STATE();
     case 171:
-      if (lookahead == 'o') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(176);
       END_STATE();
     case 172:
-      if (lookahead == 'o') ADVANCE(145);
+      if (lookahead == 'p') ADVANCE(66);
       END_STATE();
     case 173:
-      if (lookahead == 'o') ADVANCE(146);
+      if (lookahead == 'p') ADVANCE(199);
       END_STATE();
     case 174:
-      if (lookahead == 'o') ADVANCE(180);
+      if (lookahead == 'p') ADVANCE(69);
       END_STATE();
     case 175:
-      if (lookahead == 'p') ADVANCE(209);
-      if (lookahead == 'v') ADVANCE(83);
+      if (lookahead == 'p') ADVANCE(76);
       END_STATE();
     case 176:
-      if (lookahead == 'p') ADVANCE(203);
+      if (lookahead == 'p') ADVANCE(83);
       END_STATE();
     case 177:
-      if (lookahead == 'p') ADVANCE(68);
+      if (lookahead == 'q') ADVANCE(225);
       END_STATE();
     case 178:
-      if (lookahead == 'p') ADVANCE(71);
+      if (lookahead == 'q') ADVANCE(227);
       END_STATE();
     case 179:
-      if (lookahead == 'p') ADVANCE(78);
+      if (lookahead == 'r') ADVANCE(513);
       END_STATE();
     case 180:
-      if (lookahead == 'p') ADVANCE(85);
+      if (lookahead == 'r') ADVANCE(262);
       END_STATE();
     case 181:
-      if (lookahead == 'q') ADVANCE(230);
+      if (lookahead == 'r') ADVANCE(40);
       END_STATE();
     case 182:
-      if (lookahead == 'q') ADVANCE(232);
+      if (lookahead == 'r') ADVANCE(171);
       END_STATE();
     case 183:
-      if (lookahead == 'r') ADVANCE(498);
+      if (lookahead == 'r') ADVANCE(127);
       END_STATE();
     case 184:
-      if (lookahead == 'r') ADVANCE(259);
+      if (lookahead == 'r') ADVANCE(28);
       END_STATE();
     case 185:
       if (lookahead == 'r') ADVANCE(39);
       END_STATE();
     case 186:
-      if (lookahead == 'r') ADVANCE(174);
+      if (lookahead == 'r') ADVANCE(105);
       END_STATE();
     case 187:
-      if (lookahead == 'r') ADVANCE(131);
+      if (lookahead == 'r') ADVANCE(202);
       END_STATE();
     case 188:
-      if (lookahead == 'r') ADVANCE(27);
+      if (lookahead == 'r') ADVANCE(82);
       END_STATE();
     case 189:
-      if (lookahead == 'r') ADVANCE(38);
+      if (lookahead == 'r') ADVANCE(42);
       END_STATE();
     case 190:
-      if (lookahead == 'r') ADVANCE(109);
+      if (lookahead == 's') ADVANCE(272);
       END_STATE();
     case 191:
-      if (lookahead == 'r') ADVANCE(206);
+      if (lookahead == 's') ADVANCE(535);
       END_STATE();
     case 192:
-      if (lookahead == 'r') ADVANCE(86);
+      if (lookahead == 's') ADVANCE(164);
       END_STATE();
     case 193:
-      if (lookahead == 'r') ADVANCE(41);
+      if (lookahead == 's') ADVANCE(211);
       END_STATE();
     case 194:
-      if (lookahead == 's') ADVANCE(269);
+      if (lookahead == 's') ADVANCE(102);
       END_STATE();
     case 195:
-      if (lookahead == 's') ADVANCE(520);
+      if (lookahead == 's') ADVANCE(102);
+      if (lookahead == 'u') ADVANCE(97);
       END_STATE();
     case 196:
-      if (lookahead == 's') ADVANCE(167);
+      if (lookahead == 's') ADVANCE(212);
       END_STATE();
     case 197:
-      if (lookahead == 's') ADVANCE(216);
-      END_STATE();
-    case 198:
-      if (lookahead == 's') ADVANCE(106);
-      END_STATE();
-    case 199:
-      if (lookahead == 's') ADVANCE(106);
-      if (lookahead == 'u') ADVANCE(101);
-      END_STATE();
-    case 200:
-      if (lookahead == 's') ADVANCE(217);
-      END_STATE();
-    case 201:
       if (lookahead == 't') ADVANCE(12);
       END_STATE();
+    case 198:
+      if (lookahead == 't') ADVANCE(527);
+      END_STATE();
+    case 199:
+      if (lookahead == 't') ADVANCE(281);
+      END_STATE();
+    case 200:
+      if (lookahead == 't') ADVANCE(282);
+      END_STATE();
+    case 201:
+      if (lookahead == 't') ADVANCE(270);
+      END_STATE();
     case 202:
-      if (lookahead == 't') ADVANCE(512);
+      if (lookahead == 't') ADVANCE(233);
       END_STATE();
     case 203:
-      if (lookahead == 't') ADVANCE(279);
+      if (lookahead == 't') ADVANCE(79);
       END_STATE();
     case 204:
-      if (lookahead == 't') ADVANCE(280);
+      if (lookahead == 't') ADVANCE(88);
       END_STATE();
     case 205:
-      if (lookahead == 't') ADVANCE(267);
+      if (lookahead == 't') ADVANCE(108);
       END_STATE();
     case 206:
-      if (lookahead == 't') ADVANCE(238);
+      if (lookahead == 't') ADVANCE(95);
       END_STATE();
     case 207:
-      if (lookahead == 't') ADVANCE(82);
-      END_STATE();
-    case 208:
-      if (lookahead == 't') ADVANCE(91);
-      END_STATE();
-    case 209:
-      if (lookahead == 't') ADVANCE(112);
-      END_STATE();
-    case 210:
-      if (lookahead == 't') ADVANCE(99);
-      END_STATE();
-    case 211:
-      if (lookahead == 't') ADVANCE(89);
-      END_STATE();
-    case 212:
-      if (lookahead == 't') ADVANCE(104);
-      END_STATE();
-    case 213:
-      if (lookahead == 't') ADVANCE(25);
-      END_STATE();
-    case 214:
       if (lookahead == 't') ADVANCE(100);
       END_STATE();
+    case 208:
+      if (lookahead == 't') ADVANCE(26);
+      END_STATE();
+    case 209:
+      if (lookahead == 't') ADVANCE(96);
+      END_STATE();
+    case 210:
+      if (lookahead == 't') ADVANCE(73);
+      END_STATE();
+    case 211:
+      if (lookahead == 't') ADVANCE(184);
+      END_STATE();
+    case 212:
+      if (lookahead == 't') ADVANCE(185);
+      END_STATE();
+    case 213:
+      if (lookahead == 't') ADVANCE(234);
+      END_STATE();
+    case 214:
+      if (lookahead == 't') ADVANCE(110);
+      END_STATE();
     case 215:
-      if (lookahead == 't') ADVANCE(75);
+      if (lookahead == 't') ADVANCE(235);
       END_STATE();
     case 216:
-      if (lookahead == 't') ADVANCE(188);
+      if (lookahead == 't') ADVANCE(112);
       END_STATE();
     case 217:
-      if (lookahead == 't') ADVANCE(189);
+      if (lookahead == 't') ADVANCE(113);
       END_STATE();
     case 218:
-      if (lookahead == 't') ADVANCE(239);
-      END_STATE();
-    case 219:
       if (lookahead == 't') ADVANCE(114);
       END_STATE();
+    case 219:
+      if (lookahead == 't') ADVANCE(41);
+      END_STATE();
     case 220:
-      if (lookahead == 't') ADVANCE(240);
+      if (lookahead == 'u') ADVANCE(236);
+      if (lookahead == 'x') ADVANCE(253);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(512);
+      if (lookahead != 0) ADVANCE(510);
       END_STATE();
     case 221:
-      if (lookahead == 't') ADVANCE(116);
+      if (lookahead == 'u') ADVANCE(130);
       END_STATE();
     case 222:
-      if (lookahead == 't') ADVANCE(117);
-      END_STATE();
-    case 223:
-      if (lookahead == 't') ADVANCE(118);
-      END_STATE();
-    case 224:
-      if (lookahead == 't') ADVANCE(40);
-      END_STATE();
-    case 225:
-      if (lookahead == 'u') ADVANCE(241);
-      if (lookahead == 'x') ADVANCE(250);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(497);
-      if (lookahead != 0) ADVANCE(495);
-      END_STATE();
-    case 226:
-      if (lookahead == 'u') ADVANCE(134);
-      END_STATE();
-    case 227:
-      if (lookahead == 'u') ADVANCE(132);
-      END_STATE();
-    case 228:
-      if (lookahead == 'u') ADVANCE(148);
-      END_STATE();
-    case 229:
       if (lookahead == 'u') ADVANCE(128);
       END_STATE();
+    case 223:
+      if (lookahead == 'u') ADVANCE(146);
+      END_STATE();
+    case 224:
+      if (lookahead == 'u') ADVANCE(124);
+      END_STATE();
+    case 225:
+      if (lookahead == 'u') ADVANCE(103);
+      END_STATE();
+    case 226:
+      if (lookahead == 'u') ADVANCE(237);
+      END_STATE();
+    case 227:
+      if (lookahead == 'u') ADVANCE(87);
+      END_STATE();
+    case 228:
+      if (lookahead == 'u') ADVANCE(189);
+      END_STATE();
+    case 229:
+      if (lookahead == 'v') ADVANCE(78);
+      END_STATE();
     case 230:
-      if (lookahead == 'u') ADVANCE(107);
+      if (lookahead == 'x') ADVANCE(49);
       END_STATE();
     case 231:
-      if (lookahead == 'u') ADVANCE(242);
+      if (lookahead == 'x') ADVANCE(271);
       END_STATE();
     case 232:
-      if (lookahead == 'u') ADVANCE(90);
+      if (lookahead == 'y') ADVANCE(172);
       END_STATE();
     case 233:
-      if (lookahead == 'u') ADVANCE(193);
+      if (lookahead == 'y') ADVANCE(267);
       END_STATE();
     case 234:
-      if (lookahead == 'v') ADVANCE(80);
+      if (lookahead == 'y') ADVANCE(174);
       END_STATE();
     case 235:
-      if (lookahead == 'x') ADVANCE(268);
+      if (lookahead == 'y') ADVANCE(175);
       END_STATE();
     case 236:
-      if (lookahead == 'x') ADVANCE(211);
-      END_STATE();
-    case 237:
-      if (lookahead == 'y') ADVANCE(177);
-      END_STATE();
-    case 238:
-      if (lookahead == 'y') ADVANCE(264);
-      END_STATE();
-    case 239:
-      if (lookahead == 'y') ADVANCE(178);
-      END_STATE();
-    case 240:
-      if (lookahead == 'y') ADVANCE(179);
-      END_STATE();
-    case 241:
-      if (lookahead == '{') ADVANCE(247);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(245);
-      END_STATE();
-    case 242:
       if (lookahead == '{') ADVANCE(249);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(252);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
+      END_STATE();
+    case 237:
+      if (lookahead == '{') ADVANCE(252);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(255);
+      END_STATE();
+    case 238:
+      if (lookahead == '}') ADVANCE(510);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(238);
+      END_STATE();
+    case 239:
+      if (lookahead == '}') ADVANCE(709);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(239);
+      END_STATE();
+    case 240:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(246);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(719);
+      END_STATE();
+    case 241:
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(716);
+      END_STATE();
+    case 242:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(717);
       END_STATE();
     case 243:
-      if (lookahead == '}') ADVANCE(495);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(715);
       END_STATE();
     case 244:
-      if (lookahead == '}') ADVANCE(694);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(721);
       END_STATE();
     case 245:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(250);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(718);
       END_STATE();
     case 246:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(495);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(719);
       END_STATE();
     case 247:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(253);
       END_STATE();
     case 248:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(694);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(510);
       END_STATE();
     case 249:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(244);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(238);
       END_STATE();
     case 250:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(709);
       END_STATE();
     case 251:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(720);
       END_STATE();
     case 252:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(251);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(239);
       END_STATE();
     case 253:
-      if (eof) ADVANCE(254);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
+      END_STATE();
+    case 254:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(250);
+      END_STATE();
+    case 255:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(254);
+      END_STATE();
+    case 256:
+      if (eof) ADVANCE(257);
       if (lookahead == '!') ADVANCE(18);
-      if (lookahead == '#') ADVANCE(698);
-      if (lookahead == '%') ADVANCE(308);
-      if (lookahead == '&') ADVANCE(301);
-      if (lookahead == '(') ADVANCE(273);
-      if (lookahead == ')') ADVANCE(274);
-      if (lookahead == '*') ADVANCE(306);
-      if (lookahead == '+') ADVANCE(304);
+      if (lookahead == '#') ADVANCE(723);
+      if (lookahead == '%') ADVANCE(310);
+      if (lookahead == '&') ADVANCE(303);
+      if (lookahead == '\'') ADVANCE(318);
+      if (lookahead == '(') ADVANCE(278);
+      if (lookahead == ')') ADVANCE(279);
+      if (lookahead == '*') ADVANCE(308);
+      if (lookahead == '+') ADVANCE(306);
       if (lookahead == ',') ADVANCE(277);
-      if (lookahead == '-') ADVANCE(305);
-      if (lookahead == '/') ADVANCE(307);
-      if (lookahead == ':') ADVANCE(294);
-      if (lookahead == ';') ADVANCE(263);
-      if (lookahead == '<') ADVANCE(309);
-      if (lookahead == '=') ADVANCE(311);
-      if (lookahead == '>') ADVANCE(315);
-      if (lookahead == '^') ADVANCE(302);
+      if (lookahead == '-') ADVANCE(307);
+      if (lookahead == '/') ADVANCE(309);
+      if (lookahead == ':') ADVANCE(296);
+      if (lookahead == ';') ADVANCE(266);
+      if (lookahead == '<') ADVANCE(311);
+      if (lookahead == '=') ADVANCE(313);
+      if (lookahead == '>') ADVANCE(317);
+      if (lookahead == '\\') ADVANCE(220);
+      if (lookahead == '^') ADVANCE(304);
       if (lookahead == 'a') ADVANCE(43);
-      if (lookahead == 'b') ADVANCE(98);
-      if (lookahead == 'c') ADVANCE(24);
-      if (lookahead == 'd') ADVANCE(35);
-      if (lookahead == 'e') ADVANCE(58);
-      if (lookahead == 'f') ADVANCE(125);
-      if (lookahead == 'i') ADVANCE(139);
-      if (lookahead == 'j') ADVANCE(196);
-      if (lookahead == 'l') ADVANCE(105);
-      if (lookahead == 'm') ADVANCE(160);
-      if (lookahead == 'o') ADVANCE(140);
-      if (lookahead == 'p') ADVANCE(186);
-      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == 'b') ADVANCE(94);
+      if (lookahead == 'c') ADVANCE(25);
+      if (lookahead == 'd') ADVANCE(36);
+      if (lookahead == 'e') ADVANCE(135);
+      if (lookahead == 'f') ADVANCE(121);
+      if (lookahead == 'i') ADVANCE(136);
+      if (lookahead == 'j') ADVANCE(192);
+      if (lookahead == 'l') ADVANCE(101);
+      if (lookahead == 'm') ADVANCE(157);
+      if (lookahead == 'o') ADVANCE(137);
+      if (lookahead == 'p') ADVANCE(182);
+      if (lookahead == 'r') ADVANCE(64);
       if (lookahead == 's') ADVANCE(46);
-      if (lookahead == 't') ADVANCE(237);
-      if (lookahead == 'u') ADVANCE(199);
-      if (lookahead == '{') ADVANCE(256);
-      if (lookahead == '|') ADVANCE(303);
-      if (lookahead == '}') ADVANCE(257);
+      if (lookahead == 't') ADVANCE(232);
+      if (lookahead == 'u') ADVANCE(195);
+      if (lookahead == '{') ADVANCE(259);
+      if (lookahead == '|') ADVANCE(305);
+      if (lookahead == '}') ADVANCE(260);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(699);
-      END_STATE();
-    case 254:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 255:
-      ACCEPT_TOKEN(anon_sym_module);
-      END_STATE();
-    case 256:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+          lookahead == ' ') ADVANCE(724);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_type);
+      ACCEPT_TOKEN(anon_sym_module);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_scalar);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_link);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 261:
-      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      ACCEPT_TOKEN(anon_sym_type);
       END_STATE();
     case 262:
-      ACCEPT_TOKEN(anon_sym_COLON_EQ);
+      ACCEPT_TOKEN(anon_sym_scalar);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(anon_sym_SEMI);
+      ACCEPT_TOKEN(anon_sym_link);
       END_STATE();
     case 264:
-      ACCEPT_TOKEN(anon_sym_property);
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_annotation);
+      ACCEPT_TOKEN(anon_sym_COLON_EQ);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_annotation);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_constraint);
+      ACCEPT_TOKEN(anon_sym_property);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_index);
+      ACCEPT_TOKEN(anon_sym_annotation);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_alias);
+      ACCEPT_TOKEN(anon_sym_annotation);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(anon_sym_using);
+      ACCEPT_TOKEN(anon_sym_constraint);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(anon_sym_using);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_index);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(anon_sym_function);
+      ACCEPT_TOKEN(anon_sym_alias);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_using);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(anon_sym_using);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(anon_sym_edgedb);
+      ACCEPT_TOKEN(anon_sym_function);
       END_STATE();
     case 276:
       ACCEPT_TOKEN(anon_sym_extending);
@@ -2668,2568 +2657,2776 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(anon_sym_on);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(anon_sym_except);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(anon_sym_abstract);
+      ACCEPT_TOKEN(anon_sym_on);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(anon_sym_abstract);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_except);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(anon_sym_overloaded);
+      ACCEPT_TOKEN(anon_sym_abstract);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(anon_sym_overloaded);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_abstract);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 284:
-      ACCEPT_TOKEN(anon_sym_required);
+      ACCEPT_TOKEN(anon_sym_overloaded);
       END_STATE();
     case 285:
-      ACCEPT_TOKEN(anon_sym_required);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_overloaded);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 286:
-      ACCEPT_TOKEN(anon_sym_optional);
+      ACCEPT_TOKEN(anon_sym_required);
       END_STATE();
     case 287:
-      ACCEPT_TOKEN(anon_sym_optional);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_required);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 288:
-      ACCEPT_TOKEN(anon_sym_single);
+      ACCEPT_TOKEN(anon_sym_optional);
       END_STATE();
     case 289:
-      ACCEPT_TOKEN(anon_sym_single);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_optional);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 290:
-      ACCEPT_TOKEN(anon_sym_multi);
+      ACCEPT_TOKEN(anon_sym_single);
       END_STATE();
     case 291:
-      ACCEPT_TOKEN(anon_sym_multi);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_single);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 292:
-      ACCEPT_TOKEN(anon_sym_inheritable);
+      ACCEPT_TOKEN(anon_sym_multi);
       END_STATE();
     case 293:
-      ACCEPT_TOKEN(anon_sym_inheritable);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_multi);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 294:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(anon_sym_inheritable);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(anon_sym_setof);
+      ACCEPT_TOKEN(anon_sym_inheritable);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 296:
-      ACCEPT_TOKEN(anon_sym_global);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 297:
-      ACCEPT_TOKEN(anon_sym_AMP_AMP);
+      ACCEPT_TOKEN(anon_sym_setof);
       END_STATE();
     case 298:
-      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+      ACCEPT_TOKEN(anon_sym_global);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 299:
-      ACCEPT_TOKEN(anon_sym_GT_GT);
+      ACCEPT_TOKEN(anon_sym_AMP_AMP);
       END_STATE();
     case 300:
-      ACCEPT_TOKEN(anon_sym_LT_LT);
+      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
       END_STATE();
     case 301:
-      ACCEPT_TOKEN(anon_sym_AMP);
-      if (lookahead == '&') ADVANCE(297);
+      ACCEPT_TOKEN(anon_sym_GT_GT);
       END_STATE();
     case 302:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_LT_LT);
       END_STATE();
     case 303:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(298);
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(299);
       END_STATE();
     case 304:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(300);
       END_STATE();
     case 306:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 308:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 309:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '<') ADVANCE(300);
-      if (lookahead == '=') ADVANCE(310);
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 310:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 311:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '<') ADVANCE(302);
+      if (lookahead == '=') ADVANCE(312);
       END_STATE();
     case 312:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
     case 315:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(313);
-      if (lookahead == '>') ADVANCE(299);
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
     case 316:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 317:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '\n') ADVANCE(494);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(317);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(315);
+      if (lookahead == '>') ADVANCE(301);
       END_STATE();
     case 318:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == ' ') ADVANCE(435);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
     case 319:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '&') ADVANCE(494);
+      if (lookahead == '\n') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(319);
       END_STATE();
     case 320:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '1') ADVANCE(324);
-      if (lookahead == '3') ADVANCE(321);
-      if (lookahead == '6') ADVANCE(323);
+      if (lookahead == ' ') ADVANCE(440);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 321:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '2') ADVANCE(494);
+      if (lookahead == '&') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 322:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '3') ADVANCE(321);
-      if (lookahead == '6') ADVANCE(323);
+      if (lookahead == '.') ADVANCE(501);
+      if (lookahead == '0') ADVANCE(339);
+      if (lookahead == 'B' ||
+          lookahead == 'b') ADVANCE(502);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(499);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(503);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(508);
+      if (lookahead == '_') ADVANCE(506);
+      if (lookahead == 'n') ADVANCE(509);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(323);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 323:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '4') ADVANCE(494);
+      if (lookahead == '.') ADVANCE(501);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(499);
+      if (lookahead == '_') ADVANCE(504);
+      if (lookahead == 'n') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(323);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '6') ADVANCE(494);
+      if (lookahead == '1') ADVANCE(328);
+      if (lookahead == '3') ADVANCE(325);
+      if (lookahead == '6') ADVANCE(327);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 325:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == ':') ADVANCE(412);
+      if (lookahead == '2') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 326:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == ':') ADVANCE(325);
+      if (lookahead == '3') ADVANCE(325);
+      if (lookahead == '6') ADVANCE(327);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 327:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '<') ADVANCE(494);
-      if (lookahead == '=') ADVANCE(494);
+      if (lookahead == '4') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 328:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '=') ADVANCE(494);
-      if (lookahead == '>') ADVANCE(494);
+      if (lookahead == '6') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 329:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '=') ADVANCE(494);
+      if (lookahead == ':') ADVANCE(417);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 330:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '>') ADVANCE(494);
+      if (lookahead == ':') ADVANCE(329);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 331:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '_') ADVANCE(367);
+      if (lookahead == '<') ADVANCE(509);
+      if (lookahead == '=') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '_') ADVANCE(364);
+      if (lookahead == '=') ADVANCE(509);
+      if (lookahead == '>') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 333:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(406);
-      if (lookahead == 'o') ADVANCE(432);
+      if (lookahead == '=') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 334:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(491);
+      if (lookahead == '>') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 335:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(408);
-      if (lookahead == 'l') ADVANCE(439);
-      if (lookahead == 'u') ADVANCE(425);
+      if (lookahead == '_') ADVANCE(502);
+      if (lookahead == 'n') ADVANCE(509);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(335);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 336:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(450);
+      if (lookahead == '_') ADVANCE(503);
+      if (lookahead == 'n') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(336);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 337:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(357);
+      if (lookahead == '_') ADVANCE(508);
+      if (lookahead == 'n') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(337);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(352);
+      if (lookahead == '_') ADVANCE(373);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 339:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(461);
+      if (lookahead == '_') ADVANCE(506);
+      if (lookahead == 'n') ADVANCE(509);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(339);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 340:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(366);
+      if (lookahead == '_') ADVANCE(507);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(340);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 341:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(405);
+      if (lookahead == '_') ADVANCE(370);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 342:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(469);
+      if (lookahead == 'a') ADVANCE(410);
+      if (lookahead == 'o') ADVANCE(437);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 343:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(360);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(496);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 345:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(412);
+      if (lookahead == 'l') ADVANCE(444);
+      if (lookahead == 'u') ADVANCE(431);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 346:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(455);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 347:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(365);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 348:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(372);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 349:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(466);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(409);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(474);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'a') ADVANCE(415);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 353:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'a') ADVANCE(411);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
-    case 344:
+    case 354:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(407);
+      if (lookahead == 'a') ADVANCE(477);
+      if (lookahead == 'e') ADVANCE(363);
+      if (lookahead == 'u') ADVANCE(458);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
-    case 345:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(472);
-      if (lookahead == 'e') ADVANCE(355);
-      if (lookahead == 'u') ADVANCE(453);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 346:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(472);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 347:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(401);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 348:
+    case 355:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'a') ADVANCE(477);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 349:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'a') ADVANCE(479);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 350:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'b') ADVANCE(494);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 351:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'b') ADVANCE(462);
-      if (lookahead == 'l') ADVANCE(394);
-      if (lookahead == 'n') ADVANCE(429);
-      if (lookahead == 'r') ADVANCE(452);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 352:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'b') ADVANCE(413);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 353:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'b') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 354:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(343);
-      if (lookahead == 'e') ADVANCE(449);
-      if (lookahead == 'i') ADVANCE(426);
-      if (lookahead == 't') ADVANCE(450);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 355:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(395);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 356:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(378);
-      if (lookahead == 't') ADVANCE(382);
+      if (lookahead == 'a') ADVANCE(405);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 357:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(467);
+      if (lookahead == 'a') ADVANCE(482);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 358:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(370);
+      if (lookahead == 'a') ADVANCE(484);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 359:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(344);
+      if (lookahead == 'b') ADVANCE(467);
+      if (lookahead == 'l') ADVANCE(398);
+      if (lookahead == 'n') ADVANCE(434);
+      if (lookahead == 'r') ADVANCE(457);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 360:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'c') ADVANCE(479);
+      if (lookahead == 'b') ADVANCE(416);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 361:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(494);
+      if (lookahead == 'b') ADVANCE(350);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 362:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(387);
-      if (lookahead == 'n') ADVANCE(482);
-      if (lookahead == 'x') ADVANCE(356);
+      if (lookahead == 'c') ADVANCE(352);
+      if (lookahead == 'e') ADVANCE(454);
+      if (lookahead == 'i') ADVANCE(430);
+      if (lookahead == 't') ADVANCE(455);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 363:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(350);
+      if (lookahead == 'c') ADVANCE(399);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 364:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(487);
+      if (lookahead == 'c') ADVANCE(383);
+      if (lookahead == 't') ADVANCE(387);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 365:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(372);
-      if (lookahead == 'h') ADVANCE(379);
-      if (lookahead == 't') ADVANCE(320);
+      if (lookahead == 'c') ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 366:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(373);
+      if (lookahead == 'c') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 367:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(346);
-      if (lookahead == 't') ADVANCE(396);
+      if (lookahead == 'c') ADVANCE(353);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 368:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(399);
-      if (lookahead == 's') ADVANCE(398);
+      if (lookahead == 'c') ADVANCE(484);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'd') ADVANCE(485);
+      if (lookahead == 'd') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(494);
+      if (lookahead == 'd') ADVANCE(492);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(448);
+      if (lookahead == 'd') ADVANCE(378);
+      if (lookahead == 'h') ADVANCE(384);
+      if (lookahead == 't') ADVANCE(324);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(490);
+      if (lookahead == 'd') ADVANCE(379);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 373:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(361);
+      if (lookahead == 'd') ADVANCE(355);
+      if (lookahead == 't') ADVANCE(400);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 374:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(332);
+      if (lookahead == 'd') ADVANCE(403);
+      if (lookahead == 's') ADVANCE(402);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 375:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(363);
+      if (lookahead == 'd') ADVANCE(490);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 376:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(461);
+      if (lookahead == 'e') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 377:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(460);
+      if (lookahead == 'e') ADVANCE(453);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 378:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(444);
+      if (lookahead == 'e') ADVANCE(495);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 379:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(457);
+      if (lookahead == 'e') ADVANCE(369);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 380:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(458);
+      if (lookahead == 'e') ADVANCE(341);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 381:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(416);
+      if (lookahead == 'e') ADVANCE(466);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 382:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(424);
+      if (lookahead == 'e') ADVANCE(465);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 383:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(449);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(462);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(463);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'e') ADVANCE(420);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 387:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'e') ADVANCE(428);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 384:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'e') ADVANCE(476);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 385:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'f') ADVANCE(494);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 386:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'g') ADVANCE(494);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 387:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'g') ADVANCE(375);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 388:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'g') ADVANCE(413);
+      if (lookahead == 'e') ADVANCE(433);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 389:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'g') ADVANCE(401);
+      if (lookahead == 'e') ADVANCE(481);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 390:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'f') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(416);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'g') ADVANCE(405);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(393);
+      if (lookahead == 'o') ADVANCE(445);
+      if (lookahead == 'y') ADVANCE(476);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 396:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'i') ADVANCE(494);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 391:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(389);
-      if (lookahead == 'o') ADVANCE(440);
-      if (lookahead == 'y') ADVANCE(471);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 392:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(489);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 393:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(361);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 394:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(339);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 395:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(419);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 396:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(418);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 397:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(369);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'i') ADVANCE(349);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 399:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'i') ADVANCE(423);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
-    case 398:
+    case 400:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(441);
+      if (lookahead == 'i') ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
-    case 399:
+    case 401:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'i') ADVANCE(427);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 400:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(459);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 401:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(430);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 402:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(478);
+      if (lookahead == 'i') ADVANCE(446);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 403:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'i') ADVANCE(443);
+      if (lookahead == 'i') ADVANCE(432);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 404:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'k') ADVANCE(494);
+      if (lookahead == 'i') ADVANCE(464);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 405:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(494);
+      if (lookahead == 'i') ADVANCE(435);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 406:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(326);
+      if (lookahead == 'i') ADVANCE(483);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 407:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(331);
+      if (lookahead == 'i') ADVANCE(448);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 408:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(464);
+      if (lookahead == 'k') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 409:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(434);
+      if (lookahead == 'l') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 410:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(405);
+      if (lookahead == 'l') ADVANCE(330);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 411:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(336);
+      if (lookahead == 'l') ADVANCE(338);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 412:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(438);
-      if (lookahead == 'r') ADVANCE(381);
+      if (lookahead == 'l') ADVANCE(469);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 413:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(370);
+      if (lookahead == 'l') ADVANCE(439);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 414:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(442);
+      if (lookahead == 'l') ADVANCE(409);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 415:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(475);
+      if (lookahead == 'l') ADVANCE(346);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 416:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'l') ADVANCE(348);
+      if (lookahead == 'l') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 417:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'm') ADVANCE(494);
+      if (lookahead == 'l') ADVANCE(443);
+      if (lookahead == 'r') ADVANCE(386);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 418:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'm') ADVANCE(370);
+      if (lookahead == 'l') ADVANCE(447);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 419:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'm') ADVANCE(341);
+      if (lookahead == 'l') ADVANCE(480);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 420:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(494);
-      if (lookahead == 'p') ADVANCE(474);
-      if (lookahead == 'v') ADVANCE(377);
+      if (lookahead == 'l') ADVANCE(357);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 421:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(494);
+      if (lookahead == 'm') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 422:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(365);
+      if (lookahead == 'm') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 423:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(404);
+      if (lookahead == 'm') ADVANCE(350);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 424:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(509);
+      if (lookahead == 'p') ADVANCE(479);
+      if (lookahead == 'v') ADVANCE(382);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(371);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(408);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(374);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 429:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(487);
+      if (lookahead == 'x') ADVANCE(364);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 430:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'n') ADVANCE(392);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 431:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'n') ADVANCE(368);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 425:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(360);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 426:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(388);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 427:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(386);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 428:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(358);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 429:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(437);
-      if (lookahead == 'y') ADVANCE(468);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 430:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(467);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 431:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(341);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'n') ADVANCE(466);
+      if (lookahead == 'n') ADVANCE(391);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(369);
-      if (lookahead == 'u') ADVANCE(415);
+      if (lookahead == 'n') ADVANCE(366);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 434:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(353);
+      if (lookahead == 'n') ADVANCE(442);
+      if (lookahead == 'y') ADVANCE(473);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 435:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(385);
+      if (lookahead == 'n') ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(447);
+      if (lookahead == 'n') ADVANCE(350);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 437:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(473);
+      if (lookahead == 'n') ADVANCE(471);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 438:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(359);
+      if (lookahead == 'o') ADVANCE(375);
+      if (lookahead == 'u') ADVANCE(419);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(342);
+      if (lookahead == 'o') ADVANCE(361);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 440:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(405);
+      if (lookahead == 'o') ADVANCE(390);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 441:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(421);
+      if (lookahead == 'o') ADVANCE(452);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 442:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(340);
+      if (lookahead == 'o') ADVANCE(478);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 443:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'o') ADVANCE(431);
+      if (lookahead == 'o') ADVANCE(367);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'p') ADVANCE(467);
+      if (lookahead == 'o') ADVANCE(351);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 445:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'p') ADVANCE(413);
+      if (lookahead == 'o') ADVANCE(409);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 446:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'p') ADVANCE(370);
+      if (lookahead == 'o') ADVANCE(425);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 447:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'p') ADVANCE(380);
+      if (lookahead == 'o') ADVANCE(348);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 448:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'q') ADVANCE(484);
+      if (lookahead == 'o') ADVANCE(436);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 449:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'q') ADVANCE(488);
-      if (lookahead == 't') ADVANCE(318);
+      if (lookahead == 'p') ADVANCE(472);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 450:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(494);
+      if (lookahead == 'p') ADVANCE(416);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 451:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(486);
-      if (lookahead == 'u') ADVANCE(445);
-      if (lookahead == 'y') ADVANCE(446);
+      if (lookahead == 'p') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 452:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(385);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 453:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(349);
+      if (lookahead == 'q') ADVANCE(489);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 454:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(436);
+      if (lookahead == 'q') ADVANCE(493);
+      if (lookahead == 't') ADVANCE(320);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 455:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(337);
+      if (lookahead == 'r') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 456:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(491);
+      if (lookahead == 'u') ADVANCE(450);
+      if (lookahead == 'y') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 457:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(344);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 458:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(358);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 459:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'r') ADVANCE(441);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 460:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 'r') ADVANCE(347);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 457:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(402);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 458:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(470);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 459:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(373);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 460:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'r') ADVANCE(414);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 461:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(494);
+      if (lookahead == 'r') ADVANCE(356);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 462:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(480);
+      if (lookahead == 'r') ADVANCE(406);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 463:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(441);
+      if (lookahead == 'r') ADVANCE(475);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 464:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(370);
+      if (lookahead == 'r') ADVANCE(379);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 465:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(399);
-      if (lookahead == 'u') ADVANCE(393);
+      if (lookahead == 'r') ADVANCE(418);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 466:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 's') ADVANCE(481);
+      if (lookahead == 's') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 467:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(494);
+      if (lookahead == 's') ADVANCE(485);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 468:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(492);
+      if (lookahead == 's') ADVANCE(446);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 469:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(322);
+      if (lookahead == 's') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 470:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(491);
+      if (lookahead == 's') ADVANCE(403);
+      if (lookahead == 'u') ADVANCE(397);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 471:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(376);
+      if (lookahead == 's') ADVANCE(486);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 472:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(384);
+      if (lookahead == 't') ADVANCE(509);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 473:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(349);
+      if (lookahead == 't') ADVANCE(497);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 474:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(403);
+      if (lookahead == 't') ADVANCE(326);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 475:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(390);
+      if (lookahead == 't') ADVANCE(496);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 476:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(381);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 477:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(389);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 478:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(358);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(407);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(394);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 't') ADVANCE(400);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
+      END_STATE();
+    case 482:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
       if (lookahead == 't') ADVANCE(396);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 477:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(392);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 478:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(338);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 479:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(398);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 480:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(455);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 481:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 't') ADVANCE(456);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
-      END_STATE();
-    case 482:
-      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(417);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 483:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(410);
+      if (lookahead == 't') ADVANCE(343);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 484:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(400);
+      if (lookahead == 't') ADVANCE(402);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 485:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(413);
+      if (lookahead == 't') ADVANCE(460);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 486:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(370);
+      if (lookahead == 't') ADVANCE(461);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 487:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(453);
+      if (lookahead == 'u') ADVANCE(421);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 488:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'u') ADVANCE(383);
+      if (lookahead == 'u') ADVANCE(414);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 489:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'v') ADVANCE(374);
+      if (lookahead == 'u') ADVANCE(404);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 490:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'x') ADVANCE(494);
+      if (lookahead == 'u') ADVANCE(416);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 491:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'y') ADVANCE(494);
+      if (lookahead == 'u') ADVANCE(376);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 492:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == 'y') ADVANCE(446);
+      if (lookahead == 'u') ADVANCE(458);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 493:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
-      if (lookahead == '|') ADVANCE(494);
+      if (lookahead == 'u') ADVANCE(388);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 494:
       ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'v') ADVANCE(380);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(494);
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 495:
-      ACCEPT_TOKEN(sym_escape_sequence);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'x') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 496:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(495);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'y') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 497:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(496);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'y') ADVANCE(451);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 498:
-      ACCEPT_TOKEN(anon_sym_str);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '|') ADVANCE(509);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 499:
-      ACCEPT_TOKEN(anon_sym_str);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(507);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(340);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 500:
-      ACCEPT_TOKEN(anon_sym_bool);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(499);
+      if (lookahead == '_') ADVANCE(505);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(500);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 501:
-      ACCEPT_TOKEN(anon_sym_bool);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(499);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(500);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 502:
-      ACCEPT_TOKEN(anon_sym_int16);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(335);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 503:
-      ACCEPT_TOKEN(anon_sym_int16);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(336);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 504:
-      ACCEPT_TOKEN(anon_sym_int32);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(323);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 505:
-      ACCEPT_TOKEN(anon_sym_int32);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(500);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 506:
-      ACCEPT_TOKEN(anon_sym_int64);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(339);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 507:
-      ACCEPT_TOKEN(anon_sym_int64);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(340);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 508:
-      ACCEPT_TOKEN(anon_sym_float32);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(337);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 509:
-      ACCEPT_TOKEN(anon_sym_float32);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_unescaped_single_string_fragment);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(509);
       END_STATE();
     case 510:
-      ACCEPT_TOKEN(anon_sym_float64);
+      ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
     case 511:
-      ACCEPT_TOKEN(anon_sym_float64);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_escape_sequence);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(510);
       END_STATE();
     case 512:
-      ACCEPT_TOKEN(anon_sym_bigint);
+      ACCEPT_TOKEN(sym_escape_sequence);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(511);
       END_STATE();
     case 513:
-      ACCEPT_TOKEN(anon_sym_bigint);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_str);
       END_STATE();
     case 514:
-      ACCEPT_TOKEN(anon_sym_decimal);
+      ACCEPT_TOKEN(anon_sym_str);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 515:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_bool);
       END_STATE();
     case 516:
-      ACCEPT_TOKEN(anon_sym_json);
+      ACCEPT_TOKEN(anon_sym_bool);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 517:
-      ACCEPT_TOKEN(anon_sym_json);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_int16);
       END_STATE();
     case 518:
-      ACCEPT_TOKEN(anon_sym_uuid);
+      ACCEPT_TOKEN(anon_sym_int16);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 519:
-      ACCEPT_TOKEN(anon_sym_uuid);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_int32);
       END_STATE();
     case 520:
-      ACCEPT_TOKEN(anon_sym_bytes);
+      ACCEPT_TOKEN(anon_sym_int32);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 521:
-      ACCEPT_TOKEN(anon_sym_bytes);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_int64);
       END_STATE();
     case 522:
-      ACCEPT_TOKEN(anon_sym_datetime);
+      ACCEPT_TOKEN(anon_sym_int64);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 523:
-      ACCEPT_TOKEN(anon_sym_datetime);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_float32);
       END_STATE();
     case 524:
-      ACCEPT_TOKEN(anon_sym_duration);
+      ACCEPT_TOKEN(anon_sym_float32);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 525:
-      ACCEPT_TOKEN(anon_sym_duration);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_float64);
       END_STATE();
     case 526:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
+      ACCEPT_TOKEN(anon_sym_float64);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 527:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
-      if (lookahead == 't') ADVANCE(115);
+      ACCEPT_TOKEN(anon_sym_bigint);
       END_STATE();
     case 528:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
+      ACCEPT_TOKEN(anon_sym_bigint);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 529:
-      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
+      ACCEPT_TOKEN(anon_sym_decimal);
       END_STATE();
     case 530:
-      ACCEPT_TOKEN(anon_sym_sequence);
+      ACCEPT_TOKEN(anon_sym_decimal);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 531:
-      ACCEPT_TOKEN(anon_sym_sequence);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_json);
       END_STATE();
     case 532:
-      ACCEPT_TOKEN(anon_sym_anytype);
+      ACCEPT_TOKEN(anon_sym_json);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 533:
-      ACCEPT_TOKEN(anon_sym_anytype);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_uuid);
       END_STATE();
     case 534:
-      ACCEPT_TOKEN(anon_sym_array);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_uuid);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 535:
-      ACCEPT_TOKEN(anon_sym_tuple);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_bytes);
       END_STATE();
     case 536:
-      ACCEPT_TOKEN(anon_sym_scalartype);
+      ACCEPT_TOKEN(anon_sym_bytes);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 537:
-      ACCEPT_TOKEN(anon_sym_enum);
+      ACCEPT_TOKEN(anon_sym_datetime);
       END_STATE();
     case 538:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ' ') ADVANCE(161);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_datetime);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 539:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ' ') ADVANCE(220);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_duration);
       END_STATE();
     case 540:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(546);
-      if (lookahead == '3') ADVANCE(541);
-      if (lookahead == '6') ADVANCE(544);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_duration);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 541:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(505);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_datetime);
       END_STATE();
     case 542:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(509);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_date);
+      if (lookahead == 't') ADVANCE(111);
       END_STATE();
     case 543:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '3') ADVANCE(542);
-      if (lookahead == '6') ADVANCE(545);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONlocal_time);
       END_STATE();
     case 544:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(507);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_cal_COLON_COLONrelative_duration);
       END_STATE();
     case 545:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(511);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_sequence);
       END_STATE();
     case 546:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(503);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_sequence);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 547:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == ':') ADVANCE(16);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_5(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_anytype);
       END_STATE();
     case 548:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(564);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_anytype);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 549:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(609);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_array);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 550:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(573);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_tuple);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 551:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(691);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_scalartype);
       END_STATE();
     case 552:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(657);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(anon_sym_enum);
       END_STATE();
     case 553:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(568);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == ' ') ADVANCE(158);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 554:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(611);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == ' ') ADVANCE(215);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 555:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(671);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '1') ADVANCE(561);
+      if (lookahead == '3') ADVANCE(556);
+      if (lookahead == '6') ADVANCE(559);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 556:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(612);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '2') ADVANCE(520);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 557:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(616);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '2') ADVANCE(524);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 558:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(618);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '3') ADVANCE(557);
+      if (lookahead == '6') ADVANCE(560);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 559:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(614);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '4') ADVANCE(522);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 560:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(675);
-      if (lookahead == 'e') ADVANCE(566);
-      if (lookahead == 'u') ADVANCE(658);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '4') ADVANCE(526);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 561:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(678);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '6') ADVANCE(518);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 562:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(681);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == ':') ADVANCE(16);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_5(lookahead)) ADVANCE(709);
       END_STATE();
     case 563:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'b') ADVANCE(666);
-      if (lookahead == 'n') ADVANCE(636);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(579);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 564:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'b') ADVANCE(622);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(624);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 565:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'b') ADVANCE(559);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(588);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 566:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'c') ADVANCE(598);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(706);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 567:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'c') ADVANCE(578);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(672);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 568:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'c') ADVANCE(673);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(583);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 569:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'c') ADVANCE(557);
-      if (lookahead == 'e') ADVANCE(653);
-      if (lookahead == 't') ADVANCE(655);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(626);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 570:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'd') ADVANCE(519);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(686);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 571:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'd') ADVANCE(285);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(627);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 572:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'd') ADVANCE(283);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(631);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 573:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'd') ADVANCE(588);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(633);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 574:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(652);
-      if (lookahead == 't') ADVANCE(655);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(629);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 575:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(535);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(690);
+      if (lookahead == 'e') ADVANCE(581);
+      if (lookahead == 'u') ADVANCE(673);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 576:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(533);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(693);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 577:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(523);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'a') ADVANCE(696);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 578:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(531);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'b') ADVANCE(681);
+      if (lookahead == 'n') ADVANCE(651);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 579:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(653);
-      if (lookahead == 't') ADVANCE(655);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'b') ADVANCE(637);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 580:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(289);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'b') ADVANCE(574);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 581:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(293);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'c') ADVANCE(613);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 582:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(695);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'c') ADVANCE(593);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 583:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(696);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'c') ADVANCE(688);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 584:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(664);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'c') ADVANCE(572);
+      if (lookahead == 'e') ADVANCE(668);
+      if (lookahead == 't') ADVANCE(670);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 585:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(571);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'd') ADVANCE(534);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 586:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(634);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'd') ADVANCE(287);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 587:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(663);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'd') ADVANCE(285);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 588:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(572);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'd') ADVANCE(603);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 589:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(660);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(667);
+      if (lookahead == 't') ADVANCE(670);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 590:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(654);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(550);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 591:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'e') ADVANCE(677);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(548);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 592:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'g') ADVANCE(271);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(538);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 593:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'g') ADVANCE(608);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(546);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 594:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'g') ADVANCE(621);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(668);
+      if (lookahead == 't') ADVANCE(670);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 595:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'h') ADVANCE(589);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(291);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 596:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(593);
-      if (lookahead == 'o') ADVANCE(641);
-      if (lookahead == 'y') ADVANCE(669);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(295);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 597:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(570);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(710);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 598:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(626);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(711);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 599:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(291);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(679);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 600:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(625);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(586);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 601:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(642);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(649);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 602:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(643);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(678);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 603:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(661);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(587);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 604:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(646);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(675);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 605:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(632);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(669);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 606:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(635);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(692);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 607:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(679);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'g') ADVANCE(274);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 608:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'i') ADVANCE(637);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'g') ADVANCE(623);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 609:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(547);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'g') ADVANCE(636);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 610:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(501);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'h') ADVANCE(604);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 611:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(515);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(608);
+      if (lookahead == 'o') ADVANCE(656);
+      if (lookahead == 'y') ADVANCE(684);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 612:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(287);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(585);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 613:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(697);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(641);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 614:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(296);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(293);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 615:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(647);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(640);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 616:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(552);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(657);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 617:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(575);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(658);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 618:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(667);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(676);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 619:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(640);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(661);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 620:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(613);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(647);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 621:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(580);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(650);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 622:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(581);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(694);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 623:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(644);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'i') ADVANCE(652);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 624:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'l') ADVANCE(680);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(562);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 625:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'm') ADVANCE(577);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(516);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 626:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'm') ADVANCE(554);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(530);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 627:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(693);
-      if (lookahead == 'r') ADVANCE(656);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(289);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 628:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(517);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(712);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 629:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(525);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(298);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 630:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(595);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(662);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 631:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(266);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(567);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 632:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(594);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(590);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 633:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(670);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(682);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 634:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(567);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(655);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 635:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(592);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(628);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 636:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(645);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(595);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 637:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(672);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(596);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 638:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'n') ADVANCE(556);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(659);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 639:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(628);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'l') ADVANCE(695);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 640:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(565);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'm') ADVANCE(592);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 641:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(610);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'm') ADVANCE(569);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 642:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(638);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(708);
+      if (lookahead == 'r') ADVANCE(671);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 643:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(629);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(532);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 644:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(550);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(540);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 645:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(683);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(610);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 646:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(631);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(269);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 647:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'o') ADVANCE(555);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(609);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 648:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'p') ADVANCE(676);
-      if (lookahead == 'v') ADVANCE(587);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(685);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 649:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'p') ADVANCE(676);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(582);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 650:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'p') ADVANCE(617);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(607);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 651:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'p') ADVANCE(576);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(660);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 652:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'q') ADVANCE(686);
-      if (lookahead == 't') ADVANCE(538);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(687);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 653:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'q') ADVANCE(686);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(571);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 654:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'q') ADVANCE(688);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(643);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 655:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(499);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(580);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 656:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(551);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(625);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 657:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(539);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(653);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 658:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(561);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(644);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 659:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(553);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(565);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 660:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(607);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(698);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 661:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(585);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(646);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 662:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(690);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'o') ADVANCE(570);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 663:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'r') ADVANCE(623);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'p') ADVANCE(691);
+      if (lookahead == 'v') ADVANCE(602);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 664:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 's') ADVANCE(521);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'p') ADVANCE(691);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 665:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 's') ADVANCE(639);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'p') ADVANCE(632);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 666:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 's') ADVANCE(682);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'p') ADVANCE(591);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 667:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 's') ADVANCE(583);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'q') ADVANCE(701);
+      if (lookahead == 't') ADVANCE(553);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 668:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 's') ADVANCE(606);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'q') ADVANCE(701);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 669:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(584);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'q') ADVANCE(703);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 670:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(540);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(514);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 671:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(543);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(566);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 672:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(513);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(554);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 673:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(281);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(576);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 674:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(692);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(568);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 675:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(591);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(622);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 676:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(601);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(600);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 677:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(600);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(705);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 678:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(602);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'r') ADVANCE(638);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 679:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(548);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 's') ADVANCE(536);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 680:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(599);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 's') ADVANCE(654);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 681:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(604);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 's') ADVANCE(697);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 682:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(659);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 's') ADVANCE(598);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 683:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 't') ADVANCE(562);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 's') ADVANCE(621);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 684:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(597);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(599);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 685:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(650);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(555);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 686:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(586);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(558);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 687:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(624);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(528);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 688:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(603);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(283);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 689:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(620);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(707);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 690:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'u') ADVANCE(582);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(606);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 691:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'y') ADVANCE(534);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(616);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 692:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'y') ADVANCE(651);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(615);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 693:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (lookahead == 'y') ADVANCE(674);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(617);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 694:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(563);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 695:
-      ACCEPT_TOKEN(sym_true);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(614);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 696:
-      ACCEPT_TOKEN(sym_false);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(619);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 697:
-      ACCEPT_TOKEN(sym_null);
-      if (lookahead == '\\') ADVANCE(231);
-      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(694);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(674);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 698:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(698);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 't') ADVANCE(577);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
       END_STATE();
     case 699:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(612);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 700:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(665);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 701:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(601);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 702:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(639);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 703:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(618);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 704:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(635);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 705:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'u') ADVANCE(597);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 706:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'y') ADVANCE(549);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 707:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'y') ADVANCE(666);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 708:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (lookahead == 'y') ADVANCE(689);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 709:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 710:
+      ACCEPT_TOKEN(sym_true);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 711:
+      ACCEPT_TOKEN(sym_false);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 712:
+      ACCEPT_TOKEN(sym_null);
+      if (lookahead == '\\') ADVANCE(226);
+      if (!sym_identifier_character_set_4(lookahead)) ADVANCE(709);
+      END_STATE();
+    case 713:
+      ACCEPT_TOKEN(sym_number);
+      END_STATE();
+    case 714:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(722);
+      if (lookahead == '0') ADVANCE(718);
+      if (lookahead == 'B' ||
+          lookahead == 'b') ADVANCE(241);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(240);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(242);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(251);
+      if (lookahead == '_') ADVANCE(245);
+      if (lookahead == 'n') ADVANCE(713);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(715);
+      END_STATE();
+    case 715:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(722);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(240);
+      if (lookahead == '_') ADVANCE(243);
+      if (lookahead == 'n') ADVANCE(713);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(715);
+      END_STATE();
+    case 716:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(241);
+      if (lookahead == 'n') ADVANCE(713);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(716);
+      END_STATE();
+    case 717:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(242);
+      if (lookahead == 'n') ADVANCE(713);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(717);
+      END_STATE();
+    case 718:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(245);
+      if (lookahead == 'n') ADVANCE(713);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(718);
+      END_STATE();
+    case 719:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(246);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(719);
+      END_STATE();
+    case 720:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(251);
+      if (lookahead == 'n') ADVANCE(713);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(720);
+      END_STATE();
+    case 721:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(240);
+      if (lookahead == '_') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(721);
+      END_STATE();
+    case 722:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(240);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(721);
+      END_STATE();
+    case 723:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(723);
+      END_STATE();
+    case 724:
       ACCEPT_TOKEN(sym__whitespace);
       END_STATE();
     default:
@@ -5238,58 +5435,58 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 }
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
-  [0] = {.lex_state = 0},
-  [1] = {.lex_state = 253},
-  [2] = {.lex_state = 253},
-  [3] = {.lex_state = 253},
-  [4] = {.lex_state = 253},
-  [5] = {.lex_state = 253},
-  [6] = {.lex_state = 253},
-  [7] = {.lex_state = 253},
-  [8] = {.lex_state = 253},
-  [9] = {.lex_state = 253},
-  [10] = {.lex_state = 253},
-  [11] = {.lex_state = 253},
-  [12] = {.lex_state = 253},
-  [13] = {.lex_state = 253},
-  [14] = {.lex_state = 253},
-  [15] = {.lex_state = 253},
-  [16] = {.lex_state = 253},
-  [17] = {.lex_state = 253},
-  [18] = {.lex_state = 253},
-  [19] = {.lex_state = 253},
-  [20] = {.lex_state = 253},
-  [21] = {.lex_state = 253},
-  [22] = {.lex_state = 253},
-  [23] = {.lex_state = 253},
-  [24] = {.lex_state = 253},
-  [25] = {.lex_state = 253},
-  [26] = {.lex_state = 253},
-  [27] = {.lex_state = 253},
-  [28] = {.lex_state = 253},
-  [29] = {.lex_state = 253},
-  [30] = {.lex_state = 253},
+  [0] = {.lex_state = 0, .external_lex_state = 1},
+  [1] = {.lex_state = 256},
+  [2] = {.lex_state = 256},
+  [3] = {.lex_state = 256},
+  [4] = {.lex_state = 256},
+  [5] = {.lex_state = 256},
+  [6] = {.lex_state = 256},
+  [7] = {.lex_state = 256},
+  [8] = {.lex_state = 256},
+  [9] = {.lex_state = 256},
+  [10] = {.lex_state = 256},
+  [11] = {.lex_state = 256},
+  [12] = {.lex_state = 256},
+  [13] = {.lex_state = 256},
+  [14] = {.lex_state = 256},
+  [15] = {.lex_state = 256},
+  [16] = {.lex_state = 256},
+  [17] = {.lex_state = 256},
+  [18] = {.lex_state = 256},
+  [19] = {.lex_state = 256},
+  [20] = {.lex_state = 256},
+  [21] = {.lex_state = 256},
+  [22] = {.lex_state = 256},
+  [23] = {.lex_state = 256},
+  [24] = {.lex_state = 256},
+  [25] = {.lex_state = 256},
+  [26] = {.lex_state = 256},
+  [27] = {.lex_state = 256},
+  [28] = {.lex_state = 256},
+  [29] = {.lex_state = 256},
+  [30] = {.lex_state = 256},
   [31] = {.lex_state = 4},
-  [32] = {.lex_state = 4},
+  [32] = {.lex_state = 6},
   [33] = {.lex_state = 6},
-  [34] = {.lex_state = 6},
-  [35] = {.lex_state = 8},
-  [36] = {.lex_state = 8},
-  [37] = {.lex_state = 8},
-  [38] = {.lex_state = 8},
-  [39] = {.lex_state = 8},
-  [40] = {.lex_state = 8},
-  [41] = {.lex_state = 8},
-  [42] = {.lex_state = 8},
-  [43] = {.lex_state = 8},
-  [44] = {.lex_state = 8},
-  [45] = {.lex_state = 8},
-  [46] = {.lex_state = 8},
-  [47] = {.lex_state = 8},
-  [48] = {.lex_state = 8},
-  [49] = {.lex_state = 253},
-  [50] = {.lex_state = 253},
-  [51] = {.lex_state = 253},
+  [34] = {.lex_state = 7},
+  [35] = {.lex_state = 7},
+  [36] = {.lex_state = 7},
+  [37] = {.lex_state = 7},
+  [38] = {.lex_state = 7},
+  [39] = {.lex_state = 7},
+  [40] = {.lex_state = 7},
+  [41] = {.lex_state = 7},
+  [42] = {.lex_state = 7},
+  [43] = {.lex_state = 7},
+  [44] = {.lex_state = 7},
+  [45] = {.lex_state = 7},
+  [46] = {.lex_state = 7},
+  [47] = {.lex_state = 7},
+  [48] = {.lex_state = 256},
+  [49] = {.lex_state = 256},
+  [50] = {.lex_state = 256},
+  [51] = {.lex_state = 5},
   [52] = {.lex_state = 5},
   [53] = {.lex_state = 5},
   [54] = {.lex_state = 5},
@@ -5305,177 +5502,177 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [64] = {.lex_state = 5},
   [65] = {.lex_state = 5},
   [66] = {.lex_state = 5},
-  [67] = {.lex_state = 253},
+  [67] = {.lex_state = 256},
   [68] = {.lex_state = 5},
-  [69] = {.lex_state = 253},
+  [69] = {.lex_state = 256},
   [70] = {.lex_state = 5},
   [71] = {.lex_state = 5},
   [72] = {.lex_state = 5},
-  [73] = {.lex_state = 253},
+  [73] = {.lex_state = 256},
   [74] = {.lex_state = 5},
-  [75] = {.lex_state = 253},
-  [76] = {.lex_state = 5},
-  [77] = {.lex_state = 5},
-  [78] = {.lex_state = 253},
-  [79] = {.lex_state = 253},
-  [80] = {.lex_state = 253},
-  [81] = {.lex_state = 253},
-  [82] = {.lex_state = 253},
-  [83] = {.lex_state = 5},
-  [84] = {.lex_state = 253},
-  [85] = {.lex_state = 253},
-  [86] = {.lex_state = 253},
-  [87] = {.lex_state = 253},
-  [88] = {.lex_state = 253},
-  [89] = {.lex_state = 253},
-  [90] = {.lex_state = 5},
-  [91] = {.lex_state = 253},
-  [92] = {.lex_state = 5},
-  [93] = {.lex_state = 253},
-  [94] = {.lex_state = 253},
-  [95] = {.lex_state = 253},
-  [96] = {.lex_state = 253},
-  [97] = {.lex_state = 253},
-  [98] = {.lex_state = 253},
-  [99] = {.lex_state = 253},
-  [100] = {.lex_state = 253},
-  [101] = {.lex_state = 253},
-  [102] = {.lex_state = 7},
-  [103] = {.lex_state = 7},
-  [104] = {.lex_state = 7},
-  [105] = {.lex_state = 7},
-  [106] = {.lex_state = 253},
-  [107] = {.lex_state = 253},
-  [108] = {.lex_state = 253},
-  [109] = {.lex_state = 253},
-  [110] = {.lex_state = 253},
-  [111] = {.lex_state = 7},
-  [112] = {.lex_state = 7},
-  [113] = {.lex_state = 253},
-  [114] = {.lex_state = 253},
-  [115] = {.lex_state = 253},
-  [116] = {.lex_state = 253},
-  [117] = {.lex_state = 7},
-  [118] = {.lex_state = 7},
-  [119] = {.lex_state = 253},
-  [120] = {.lex_state = 253},
-  [121] = {.lex_state = 253},
-  [122] = {.lex_state = 7},
-  [123] = {.lex_state = 253},
-  [124] = {.lex_state = 253},
-  [125] = {.lex_state = 253},
-  [126] = {.lex_state = 7},
-  [127] = {.lex_state = 7},
-  [128] = {.lex_state = 253},
-  [129] = {.lex_state = 253},
-  [130] = {.lex_state = 253},
-  [131] = {.lex_state = 253},
-  [132] = {.lex_state = 253},
-  [133] = {.lex_state = 253},
-  [134] = {.lex_state = 253},
-  [135] = {.lex_state = 253},
-  [136] = {.lex_state = 7},
-  [137] = {.lex_state = 253},
-  [138] = {.lex_state = 253},
-  [139] = {.lex_state = 253},
-  [140] = {.lex_state = 253},
-  [141] = {.lex_state = 253},
-  [142] = {.lex_state = 253},
-  [143] = {.lex_state = 7},
-  [144] = {.lex_state = 253},
-  [145] = {.lex_state = 7},
-  [146] = {.lex_state = 253},
-  [147] = {.lex_state = 253},
-  [148] = {.lex_state = 253},
-  [149] = {.lex_state = 253},
-  [150] = {.lex_state = 7},
-  [151] = {.lex_state = 7},
-  [152] = {.lex_state = 7},
-  [153] = {.lex_state = 253},
-  [154] = {.lex_state = 7},
-  [155] = {.lex_state = 253},
-  [156] = {.lex_state = 253},
-  [157] = {.lex_state = 253},
-  [158] = {.lex_state = 7},
-  [159] = {.lex_state = 253},
-  [160] = {.lex_state = 253},
-  [161] = {.lex_state = 253},
-  [162] = {.lex_state = 253},
-  [163] = {.lex_state = 253},
-  [164] = {.lex_state = 7},
-  [165] = {.lex_state = 7},
-  [166] = {.lex_state = 253},
-  [167] = {.lex_state = 7},
-  [168] = {.lex_state = 253},
-  [169] = {.lex_state = 7},
-  [170] = {.lex_state = 7},
-  [171] = {.lex_state = 253},
-  [172] = {.lex_state = 253},
-  [173] = {.lex_state = 7},
-  [174] = {.lex_state = 253},
-  [175] = {.lex_state = 253},
-  [176] = {.lex_state = 253},
-  [177] = {.lex_state = 253},
-  [178] = {.lex_state = 7},
-  [179] = {.lex_state = 253},
-  [180] = {.lex_state = 253},
-  [181] = {.lex_state = 253},
-  [182] = {.lex_state = 253},
-  [183] = {.lex_state = 7},
-  [184] = {.lex_state = 253},
-  [185] = {.lex_state = 253},
-  [186] = {.lex_state = 7},
-  [187] = {.lex_state = 7},
-  [188] = {.lex_state = 7},
-  [189] = {.lex_state = 253},
-  [190] = {.lex_state = 7},
-  [191] = {.lex_state = 7},
-  [192] = {.lex_state = 253},
-  [193] = {.lex_state = 253},
-  [194] = {.lex_state = 253},
-  [195] = {.lex_state = 253},
-  [196] = {.lex_state = 253},
-  [197] = {.lex_state = 253},
-  [198] = {.lex_state = 253},
-  [199] = {.lex_state = 253},
-  [200] = {.lex_state = 253},
-  [201] = {.lex_state = 253},
-  [202] = {.lex_state = 253},
-  [203] = {.lex_state = 253},
-  [204] = {.lex_state = 253},
-  [205] = {.lex_state = 253},
-  [206] = {.lex_state = 253},
-  [207] = {.lex_state = 253},
-  [208] = {.lex_state = 253},
-  [209] = {.lex_state = 253},
-  [210] = {.lex_state = 253},
-  [211] = {.lex_state = 253},
-  [212] = {.lex_state = 5},
-  [213] = {.lex_state = 5},
-  [214] = {.lex_state = 5},
-  [215] = {.lex_state = 253},
-  [216] = {.lex_state = 5},
-  [217] = {.lex_state = 253},
-  [218] = {.lex_state = 253},
-  [219] = {.lex_state = 253},
-  [220] = {.lex_state = 253},
-  [221] = {.lex_state = 253},
-  [222] = {.lex_state = 253},
-  [223] = {.lex_state = 253},
-  [224] = {.lex_state = 253},
-  [225] = {.lex_state = 253},
-  [226] = {.lex_state = 253},
-  [227] = {.lex_state = 253},
-  [228] = {.lex_state = 253},
-  [229] = {.lex_state = 253},
-  [230] = {.lex_state = 253},
-  [231] = {.lex_state = 253},
-  [232] = {.lex_state = 7},
-  [233] = {.lex_state = 253},
-  [234] = {.lex_state = 253},
-  [235] = {.lex_state = 253},
+  [75] = {.lex_state = 5},
+  [76] = {.lex_state = 256},
+  [77] = {.lex_state = 256},
+  [78] = {.lex_state = 256},
+  [79] = {.lex_state = 256},
+  [80] = {.lex_state = 256},
+  [81] = {.lex_state = 5},
+  [82] = {.lex_state = 256},
+  [83] = {.lex_state = 256},
+  [84] = {.lex_state = 256},
+  [85] = {.lex_state = 256},
+  [86] = {.lex_state = 256},
+  [87] = {.lex_state = 5},
+  [88] = {.lex_state = 256},
+  [89] = {.lex_state = 5},
+  [90] = {.lex_state = 256},
+  [91] = {.lex_state = 256},
+  [92] = {.lex_state = 256},
+  [93] = {.lex_state = 256},
+  [94] = {.lex_state = 256},
+  [95] = {.lex_state = 256},
+  [96] = {.lex_state = 256},
+  [97] = {.lex_state = 256},
+  [98] = {.lex_state = 256},
+  [99] = {.lex_state = 256},
+  [100] = {.lex_state = 256},
+  [101] = {.lex_state = 256},
+  [102] = {.lex_state = 256},
+  [103] = {.lex_state = 256},
+  [104] = {.lex_state = 256},
+  [105] = {.lex_state = 256},
+  [106] = {.lex_state = 256},
+  [107] = {.lex_state = 256},
+  [108] = {.lex_state = 256},
+  [109] = {.lex_state = 256},
+  [110] = {.lex_state = 256},
+  [111] = {.lex_state = 256},
+  [112] = {.lex_state = 256},
+  [113] = {.lex_state = 256},
+  [114] = {.lex_state = 256},
+  [115] = {.lex_state = 256},
+  [116] = {.lex_state = 256},
+  [117] = {.lex_state = 256},
+  [118] = {.lex_state = 256},
+  [119] = {.lex_state = 256},
+  [120] = {.lex_state = 256},
+  [121] = {.lex_state = 256},
+  [122] = {.lex_state = 256},
+  [123] = {.lex_state = 256},
+  [124] = {.lex_state = 256},
+  [125] = {.lex_state = 256},
+  [126] = {.lex_state = 8},
+  [127] = {.lex_state = 8},
+  [128] = {.lex_state = 256},
+  [129] = {.lex_state = 8},
+  [130] = {.lex_state = 256},
+  [131] = {.lex_state = 256},
+  [132] = {.lex_state = 8},
+  [133] = {.lex_state = 256},
+  [134] = {.lex_state = 256},
+  [135] = {.lex_state = 256},
+  [136] = {.lex_state = 256},
+  [137] = {.lex_state = 256},
+  [138] = {.lex_state = 256},
+  [139] = {.lex_state = 256},
+  [140] = {.lex_state = 8},
+  [141] = {.lex_state = 8},
+  [142] = {.lex_state = 8},
+  [143] = {.lex_state = 256},
+  [144] = {.lex_state = 8},
+  [145] = {.lex_state = 8},
+  [146] = {.lex_state = 256},
+  [147] = {.lex_state = 256},
+  [148] = {.lex_state = 256},
+  [149] = {.lex_state = 256},
+  [150] = {.lex_state = 256},
+  [151] = {.lex_state = 8},
+  [152] = {.lex_state = 256},
+  [153] = {.lex_state = 256},
+  [154] = {.lex_state = 8},
+  [155] = {.lex_state = 256},
+  [156] = {.lex_state = 256},
+  [157] = {.lex_state = 8},
+  [158] = {.lex_state = 256},
+  [159] = {.lex_state = 256},
+  [160] = {.lex_state = 8},
+  [161] = {.lex_state = 8},
+  [162] = {.lex_state = 8},
+  [163] = {.lex_state = 256},
+  [164] = {.lex_state = 8},
+  [165] = {.lex_state = 8},
+  [166] = {.lex_state = 256},
+  [167] = {.lex_state = 256},
+  [168] = {.lex_state = 256},
+  [169] = {.lex_state = 8},
+  [170] = {.lex_state = 8},
+  [171] = {.lex_state = 8},
+  [172] = {.lex_state = 8},
+  [173] = {.lex_state = 256},
+  [174] = {.lex_state = 256},
+  [175] = {.lex_state = 8},
+  [176] = {.lex_state = 8},
+  [177] = {.lex_state = 256},
+  [178] = {.lex_state = 256},
+  [179] = {.lex_state = 256},
+  [180] = {.lex_state = 256},
+  [181] = {.lex_state = 8},
+  [182] = {.lex_state = 256},
+  [183] = {.lex_state = 256},
+  [184] = {.lex_state = 256},
+  [185] = {.lex_state = 256},
+  [186] = {.lex_state = 256},
+  [187] = {.lex_state = 256},
+  [188] = {.lex_state = 256},
+  [189] = {.lex_state = 256},
+  [190] = {.lex_state = 256},
+  [191] = {.lex_state = 256},
+  [192] = {.lex_state = 256},
+  [193] = {.lex_state = 256},
+  [194] = {.lex_state = 256},
+  [195] = {.lex_state = 256},
+  [196] = {.lex_state = 256},
+  [197] = {.lex_state = 256},
+  [198] = {.lex_state = 256},
+  [199] = {.lex_state = 256},
+  [200] = {.lex_state = 256},
+  [201] = {.lex_state = 5},
+  [202] = {.lex_state = 5},
+  [203] = {.lex_state = 5},
+  [204] = {.lex_state = 5},
+  [205] = {.lex_state = 256},
+  [206] = {.lex_state = 256},
+  [207] = {.lex_state = 256},
+  [208] = {.lex_state = 256},
+  [209] = {.lex_state = 256},
+  [210] = {.lex_state = 256},
+  [211] = {.lex_state = 256},
+  [212] = {.lex_state = 256},
+  [213] = {.lex_state = 256},
+  [214] = {.lex_state = 256},
+  [215] = {.lex_state = 256},
+  [216] = {.lex_state = 256},
+  [217] = {.lex_state = 256},
+  [218] = {.lex_state = 2},
+  [219] = {.lex_state = 256},
+  [220] = {.lex_state = 256},
+  [221] = {.lex_state = 256},
+  [222] = {.lex_state = 256},
+  [223] = {.lex_state = 256},
+  [224] = {.lex_state = 2},
+  [225] = {.lex_state = 2},
+  [226] = {.lex_state = 2},
+  [227] = {.lex_state = 2},
+  [228] = {.lex_state = 2},
+  [229] = {.lex_state = 2},
+  [230] = {.lex_state = 2},
+  [231] = {.lex_state = 2},
+  [232] = {.lex_state = 2},
+  [233] = {.lex_state = 2},
+  [234] = {.lex_state = 2},
+  [235] = {.lex_state = 2},
   [236] = {.lex_state = 2},
-  [237] = {.lex_state = 7},
+  [237] = {.lex_state = 2},
   [238] = {.lex_state = 2},
   [239] = {.lex_state = 2},
   [240] = {.lex_state = 2},
@@ -5484,186 +5681,176 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [243] = {.lex_state = 2},
   [244] = {.lex_state = 2},
   [245] = {.lex_state = 2},
-  [246] = {.lex_state = 2},
+  [246] = {.lex_state = 256},
   [247] = {.lex_state = 2},
   [248] = {.lex_state = 2},
   [249] = {.lex_state = 2},
   [250] = {.lex_state = 2},
-  [251] = {.lex_state = 7},
-  [252] = {.lex_state = 7},
+  [251] = {.lex_state = 2},
+  [252] = {.lex_state = 2},
   [253] = {.lex_state = 2},
   [254] = {.lex_state = 2},
-  [255] = {.lex_state = 253},
+  [255] = {.lex_state = 2},
   [256] = {.lex_state = 2},
   [257] = {.lex_state = 2},
-  [258] = {.lex_state = 2},
-  [259] = {.lex_state = 2},
-  [260] = {.lex_state = 7},
-  [261] = {.lex_state = 7},
-  [262] = {.lex_state = 2},
-  [263] = {.lex_state = 7},
-  [264] = {.lex_state = 2},
-  [265] = {.lex_state = 2},
-  [266] = {.lex_state = 7},
-  [267] = {.lex_state = 2},
-  [268] = {.lex_state = 2},
-  [269] = {.lex_state = 2},
-  [270] = {.lex_state = 2},
-  [271] = {.lex_state = 2},
-  [272] = {.lex_state = 2},
-  [273] = {.lex_state = 2},
-  [274] = {.lex_state = 2},
-  [275] = {.lex_state = 2},
-  [276] = {.lex_state = 2},
-  [277] = {.lex_state = 7},
-  [278] = {.lex_state = 2},
-  [279] = {.lex_state = 2},
-  [280] = {.lex_state = 253},
-  [281] = {.lex_state = 253},
-  [282] = {.lex_state = 253},
-  [283] = {.lex_state = 253},
-  [284] = {.lex_state = 253},
-  [285] = {.lex_state = 253},
-  [286] = {.lex_state = 253},
-  [287] = {.lex_state = 253},
-  [288] = {.lex_state = 253},
-  [289] = {.lex_state = 253},
-  [290] = {.lex_state = 253},
-  [291] = {.lex_state = 253},
-  [292] = {.lex_state = 253},
-  [293] = {.lex_state = 253},
-  [294] = {.lex_state = 253},
-  [295] = {.lex_state = 253},
-  [296] = {.lex_state = 253},
-  [297] = {.lex_state = 253},
-  [298] = {.lex_state = 1},
-  [299] = {.lex_state = 1},
-  [300] = {.lex_state = 253},
-  [301] = {.lex_state = 253},
-  [302] = {.lex_state = 1},
-  [303] = {.lex_state = 253},
-  [304] = {.lex_state = 253},
-  [305] = {.lex_state = 253},
-  [306] = {.lex_state = 253},
-  [307] = {.lex_state = 253},
-  [308] = {.lex_state = 253},
-  [309] = {.lex_state = 253},
-  [310] = {.lex_state = 253},
-  [311] = {.lex_state = 4},
-  [312] = {.lex_state = 253},
+  [258] = {.lex_state = 8},
+  [259] = {.lex_state = 8},
+  [260] = {.lex_state = 256},
+  [261] = {.lex_state = 8},
+  [262] = {.lex_state = 8},
+  [263] = {.lex_state = 8},
+  [264] = {.lex_state = 8},
+  [265] = {.lex_state = 8},
+  [266] = {.lex_state = 8},
+  [267] = {.lex_state = 8},
+  [268] = {.lex_state = 256},
+  [269] = {.lex_state = 256},
+  [270] = {.lex_state = 256},
+  [271] = {.lex_state = 256},
+  [272] = {.lex_state = 256},
+  [273] = {.lex_state = 256},
+  [274] = {.lex_state = 5},
+  [275] = {.lex_state = 5},
+  [276] = {.lex_state = 5},
+  [277] = {.lex_state = 256},
+  [278] = {.lex_state = 256},
+  [279] = {.lex_state = 5},
+  [280] = {.lex_state = 5},
+  [281] = {.lex_state = 256},
+  [282] = {.lex_state = 256},
+  [283] = {.lex_state = 256},
+  [284] = {.lex_state = 256},
+  [285] = {.lex_state = 256},
+  [286] = {.lex_state = 256},
+  [287] = {.lex_state = 256},
+  [288] = {.lex_state = 1},
+  [289] = {.lex_state = 256},
+  [290] = {.lex_state = 256},
+  [291] = {.lex_state = 256},
+  [292] = {.lex_state = 1},
+  [293] = {.lex_state = 256},
+  [294] = {.lex_state = 256},
+  [295] = {.lex_state = 1},
+  [296] = {.lex_state = 256},
+  [297] = {.lex_state = 256},
+  [298] = {.lex_state = 4},
+  [299] = {.lex_state = 4},
+  [300] = {.lex_state = 4},
+  [301] = {.lex_state = 4},
+  [302] = {.lex_state = 4},
+  [303] = {.lex_state = 256},
+  [304] = {.lex_state = 256},
+  [305] = {.lex_state = 256},
+  [306] = {.lex_state = 4},
+  [307] = {.lex_state = 4},
+  [308] = {.lex_state = 4},
+  [309] = {.lex_state = 256},
+  [310] = {.lex_state = 256},
+  [311] = {.lex_state = 256},
+  [312] = {.lex_state = 256},
   [313] = {.lex_state = 4},
-  [314] = {.lex_state = 253},
-  [315] = {.lex_state = 253},
-  [316] = {.lex_state = 253},
-  [317] = {.lex_state = 253},
-  [318] = {.lex_state = 4},
-  [319] = {.lex_state = 4},
-  [320] = {.lex_state = 4},
-  [321] = {.lex_state = 253},
-  [322] = {.lex_state = 253},
-  [323] = {.lex_state = 253},
-  [324] = {.lex_state = 253},
-  [325] = {.lex_state = 253},
-  [326] = {.lex_state = 4},
-  [327] = {.lex_state = 4},
-  [328] = {.lex_state = 4},
-  [329] = {.lex_state = 4},
+  [314] = {.lex_state = 4},
+  [315] = {.lex_state = 256},
+  [316] = {.lex_state = 256},
+  [317] = {.lex_state = 256},
+  [318] = {.lex_state = 256, .external_lex_state = 1},
+  [319] = {.lex_state = 256},
+  [320] = {.lex_state = 256},
+  [321] = {.lex_state = 256},
+  [322] = {.lex_state = 3},
+  [323] = {.lex_state = 256},
+  [324] = {.lex_state = 256},
+  [325] = {.lex_state = 256},
+  [326] = {.lex_state = 256, .external_lex_state = 1},
+  [327] = {.lex_state = 256},
+  [328] = {.lex_state = 256},
+  [329] = {.lex_state = 256},
   [330] = {.lex_state = 4},
-  [331] = {.lex_state = 3},
-  [332] = {.lex_state = 253},
-  [333] = {.lex_state = 253},
-  [334] = {.lex_state = 253},
-  [335] = {.lex_state = 253},
-  [336] = {.lex_state = 253},
-  [337] = {.lex_state = 253},
-  [338] = {.lex_state = 253},
-  [339] = {.lex_state = 253},
-  [340] = {.lex_state = 253},
-  [341] = {.lex_state = 253},
+  [331] = {.lex_state = 256},
+  [332] = {.lex_state = 256},
+  [333] = {.lex_state = 256},
+  [334] = {.lex_state = 4},
+  [335] = {.lex_state = 256},
+  [336] = {.lex_state = 6},
+  [337] = {.lex_state = 3},
+  [338] = {.lex_state = 256},
+  [339] = {.lex_state = 256},
+  [340] = {.lex_state = 256},
+  [341] = {.lex_state = 256},
   [342] = {.lex_state = 4},
-  [343] = {.lex_state = 3},
-  [344] = {.lex_state = 253},
-  [345] = {.lex_state = 253},
-  [346] = {.lex_state = 253},
-  [347] = {.lex_state = 253},
-  [348] = {.lex_state = 4},
-  [349] = {.lex_state = 253},
-  [350] = {.lex_state = 253},
+  [343] = {.lex_state = 256},
+  [344] = {.lex_state = 256},
+  [345] = {.lex_state = 3},
+  [346] = {.lex_state = 256},
+  [347] = {.lex_state = 256},
+  [348] = {.lex_state = 256},
+  [349] = {.lex_state = 256},
+  [350] = {.lex_state = 3},
   [351] = {.lex_state = 3},
-  [352] = {.lex_state = 253},
-  [353] = {.lex_state = 253},
-  [354] = {.lex_state = 6},
-  [355] = {.lex_state = 253},
-  [356] = {.lex_state = 253},
-  [357] = {.lex_state = 253},
-  [358] = {.lex_state = 4},
-  [359] = {.lex_state = 253},
+  [352] = {.lex_state = 256},
+  [353] = {.lex_state = 256},
+  [354] = {.lex_state = 3},
+  [355] = {.lex_state = 3},
+  [356] = {.lex_state = 256},
+  [357] = {.lex_state = 3},
+  [358] = {.lex_state = 3},
+  [359] = {.lex_state = 256},
   [360] = {.lex_state = 3},
-  [361] = {.lex_state = 3},
-  [362] = {.lex_state = 3},
+  [361] = {.lex_state = 256},
+  [362] = {.lex_state = 256},
   [363] = {.lex_state = 3},
-  [364] = {.lex_state = 3},
+  [364] = {.lex_state = 256},
   [365] = {.lex_state = 3},
-  [366] = {.lex_state = 253},
-  [367] = {.lex_state = 3},
-  [368] = {.lex_state = 253},
-  [369] = {.lex_state = 253},
-  [370] = {.lex_state = 253},
-  [371] = {.lex_state = 253},
-  [372] = {.lex_state = 253},
-  [373] = {.lex_state = 253},
-  [374] = {.lex_state = 253},
-  [375] = {.lex_state = 253},
-  [376] = {.lex_state = 253},
-  [377] = {.lex_state = 253},
+  [366] = {.lex_state = 256},
+  [367] = {.lex_state = 256},
+  [368] = {.lex_state = 256},
+  [369] = {.lex_state = 3},
+  [370] = {.lex_state = 256},
+  [371] = {.lex_state = 4},
+  [372] = {.lex_state = 256},
+  [373] = {.lex_state = 3},
+  [374] = {.lex_state = 256},
+  [375] = {.lex_state = 256},
+  [376] = {.lex_state = 3},
+  [377] = {.lex_state = 6},
   [378] = {.lex_state = 3},
   [379] = {.lex_state = 3},
   [380] = {.lex_state = 3},
-  [381] = {.lex_state = 253},
-  [382] = {.lex_state = 253},
-  [383] = {.lex_state = 3},
-  [384] = {.lex_state = 3},
-  [385] = {.lex_state = 3},
-  [386] = {.lex_state = 3},
-  [387] = {.lex_state = 253},
-  [388] = {.lex_state = 253},
-  [389] = {.lex_state = 253},
-  [390] = {.lex_state = 3},
-  [391] = {.lex_state = 253},
-  [392] = {.lex_state = 3},
-  [393] = {.lex_state = 4},
-  [394] = {.lex_state = 253},
+  [381] = {.lex_state = 3},
+  [382] = {.lex_state = 256},
+  [383] = {.lex_state = 256},
+  [384] = {.lex_state = 4},
+  [385] = {.lex_state = 256},
+  [386] = {.lex_state = 256},
+  [387] = {.lex_state = 256},
+  [388] = {.lex_state = 256},
+  [389] = {.lex_state = 256},
+  [390] = {.lex_state = 256},
+  [391] = {.lex_state = 256},
+  [392] = {.lex_state = 256},
+  [393] = {.lex_state = 3},
+  [394] = {.lex_state = 256},
   [395] = {.lex_state = 3},
-  [396] = {.lex_state = 253},
-  [397] = {.lex_state = 253},
-  [398] = {.lex_state = 253},
-  [399] = {.lex_state = 253},
-  [400] = {.lex_state = 253},
-  [401] = {.lex_state = 253},
-  [402] = {.lex_state = 253},
-  [403] = {.lex_state = 253},
-  [404] = {.lex_state = 253},
-  [405] = {.lex_state = 4},
-  [406] = {.lex_state = 253},
-  [407] = {.lex_state = 253},
-  [408] = {.lex_state = 253},
-  [409] = {.lex_state = 253},
-  [410] = {.lex_state = 253},
-  [411] = {.lex_state = 253},
-  [412] = {.lex_state = 253},
-  [413] = {.lex_state = 253},
-  [414] = {.lex_state = 253},
-  [415] = {.lex_state = 3},
-  [416] = {.lex_state = 253},
-  [417] = {.lex_state = 3},
-  [418] = {.lex_state = 253},
-  [419] = {.lex_state = 4},
-  [420] = {.lex_state = 253},
-  [421] = {.lex_state = 3},
-  [422] = {.lex_state = 3},
-  [423] = {.lex_state = 253},
-  [424] = {.lex_state = 6},
-  [425] = {.lex_state = 253},
+  [396] = {.lex_state = 256},
+  [397] = {.lex_state = 256},
+  [398] = {.lex_state = 3},
+  [399] = {.lex_state = 256},
+  [400] = {.lex_state = 3},
+  [401] = {.lex_state = 256},
+};
+
+enum {
+  ts_external_token__edgeql_chars = 0,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token__edgeql_chars] = sym__edgeql_chars,
+};
+
+static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token__edgeql_chars] = true,
+  },
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -5685,12 +5872,11 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_alias] = ACTIONS(1),
     [anon_sym_using] = ACTIONS(1),
     [anon_sym_function] = ACTIONS(1),
-    [anon_sym_LPAREN] = ACTIONS(1),
-    [anon_sym_RPAREN] = ACTIONS(1),
-    [anon_sym_edgedb] = ACTIONS(1),
     [anon_sym_extension] = ACTIONS(1),
     [anon_sym_extending] = ACTIONS(1),
     [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
     [anon_sym_on] = ACTIONS(1),
     [anon_sym_except] = ACTIONS(1),
     [anon_sym_abstract] = ACTIONS(1),
@@ -5750,13 +5936,15 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_true] = ACTIONS(1),
     [sym_false] = ACTIONS(1),
     [sym_null] = ACTIONS(1),
+    [sym_number] = ACTIONS(1),
     [sym_comment] = ACTIONS(3),
     [sym__whitespace] = ACTIONS(3),
+    [sym__edgeql_chars] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(420),
-    [sym_module] = STATE(306),
-    [aux_sym_source_file_repeat1] = STATE(306),
+    [sym_source_file] = STATE(390),
+    [sym_module] = STATE(297),
+    [aux_sym_source_file_repeat1] = STATE(297),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_module] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -5788,8 +5976,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -5811,124 +5999,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [50] = 3,
+  [50] = 9,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(19), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(17), 34,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-      anon_sym_CARET,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [97] = 3,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(23), 4,
+    ACTIONS(21), 2,
       anon_sym_AMP,
       anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(21), 34,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_CARET,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [144] = 11,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
     ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-    ACTIONS(25), 22,
+    ACTIONS(17), 23,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -5940,8 +6037,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -5951,38 +6048,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_inheritable,
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
-  [207] = 12,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
+  [109] = 3,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(35), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(25), 21,
+    ACTIONS(33), 34,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -5994,8 +6070,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6003,8 +6079,161 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
+      anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
-  [272] = 3,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [156] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(39), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(37), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [203] = 6,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(21), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(17), 27,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [256] = 8,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(21), 2,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(17), 25,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+  [313] = 3,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -6025,8 +6254,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6048,23 +6277,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [319] = 5,
+  [360] = 3,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(47), 4,
+    ACTIONS(21), 4,
       anon_sym_AMP,
       anon_sym_PIPE,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(25), 29,
+    ACTIONS(17), 34,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6076,97 +6298,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_CARET,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [370] = 9,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(47), 2,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(25), 23,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
       anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_CARET,
-  [429] = 3,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(51), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(49), 34,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6188,34 +6321,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [476] = 10,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(47), 1,
-      anon_sym_PIPE,
+  [407] = 4,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-    ACTIONS(25), 23,
+    ACTIONS(21), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(17), 31,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6227,8 +6346,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6238,17 +6357,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_inheritable,
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
       anon_sym_CARET,
-  [537] = 3,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [456] = 3,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(55), 4,
+    ACTIONS(43), 4,
       anon_sym_AMP,
       anon_sym_PIPE,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(53), 34,
+    ACTIONS(41), 34,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6260,8 +6387,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6283,104 +6410,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [584] = 11,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(47), 1,
-      anon_sym_PIPE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(25), 22,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-  [647] = 4,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(47), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(25), 31,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_CARET,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [696] = 3,
+  [503] = 3,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -6389,7 +6419,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(25), 34,
+    ACTIONS(45), 34,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6401,8 +6431,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6424,26 +6454,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [743] = 6,
+  [550] = 11,
+    ACTIONS(21), 1,
+      anon_sym_PIPE,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
     ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(37), 3,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-    ACTIONS(47), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(25), 27,
+    ACTIONS(17), 22,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6455,8 +6495,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6466,79 +6506,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_inheritable,
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
+  [613] = 11,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [796] = 3,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(59), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(57), 34,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-      anon_sym_CARET,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [843] = 8,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
     ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(47), 2,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-    ACTIONS(37), 3,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-    ACTIONS(25), 25,
+    ACTIONS(17), 22,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6550,8 +6547,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6561,19 +6558,34 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_inheritable,
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
-      anon_sym_CARET,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-  [900] = 3,
+  [676] = 10,
+    ACTIONS(21), 1,
+      anon_sym_PIPE,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(63), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(61), 34,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(17), 23,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -6585,8 +6597,41 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_CARET,
+  [737] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(57), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(55), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6604,6 +6649,149 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [784] = 3,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(61), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(59), 34,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [831] = 12,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(17), 21,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_PIPE_PIPE,
+  [896] = 5,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(21), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(17), 29,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
       anon_sym_LT_EQ,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
@@ -6629,8 +6817,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -6653,13 +6841,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
   [994] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(71), 1,
       anon_sym_SEMI,
@@ -6668,22 +6856,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6706,13 +6894,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1061] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6721,22 +6909,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6759,13 +6947,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1128] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6774,22 +6962,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6812,13 +7000,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1195] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6827,22 +7015,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6865,13 +7053,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1262] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6880,22 +7068,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6918,13 +7106,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1329] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6933,22 +7121,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -6971,13 +7159,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1396] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -6986,22 +7174,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -7024,13 +7212,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1463] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -7039,22 +7227,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -7077,13 +7265,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1530] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -7092,22 +7280,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -7130,13 +7318,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
   [1597] = 14,
-    ACTIONS(29), 1,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
@@ -7145,22 +7333,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
+    ACTIONS(27), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -7191,21 +7379,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(309), 1,
+    STATE(94), 1,
       sym_returnspec,
-    STATE(324), 1,
+    STATE(114), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7228,53 +7416,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [1721] = 11,
-    ACTIONS(111), 1,
-      anon_sym_optional,
-    ACTIONS(113), 1,
-      anon_sym_setof,
-    ACTIONS(119), 1,
-      anon_sym_array,
-    ACTIONS(121), 1,
-      anon_sym_tuple,
-    STATE(308), 1,
-      sym_returnspec,
-    STATE(324), 1,
-      sym_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(57), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(117), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(115), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [1778] = 9,
+  [1721] = 9,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
@@ -7284,17 +7426,17 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
-    STATE(65), 2,
+    STATE(62), 2,
       sym_enum,
       sym_type,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7317,7 +7459,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [1830] = 9,
+  [1773] = 9,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
@@ -7327,17 +7469,17 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
-    STATE(71), 2,
+    STATE(68), 2,
       sym_enum,
       sym_type,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7360,7 +7502,47 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [1882] = 8,
+  [1825] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(106), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(52), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(53), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [1873] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
@@ -7370,14 +7552,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7400,24 +7582,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [1930] = 8,
+  [1921] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(348), 1,
+    STATE(384), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7440,26 +7622,106 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [1978] = 9,
+  [1969] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(314), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(52), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(53), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2017] = 8,
+    ACTIONS(119), 1,
+      anon_sym_array,
+    ACTIONS(121), 1,
+      anon_sym_tuple,
+    STATE(109), 1,
+      sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(52), 2,
+      sym__tuple,
+      sym__named_tuple,
+    ACTIONS(117), 3,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+    STATE(53), 3,
+      sym__scalar_type,
+      sym_array,
+      sym_tuple,
+    ACTIONS(115), 18,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_date,
+      anon_sym_sequence,
+      anon_sym_anytype,
+      sym_identifier,
+  [2065] = 9,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
     ACTIONS(125), 1,
       sym_identifier,
-    STATE(313), 1,
+    STATE(302), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7481,24 +7743,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_cal_COLON_COLONlocal_date,
       anon_sym_sequence,
       anon_sym_anytype,
-  [2028] = 8,
+  [2115] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(318), 1,
+    STATE(81), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7521,24 +7783,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2076] = 8,
+  [2163] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(393), 1,
+    STATE(75), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7561,24 +7823,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2124] = 8,
+  [2211] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(83), 1,
+    STATE(121), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7601,24 +7863,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2172] = 8,
+  [2259] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(108), 1,
+    STATE(72), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7641,24 +7903,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2220] = 8,
+  [2307] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(76), 1,
+    STATE(101), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7681,24 +7943,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2268] = 8,
+  [2355] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(133), 1,
+    STATE(102), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7721,24 +7983,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2316] = 8,
+  [2403] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(77), 1,
+    STATE(330), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7761,24 +8023,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2364] = 8,
+  [2451] = 8,
     ACTIONS(119), 1,
       anon_sym_array,
     ACTIONS(121), 1,
       anon_sym_tuple,
-    STATE(315), 1,
+    STATE(334), 1,
       sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(57), 2,
+    STATE(52), 2,
       sym__tuple,
       sym__named_tuple,
     ACTIONS(117), 3,
       anon_sym_cal_COLON_COLONlocal_datetime,
       anon_sym_cal_COLON_COLONlocal_time,
       anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
+    STATE(53), 3,
       sym__scalar_type,
       sym_array,
       sym_tuple,
@@ -7801,127 +8063,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_sequence,
       anon_sym_anytype,
       sym_identifier,
-  [2412] = 8,
-    ACTIONS(119), 1,
-      anon_sym_array,
-    ACTIONS(121), 1,
-      anon_sym_tuple,
-    STATE(107), 1,
-      sym_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(57), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(117), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(115), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [2460] = 8,
-    ACTIONS(119), 1,
-      anon_sym_array,
-    ACTIONS(121), 1,
-      anon_sym_tuple,
-    STATE(342), 1,
-      sym_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(57), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(117), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(115), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [2508] = 8,
-    ACTIONS(119), 1,
-      anon_sym_array,
-    ACTIONS(121), 1,
-      anon_sym_tuple,
-    STATE(114), 1,
-      sym_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(57), 2,
-      sym__tuple,
-      sym__named_tuple,
-    ACTIONS(117), 3,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-    STATE(58), 3,
-      sym__scalar_type,
-      sym_array,
-      sym_tuple,
-    ACTIONS(115), 18,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_date,
-      anon_sym_sequence,
-      anon_sym_anytype,
-      sym_identifier,
-  [2556] = 14,
+  [2499] = 14,
     ACTIONS(127), 1,
       anon_sym_RBRACE,
     ACTIONS(129), 1,
@@ -7940,10 +8082,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_alias,
     ACTIONS(150), 1,
       anon_sym_function,
-    STATE(225), 1,
-      sym_modifier,
-    STATE(234), 1,
+    STATE(206), 1,
       aux_sym_scalar_type_def_repeat1,
+    STATE(209), 1,
+      sym_modifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -7955,7 +8097,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-    STATE(49), 9,
+    STATE(48), 9,
       sym_object_type,
       sym_scalar_type_def,
       sym_link,
@@ -7965,7 +8107,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_alias,
       sym_function,
       aux_sym_schema_declarations_repeat1,
-  [2614] = 14,
+  [2557] = 14,
     ACTIONS(156), 1,
       anon_sym_RBRACE,
     ACTIONS(158), 1,
@@ -7984,10 +8126,54 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_alias,
     ACTIONS(172), 1,
       anon_sym_function,
-    STATE(225), 1,
-      sym_modifier,
-    STATE(234), 1,
+    STATE(206), 1,
       aux_sym_scalar_type_def_repeat1,
+    STATE(209), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+    STATE(48), 9,
+      sym_object_type,
+      sym_scalar_type_def,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_alias,
+      sym_function,
+      aux_sym_schema_declarations_repeat1,
+  [2615] = 14,
+    ACTIONS(158), 1,
+      anon_sym_type,
+    ACTIONS(160), 1,
+      anon_sym_scalar,
+    ACTIONS(162), 1,
+      anon_sym_link,
+    ACTIONS(164), 1,
+      anon_sym_property,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(168), 1,
+      anon_sym_constraint,
+    ACTIONS(170), 1,
+      anon_sym_alias,
+    ACTIONS(172), 1,
+      anon_sym_function,
+    ACTIONS(176), 1,
+      anon_sym_RBRACE,
+    STATE(206), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(209), 1,
+      sym_modifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -8009,33 +8195,27 @@ static const uint16_t ts_small_parse_table[] = {
       sym_alias,
       sym_function,
       aux_sym_schema_declarations_repeat1,
-  [2672] = 14,
-    ACTIONS(158), 1,
-      anon_sym_type,
-    ACTIONS(160), 1,
-      anon_sym_scalar,
-    ACTIONS(162), 1,
-      anon_sym_link,
-    ACTIONS(164), 1,
-      anon_sym_property,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(168), 1,
-      anon_sym_constraint,
-    ACTIONS(170), 1,
-      anon_sym_alias,
-    ACTIONS(172), 1,
-      anon_sym_function,
-    ACTIONS(176), 1,
-      anon_sym_RBRACE,
-    STATE(225), 1,
-      sym_modifier,
-    STATE(234), 1,
-      aux_sym_scalar_type_def_repeat1,
+  [2673] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(174), 7,
+    ACTIONS(178), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8043,71 +8223,84 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-    STATE(50), 9,
-      sym_object_type,
-      sym_scalar_type_def,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_alias,
-      sym_function,
-      aux_sym_schema_declarations_repeat1,
-  [2730] = 9,
-    ACTIONS(178), 1,
+      anon_sym_GT,
+  [2704] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(180), 24,
       anon_sym_LBRACE,
-    ACTIONS(182), 1,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
       anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2735] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(182), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [2766] = 9,
     ACTIONS(184), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(186), 1,
-      anon_sym_SEMI,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    STATE(92), 1,
-      sym_extending,
-    STATE(120), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(180), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [2775] = 9,
-    ACTIONS(178), 1,
       anon_sym_LBRACE,
     ACTIONS(188), 1,
-      anon_sym_extending,
+      anon_sym_DASH_GT,
+    ACTIONS(190), 1,
+      anon_sym_COLON_EQ,
     ACTIONS(192), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(194), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(196), 1,
       anon_sym_SEMI,
-    STATE(72), 1,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    STATE(87), 1,
       sym_extending,
-    STATE(129), 1,
+    STATE(125), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(190), 17,
+    ACTIONS(186), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8125,27 +8318,35 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [2820] = 2,
+  [2811] = 9,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(198), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(200), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(202), 1,
+      anon_sym_SEMI,
+    STATE(71), 1,
+      sym_extending,
+    STATE(118), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(198), 24,
-      anon_sym_LBRACE,
+    ACTIONS(196), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
       anon_sym_index,
       anon_sym_alias,
-      anon_sym_using,
       anon_sym_function,
-      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8153,66 +8354,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-      anon_sym_GT,
-  [2851] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(200), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [2882] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(202), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [2913] = 2,
+  [2856] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -8241,148 +8383,61 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
       anon_sym_GT,
-  [2944] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(206), 24,
+  [2887] = 9,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [2975] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(208), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [3006] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(210), 24,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_using,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      anon_sym_GT,
-  [3037] = 9,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
+    ACTIONS(194), 1,
       anon_sym_extending,
-    ACTIONS(214), 1,
+    ACTIONS(208), 1,
       anon_sym_DASH_GT,
+    ACTIONS(210), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(212), 1,
+      anon_sym_SEMI,
+    STATE(89), 1,
+      sym_extending,
+    STATE(124), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(206), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [2932] = 9,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    ACTIONS(194), 1,
+      anon_sym_extending,
     ACTIONS(216), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(218), 1,
-      anon_sym_SEMI,
-    STATE(66), 1,
-      sym_extending,
-    STATE(121), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(212), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3082] = 9,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(222), 1,
       anon_sym_DASH_GT,
-    ACTIONS(224), 1,
+    ACTIONS(218), 1,
       anon_sym_COLON_EQ,
-    ACTIONS(226), 1,
+    ACTIONS(220), 1,
       anon_sym_SEMI,
-    STATE(90), 1,
+    STATE(70), 1,
       sym_extending,
-    STATE(131), 1,
+    STATE(122), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(220), 17,
+    ACTIONS(214), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -8400,7 +8455,94 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3127] = 4,
+  [2977] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(222), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [3008] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(224), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [3039] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(226), 24,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      anon_sym_GT,
+  [3070] = 4,
     ACTIONS(230), 1,
       anon_sym_COMMA,
     STATE(64), 1,
@@ -8430,10 +8572,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3161] = 4,
+  [3104] = 4,
     ACTIONS(234), 1,
       anon_sym_COMMA,
-    STATE(64), 1,
+    STATE(63), 1,
       aux_sym_extending_repeat1,
     ACTIONS(9), 2,
       sym_comment,
@@ -8460,7 +8602,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3195] = 4,
+  [3138] = 4,
     ACTIONS(230), 1,
       anon_sym_COMMA,
     STATE(63), 1,
@@ -8490,31 +8632,26 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3229] = 7,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(241), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(243), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(245), 1,
-      anon_sym_SEMI,
-    STATE(106), 1,
-      sym_declarations,
+  [3172] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(239), 17,
+    ACTIONS(239), 22,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
+      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8522,7 +8659,91 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3268] = 5,
+  [3201] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(241), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3230] = 5,
+    ACTIONS(13), 1,
+      anon_sym_LPAREN,
+    ACTIONS(243), 1,
+      anon_sym_COLON,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(15), 4,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(11), 16,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_AMP_AMP,
+      anon_sym_PIPE_PIPE,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_CARET,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_LT_EQ,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+  [3265] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(245), 22,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_DASH_GT,
+      anon_sym_COLON_EQ,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_COMMA,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [3294] = 5,
     ACTIONS(13), 1,
       anon_sym_LPAREN,
     ACTIONS(247), 1,
@@ -8536,8 +8757,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_GT,
     ACTIONS(11), 16,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
+      anon_sym_RPAREN,
       anon_sym_AMP_AMP,
       anon_sym_PIPE_PIPE,
       anon_sym_GT_GT,
@@ -8552,83 +8773,31 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_BANG_EQ,
       anon_sym_GT_EQ,
-  [3303] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(249), 22,
+  [3329] = 7,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3332] = 5,
-    ACTIONS(13), 1,
-      anon_sym_LPAREN,
     ACTIONS(251), 1,
-      anon_sym_COLON,
+      anon_sym_DASH_GT,
+    ACTIONS(253), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(255), 1,
+      anon_sym_SEMI,
+    STATE(113), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(15), 4,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(11), 16,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_CARET,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_LT_EQ,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-  [3367] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(253), 22,
-      anon_sym_LBRACE,
+    ACTIONS(249), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
       anon_sym_property,
       anon_sym_annotation,
       anon_sym_constraint,
       anon_sym_index,
       anon_sym_alias,
       anon_sym_function,
-      anon_sym_COMMA,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8636,35 +8805,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3396] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(255), 22,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_DASH_GT,
-      anon_sym_COLON_EQ,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_COMMA,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3425] = 7,
-    ACTIONS(178), 1,
+  [3368] = 7,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
     ACTIONS(259), 1,
       anon_sym_DASH_GT,
@@ -8672,7 +8814,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COLON_EQ,
     ACTIONS(263), 1,
       anon_sym_SEMI,
-    STATE(101), 1,
+    STATE(120), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
@@ -8695,34 +8837,29 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3464] = 11,
+  [3407] = 6,
+    ACTIONS(101), 1,
+      anon_sym_SEMI,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
     ACTIONS(265), 1,
-      anon_sym_RBRACE,
-    ACTIONS(267), 1,
-      anon_sym_link,
-    ACTIONS(270), 1,
-      anon_sym_property,
-    ACTIONS(273), 1,
-      anon_sym_annotation,
-    ACTIONS(276), 1,
-      anon_sym_constraint,
-    ACTIONS(279), 1,
-      anon_sym_index,
-    STATE(235), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(255), 1,
-      sym_modifier,
+      anon_sym_COLON_EQ,
+    STATE(117), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(73), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(282), 7,
+    ACTIONS(99), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -8730,14 +8867,53 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3510] = 6,
+  [3443] = 15,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(267), 1,
+      anon_sym_COMMA,
+    ACTIONS(269), 1,
+      anon_sym_RPAREN,
+    STATE(303), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [3497] = 6,
     ACTIONS(93), 1,
       anon_sym_SEMI,
-    ACTIONS(178), 1,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-    ACTIONS(285), 1,
+    ACTIONS(271), 1,
       anon_sym_COLON_EQ,
-    STATE(123), 1,
+    STATE(116), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
@@ -8760,278 +8936,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3546] = 15,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(287), 1,
-      anon_sym_RPAREN,
-    ACTIONS(289), 1,
-      anon_sym_COMMA,
-    STATE(317), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3600] = 6,
-    ACTIONS(109), 1,
-      anon_sym_SEMI,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(291), 1,
-      anon_sym_COLON_EQ,
-    STATE(135), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(107), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3636] = 6,
-    ACTIONS(85), 1,
-      anon_sym_SEMI,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(293), 1,
-      anon_sym_COLON_EQ,
-    STATE(125), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(83), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3672] = 15,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(295), 1,
-      anon_sym_RPAREN,
-    ACTIONS(297), 1,
-      anon_sym_COMMA,
-    STATE(325), 1,
-      aux_sym_fncall_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3726] = 11,
-    ACTIONS(162), 1,
-      anon_sym_link,
-    ACTIONS(164), 1,
-      anon_sym_property,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(168), 1,
-      anon_sym_constraint,
-    ACTIONS(299), 1,
-      anon_sym_RBRACE,
-    ACTIONS(301), 1,
-      anon_sym_index,
-    STATE(235), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(255), 1,
-      sym_modifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(73), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3772] = 11,
-    ACTIONS(162), 1,
-      anon_sym_link,
-    ACTIONS(164), 1,
-      anon_sym_property,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(168), 1,
-      anon_sym_constraint,
-    ACTIONS(301), 1,
-      anon_sym_index,
-    ACTIONS(303), 1,
-      anon_sym_RBRACE,
-    STATE(235), 1,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(255), 1,
-      sym_modifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(79), 6,
-      sym_link,
-      sym_property,
-      sym_annotation,
-      sym_constraint,
-      sym_index,
-      aux_sym_declarations_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [3818] = 4,
-    ACTIONS(307), 1,
-      anon_sym_cal_COLON_COLONlocal_date,
-    STATE(322), 1,
-      sym__scalar_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(305), 19,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [3850] = 4,
-    ACTIONS(311), 1,
-      anon_sym_cal_COLON_COLONlocal_date,
-    STATE(340), 1,
-      sym__scalar_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(309), 19,
-      anon_sym_str,
-      anon_sym_bool,
-      anon_sym_int16,
-      anon_sym_int32,
-      anon_sym_int64,
-      anon_sym_float32,
-      anon_sym_float64,
-      anon_sym_bigint,
-      anon_sym_decimal,
-      anon_sym_json,
-      anon_sym_uuid,
-      anon_sym_bytes,
-      anon_sym_datetime,
-      anon_sym_duration,
-      anon_sym_cal_COLON_COLONlocal_datetime,
-      anon_sym_cal_COLON_COLONlocal_time,
-      anon_sym_cal_COLON_COLONrelative_duration,
-      anon_sym_sequence,
-      anon_sym_anytype,
-  [3882] = 6,
+  [3533] = 6,
     ACTIONS(89), 1,
       anon_sym_SEMI,
-    ACTIONS(178), 1,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-    ACTIONS(313), 1,
+    ACTIONS(273), 1,
       anon_sym_COLON_EQ,
-    STATE(115), 1,
+    STATE(107), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
@@ -9054,225 +8966,129 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [3918] = 13,
-    ACTIONS(29), 1,
+  [3569] = 15,
+    ACTIONS(49), 1,
       anon_sym_AMP,
-    ACTIONS(31), 1,
+    ACTIONS(51), 1,
       anon_sym_CARET,
-    ACTIONS(33), 1,
+    ACTIONS(53), 1,
       anon_sym_PIPE,
-    ACTIONS(45), 1,
+    ACTIONS(63), 1,
       anon_sym_AMP_AMP,
     ACTIONS(73), 1,
       anon_sym_PIPE_PIPE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(315), 2,
-      anon_sym_RPAREN,
+    ACTIONS(275), 1,
       anon_sym_COMMA,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3967] = 6,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    STATE(130), 1,
-      sym_extending,
-    STATE(194), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(317), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4002] = 6,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    STATE(110), 1,
-      sym_extending,
-    STATE(211), 1,
-      sym_declarations,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(319), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4037] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(321), 2,
+    ACTIONS(277), 1,
       anon_sym_RPAREN,
-      anon_sym_COMMA,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4086] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(323), 1,
-      anon_sym_SEMI,
+    STATE(305), 1,
+      aux_sym_argspec_repeat1,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(27), 2,
+    ACTIONS(19), 2,
       anon_sym_GT_GT,
       anon_sym_LT_LT,
-    ACTIONS(35), 2,
+    ACTIONS(23), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4134] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(325), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
     ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
       anon_sym_LT,
       anon_sym_GT,
-    ACTIONS(41), 2,
+    ACTIONS(29), 2,
       anon_sym_LT_EQ,
       anon_sym_GT_EQ,
-    ACTIONS(43), 2,
+    ACTIONS(31), 2,
       anon_sym_EQ,
       anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
+    ACTIONS(25), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-  [4182] = 4,
-    ACTIONS(329), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(331), 1,
-      anon_sym_SEMI,
+  [3623] = 4,
+    ACTIONS(281), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(339), 1,
+      sym__scalar_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(327), 17,
+    ACTIONS(279), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [3655] = 4,
+    ACTIONS(285), 1,
+      anon_sym_cal_COLON_COLONlocal_date,
+    STATE(309), 1,
+      sym__scalar_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(283), 19,
+      anon_sym_str,
+      anon_sym_bool,
+      anon_sym_int16,
+      anon_sym_int32,
+      anon_sym_int64,
+      anon_sym_float32,
+      anon_sym_float64,
+      anon_sym_bigint,
+      anon_sym_decimal,
+      anon_sym_json,
+      anon_sym_uuid,
+      anon_sym_bytes,
+      anon_sym_datetime,
+      anon_sym_duration,
+      anon_sym_cal_COLON_COLONlocal_datetime,
+      anon_sym_cal_COLON_COLONlocal_time,
+      anon_sym_cal_COLON_COLONrelative_duration,
+      anon_sym_sequence,
+      anon_sym_anytype,
+  [3687] = 11,
+    ACTIONS(287), 1,
       anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
+    ACTIONS(289), 1,
       anon_sym_link,
+    ACTIONS(292), 1,
       anon_sym_property,
+    ACTIONS(295), 1,
       anon_sym_annotation,
+    ACTIONS(298), 1,
       anon_sym_constraint,
+    ACTIONS(301), 1,
       anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(246), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(260), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(79), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(304), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9280,60 +9096,34 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4212] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(333), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4260] = 4,
-    ACTIONS(337), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(339), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(335), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
+  [3733] = 11,
+    ACTIONS(162), 1,
       anon_sym_link,
+    ACTIONS(164), 1,
       anon_sym_property,
+    ACTIONS(166), 1,
       anon_sym_annotation,
+    ACTIONS(168), 1,
       anon_sym_constraint,
+    ACTIONS(307), 1,
+      anon_sym_RBRACE,
+    ACTIONS(309), 1,
       anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(246), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(260), 1,
+      sym_modifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(82), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9341,289 +9131,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4290] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(341), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4338] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(343), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4386] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(345), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4434] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(347), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4482] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(349), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4530] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(351), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4578] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(353), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4626] = 13,
-    ACTIONS(29), 1,
-      anon_sym_AMP,
-    ACTIONS(31), 1,
-      anon_sym_CARET,
-    ACTIONS(33), 1,
-      anon_sym_PIPE,
-    ACTIONS(45), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(73), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(355), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(27), 2,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(39), 2,
-      anon_sym_LT,
-      anon_sym_GT,
-    ACTIONS(41), 2,
-      anon_sym_LT_EQ,
-      anon_sym_GT_EQ,
-    ACTIONS(43), 2,
-      anon_sym_EQ,
-      anon_sym_BANG_EQ,
-    ACTIONS(37), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [4674] = 3,
+  [3779] = 6,
     ACTIONS(109), 1,
       anon_sym_SEMI,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    ACTIONS(311), 1,
+      anon_sym_COLON_EQ,
+    STATE(108), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -9645,163 +9161,34 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4701] = 8,
-    ACTIONS(357), 1,
-      anon_sym_RBRACE,
-    ACTIONS(359), 1,
-      anon_sym_annotation,
-    ACTIONS(362), 1,
-      anon_sym_using,
-    ACTIONS(368), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(365), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4738] = 8,
-    ACTIONS(371), 1,
-      anon_sym_RBRACE,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(127), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4775] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(381), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(112), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4812] = 8,
-    ACTIONS(371), 1,
-      anon_sym_RBRACE,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4849] = 3,
-    ACTIONS(85), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(83), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
+  [3815] = 11,
+    ACTIONS(162), 1,
       anon_sym_link,
+    ACTIONS(164), 1,
       anon_sym_property,
+    ACTIONS(166), 1,
       anon_sym_annotation,
+    ACTIONS(168), 1,
       anon_sym_constraint,
+    ACTIONS(309), 1,
       anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4876] = 3,
-    ACTIONS(101), 1,
-      anon_sym_SEMI,
+    ACTIONS(313), 1,
+      anon_sym_RBRACE,
+    STATE(246), 1,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(260), 1,
+      sym_modifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(99), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(79), 6,
+      sym_link,
+      sym_property,
+      sym_annotation,
+      sym_constraint,
+      sym_index,
+      aux_sym_declarations_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9809,62 +9196,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4903] = 3,
-    ACTIONS(71), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(69), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4930] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(383), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [4955] = 4,
-    ACTIONS(178), 1,
+  [3861] = 6,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-    STATE(206), 1,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    STATE(119), 1,
+      sym_extending,
+    STATE(195), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(385), 16,
+    ACTIONS(315), 16,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -9881,28 +9225,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [4984] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(381), 1,
-      anon_sym_RBRACE,
+  [3896] = 6,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    STATE(115), 1,
+      sym_extending,
+    STATE(193), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
+    ACTIONS(317), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9910,28 +9254,97 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5021] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(387), 1,
-      anon_sym_RBRACE,
+  [3931] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(319), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [3980] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(321), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4029] = 4,
+    ACTIONS(325), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(327), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(323), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -9939,11 +9352,414 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5058] = 2,
+  [4059] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(329), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(389), 18,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4107] = 4,
+    ACTIONS(333), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(335), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(331), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4137] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(337), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4185] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(339), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4233] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(341), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4281] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(343), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4329] = 5,
+    ACTIONS(345), 1,
+      anon_sym_LBRACE,
+    ACTIONS(349), 1,
+      anon_sym_using,
+    STATE(200), 1,
+      sym_using,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(347), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4361] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(351), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4409] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(353), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4457] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(355), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4505] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(357), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4553] = 13,
+    ACTIONS(49), 1,
+      anon_sym_AMP,
+    ACTIONS(51), 1,
+      anon_sym_CARET,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(63), 1,
+      anon_sym_AMP_AMP,
+    ACTIONS(73), 1,
+      anon_sym_PIPE_PIPE,
+    ACTIONS(359), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(19), 2,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+    ACTIONS(23), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(27), 2,
+      anon_sym_LT,
+      anon_sym_GT,
+    ACTIONS(29), 2,
+      anon_sym_LT_EQ,
+      anon_sym_GT_EQ,
+    ACTIONS(31), 2,
+      anon_sym_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(25), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4601] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(361), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -9962,13 +9778,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5083] = 3,
-    ACTIONS(393), 1,
+  [4626] = 3,
+    ACTIONS(365), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(391), 17,
+    ACTIONS(363), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -9986,7 +9802,147 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5110] = 3,
+  [4653] = 3,
+    ACTIONS(97), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(95), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4680] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(367), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4705] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(369), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4730] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(371), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4755] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(373), 18,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4780] = 3,
+    ACTIONS(77), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(75), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4807] = 3,
     ACTIONS(105), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
@@ -10010,11 +9966,35 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5137] = 2,
+  [4834] = 3,
+    ACTIONS(377), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(395), 18,
+    ACTIONS(375), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4861] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(379), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -10033,69 +10013,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5162] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(397), 1,
-      anon_sym_RBRACE,
+  [4886] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(111), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5199] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(399), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5236] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(401), 18,
+    ACTIONS(381), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -10114,112 +10036,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5261] = 3,
-    ACTIONS(339), 1,
-      anon_sym_SEMI,
+  [4911] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(335), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5288] = 3,
-    ACTIONS(245), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(239), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5315] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(403), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(105), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5352] = 3,
-    ACTIONS(81), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(79), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5379] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(405), 18,
+    ACTIONS(383), 18,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -10238,13 +10059,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5404] = 3,
-    ACTIONS(93), 1,
+  [4936] = 3,
+    ACTIONS(101), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(91), 17,
+    ACTIONS(99), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -10262,120 +10083,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5431] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(407), 1,
-      anon_sym_RBRACE,
+  [4963] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(118), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5468] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(375), 1,
-      anon_sym_using,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(407), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(102), 5,
-      sym_annotation,
-      sym_using,
-      sym_uselang,
-      sym_computed,
-      aux_sym_function_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5505] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(409), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5530] = 3,
-    ACTIONS(263), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(257), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5557] = 4,
-    ACTIONS(178), 1,
+    ACTIONS(385), 18,
       anon_sym_LBRACE,
-    STATE(199), 1,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_using,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [4988] = 4,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    STATE(197), 1,
       sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(411), 16,
+    ACTIONS(387), 16,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -10392,101 +10131,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5586] = 3,
-    ACTIONS(331), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(327), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5613] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(413), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5638] = 3,
-    ACTIONS(417), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(415), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5665] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(419), 18,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_SEMI,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5690] = 3,
+  [5017] = 3,
     ACTIONS(89), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
@@ -10510,605 +10155,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [5717] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(421), 1,
-      anon_sym_RBRACE,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5753] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(335), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5777] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(75), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5801] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(95), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5825] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(415), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5849] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(257), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5873] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(87), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5897] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(425), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(167), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5933] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(327), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5957] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(425), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [5993] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(427), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6017] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(429), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6041] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(83), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6065] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(431), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6089] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(433), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(136), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6125] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(433), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6161] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(435), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(187), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6197] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(437), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6221] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(439), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6257] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(441), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6281] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(443), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6305] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(91), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6329] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(445), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6365] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(447), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6389] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(449), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6413] = 2,
+  [5044] = 3,
+    ACTIONS(109), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11130,11 +10179,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6437] = 2,
+  [5071] = 3,
+    ACTIONS(263), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(451), 17,
+    ACTIONS(257), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -11152,11 +10203,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6461] = 2,
+  [5098] = 4,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    STATE(192), 1,
+      sym_declarations,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(239), 17,
+    ACTIONS(389), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5127] = 3,
+    ACTIONS(93), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(91), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -11174,285 +10252,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6485] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(421), 1,
-      anon_sym_RBRACE,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(186), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6521] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(445), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(154), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6557] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(453), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6581] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(455), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6617] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(79), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6641] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(457), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(178), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6677] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(455), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(158), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6713] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(459), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6737] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(461), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6761] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(463), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(190), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6797] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(465), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6821] = 2,
+  [5154] = 3,
+    ACTIONS(71), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11474,11 +10276,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6845] = 2,
+  [5181] = 3,
+    ACTIONS(255), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(391), 17,
+    ACTIONS(249), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -11496,7 +10300,184 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6869] = 2,
+  [5208] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(391), 18,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_SEMI,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5233] = 3,
+    ACTIONS(335), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(331), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5260] = 3,
+    ACTIONS(327), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(323), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5287] = 8,
+    ACTIONS(393), 1,
+      anon_sym_RBRACE,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(169), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5323] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(403), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(171), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5359] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(405), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5383] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(407), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(164), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5419] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11518,39 +10499,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6893] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(463), 1,
-      anon_sym_RBRACE,
+  [5443] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [6929] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(467), 17,
+    ACTIONS(409), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -11568,11 +10521,39 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6953] = 2,
+  [5467] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(407), 1,
+      anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(469), 17,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5503] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(95), 17,
       anon_sym_RBRACE,
       anon_sym_type,
       anon_sym_scalar,
@@ -11590,285 +10571,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [6977] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(471), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7001] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(473), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7025] = 8,
-    ACTIONS(475), 1,
-      anon_sym_RBRACE,
-    ACTIONS(477), 1,
-      anon_sym_annotation,
-    ACTIONS(480), 1,
-      anon_sym_using,
-    ACTIONS(486), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(483), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7061] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(489), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7085] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(491), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7109] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(493), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7145] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(495), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7181] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(495), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(145), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7217] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(497), 17,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7241] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(499), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(183), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7277] = 8,
-    ACTIONS(373), 1,
-      anon_sym_annotation,
-    ACTIONS(379), 1,
-      sym_identifier,
-    ACTIONS(423), 1,
-      anon_sym_using,
-    ACTIONS(499), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(280), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    STATE(151), 4,
-      sym_annotation,
-      sym_using,
-      sym_computed,
-      aux_sym_constraint_repeat1,
-    ACTIONS(377), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7313] = 2,
+  [5527] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11890,7 +10593,1291 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7337] = 2,
+  [5551] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(257), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5575] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(411), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5599] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(413), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5623] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(415), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5647] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(323), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5671] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(417), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5707] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(417), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(154), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5743] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(419), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(157), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5779] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(421), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5803] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5839] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(423), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(161), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5875] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(87), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5899] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(363), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5923] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(83), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5947] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(107), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5971] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(425), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [5995] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(427), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(132), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6031] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(429), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6055] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(331), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6079] = 8,
+    ACTIONS(393), 1,
+      anon_sym_RBRACE,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6115] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(249), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6139] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(375), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6163] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(431), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(170), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6199] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(433), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6223] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(435), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6247] = 8,
+    ACTIONS(437), 1,
+      anon_sym_RBRACE,
+    ACTIONS(439), 1,
+      anon_sym_annotation,
+    ACTIONS(442), 1,
+      anon_sym_using,
+    ACTIONS(448), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(445), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6283] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(451), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6319] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(451), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(175), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6355] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(75), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6379] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(453), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6415] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(453), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(140), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6451] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(455), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6475] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(457), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6499] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(459), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6523] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(461), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6559] = 8,
+    ACTIONS(463), 1,
+      anon_sym_RBRACE,
+    ACTIONS(465), 1,
+      anon_sym_annotation,
+    ACTIONS(468), 1,
+      anon_sym_using,
+    ACTIONS(474), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(170), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_function_repeat1,
+    ACTIONS(471), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6595] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(477), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6631] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(477), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(144), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6667] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(479), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6691] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(481), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6715] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(483), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6751] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(483), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(181), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6787] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(91), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6811] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(79), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6835] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(485), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6859] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(487), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6883] = 8,
+    ACTIONS(395), 1,
+      anon_sym_annotation,
+    ACTIONS(397), 1,
+      anon_sym_using,
+    ACTIONS(401), 1,
+      sym_identifier,
+    ACTIONS(489), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(270), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    STATE(160), 4,
+      sym_annotation,
+      sym_using,
+      sym_computed,
+      aux_sym_constraint_repeat1,
+    ACTIONS(399), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6919] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(69), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6943] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(491), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6967] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(493), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [6991] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(495), 17,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7015] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(497), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7038] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(499), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7061] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11911,28 +11898,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7360] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(411), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7383] = 2,
+  [7084] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11953,7 +11919,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7406] = 2,
+  [7107] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11974,7 +11940,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7429] = 2,
+  [7130] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -11995,7 +11961,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7452] = 2,
+  [7153] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12016,7 +11982,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7475] = 2,
+  [7176] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(387), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7199] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12037,7 +12024,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7498] = 2,
+  [7222] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(389), 16,
+      anon_sym_RBRACE,
+      anon_sym_type,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_alias,
+      anon_sym_function,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7245] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12058,7 +12066,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7521] = 2,
+  [7268] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12079,7 +12087,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7544] = 2,
+  [7291] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12100,7 +12108,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7567] = 2,
+  [7314] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12121,7 +12129,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7590] = 2,
+  [7337] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12142,20 +12150,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7613] = 2,
+  [7360] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(523), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(525), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(523), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(215), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -12163,20 +12174,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7636] = 2,
+  [7391] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(527), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(529), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(525), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(219), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -12184,20 +12198,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7659] = 2,
+  [7422] = 7,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(531), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(533), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(527), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
+    STATE(221), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -12205,91 +12222,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7682] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(529), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7705] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(531), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7728] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(533), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7751] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(385), 16,
-      anon_sym_RBRACE,
-      anon_sym_type,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_alias,
-      anon_sym_function,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7774] = 7,
+  [7453] = 7,
     ACTIONS(166), 1,
       anon_sym_annotation,
     ACTIONS(535), 1,
@@ -12299,10 +12232,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(228), 2,
+    STATE(217), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12313,70 +12246,22 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7805] = 7,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(539), 1,
-      anon_sym_COLON_EQ,
+  [7484] = 6,
     ACTIONS(541), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(224), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7836] = 7,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(543), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(545), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(227), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [7867] = 6,
-    ACTIONS(549), 1,
       anon_sym_annotation,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(547), 2,
+    ACTIONS(539), 2,
       anon_sym_RBRACE,
       anon_sym_SEMI,
-    STATE(215), 2,
+    STATE(205), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
-    ACTIONS(552), 7,
+    ACTIONS(544), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -12384,20 +12269,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7896] = 7,
-    ACTIONS(166), 1,
+  [7513] = 7,
+    ACTIONS(547), 1,
+      anon_sym_scalar,
+    ACTIONS(549), 1,
+      anon_sym_link,
+    ACTIONS(551), 1,
+      anon_sym_property,
+    ACTIONS(553), 1,
       anon_sym_annotation,
-    ACTIONS(555), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(557), 1,
-      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(226), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(220), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12408,11 +12292,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7927] = 2,
+  [7543] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(559), 13,
+    ACTIONS(555), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -12426,18 +12310,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7947] = 6,
+  [7563] = 6,
     ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(561), 1,
+    ACTIONS(557), 1,
       anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(230), 2,
+    STATE(205), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12448,18 +12332,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [7975] = 6,
+  [7591] = 4,
+    ACTIONS(559), 1,
+      anon_sym_type,
+    ACTIONS(563), 1,
+      anon_sym_constraint,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(561), 11,
+      anon_sym_scalar,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7615] = 6,
     ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(561), 1,
+    ACTIONS(557), 1,
       anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(215), 2,
+    STATE(213), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12470,11 +12374,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8003] = 2,
+  [7643] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(563), 13,
+    ACTIONS(565), 13,
       anon_sym_type,
       anon_sym_scalar,
       anon_sym_link,
@@ -12488,29 +12392,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8023] = 6,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
-    ACTIONS(565), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(219), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8051] = 2,
+  [7663] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -12528,11 +12410,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8071] = 2,
+  [7683] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
+    ACTIONS(569), 1,
+      anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(569), 13,
+    STATE(205), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7711] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(571), 13,
       anon_sym_RBRACE,
       anon_sym_link,
       anon_sym_property,
@@ -12546,41 +12450,61 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8091] = 6,
+  [7731] = 6,
     ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(571), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(215), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8119] = 4,
     ACTIONS(573), 1,
-      anon_sym_type,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(205), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7759] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(575), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7779] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
     ACTIONS(577), 1,
-      anon_sym_constraint,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(575), 11,
-      anon_sym_scalar,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
+    STATE(205), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
       anon_sym_abstract,
       anon_sym_overloaded,
       anon_sym_required,
@@ -12588,102 +12512,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8143] = 6,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
+  [7807] = 10,
     ACTIONS(579), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(215), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8171] = 6,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
+      anon_sym_LPAREN,
     ACTIONS(581), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(215), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8199] = 6,
-    ACTIONS(166), 1,
-      anon_sym_annotation,
+      anon_sym_RPAREN,
     ACTIONS(583), 1,
-      anon_sym_SEMI,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(73), 1,
+      sym_expression,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(215), 2,
-      sym_annotation,
-      aux_sym_annotation_repeat1,
-    STATE(282), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8227] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(585), 13,
-      anon_sym_RBRACE,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8247] = 6,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [7843] = 6,
     ACTIONS(166), 1,
       anon_sym_annotation,
-    ACTIONS(587), 1,
-      anon_sym_RBRACE,
+    ACTIONS(593), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(215), 2,
+    STATE(205), 2,
       sym_annotation,
       aux_sym_annotation_repeat1,
-    STATE(282), 2,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12694,48 +12560,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8275] = 2,
+  [7871] = 4,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(589), 13,
-      anon_sym_RBRACE,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_constraint,
-      anon_sym_index,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8295] = 3,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(591), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_SEMI,
-    ACTIONS(593), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [8317] = 4,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(233), 2,
+    STATE(220), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(595), 4,
@@ -12751,19 +12580,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8341] = 7,
+  [7895] = 6,
+    ACTIONS(166), 1,
+      anon_sym_annotation,
     ACTIONS(600), 1,
-      anon_sym_scalar,
-    ACTIONS(602), 1,
-      anon_sym_link,
-    ACTIONS(604), 1,
-      anon_sym_property,
-    ACTIONS(606), 1,
-      anon_sym_annotation,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(233), 2,
+    STATE(205), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12774,17 +12602,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8371] = 6,
-    ACTIONS(602), 1,
-      anon_sym_link,
-    ACTIONS(604), 1,
-      anon_sym_property,
-    ACTIONS(606), 1,
+  [7923] = 6,
+    ACTIONS(166), 1,
       anon_sym_annotation,
+    ACTIONS(602), 1,
+      anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(233), 2,
+    STATE(208), 2,
+      sym_annotation,
+      aux_sym_annotation_repeat1,
+    STATE(271), 2,
       sym_modifier,
       aux_sym_scalar_type_def_repeat1,
     ACTIONS(174), 7,
@@ -12795,32 +12624,926 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_single,
       anon_sym_multi,
       anon_sym_inheritable,
-  [8398] = 9,
-    ACTIONS(608), 1,
+  [7951] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(604), 13,
+      anon_sym_RBRACE,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_constraint,
+      anon_sym_index,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [7971] = 10,
+    ACTIONS(579), 1,
       anon_sym_LPAREN,
-    ACTIONS(610), 1,
-      anon_sym_RPAREN,
-    ACTIONS(612), 1,
+    ACTIONS(583), 1,
       anon_sym_global,
-    ACTIONS(614), 1,
+    ACTIONS(585), 1,
       anon_sym_SQUOTE,
-    ACTIONS(616), 1,
+    ACTIONS(591), 1,
+      sym_number,
+    ACTIONS(606), 1,
+      anon_sym_RPAREN,
+    ACTIONS(608), 1,
       sym_identifier,
-    STATE(78), 1,
+    STATE(76), 1,
       sym_expression,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(618), 3,
+    ACTIONS(589), 3,
       sym_true,
       sym_false,
       sym_null,
-    STATE(7), 3,
+    STATE(8), 3,
       sym_fncall,
       sym_binary_expression,
       sym_string,
-  [8431] = 3,
-    ACTIONS(389), 1,
+  [8007] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(21), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8040] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(91), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8073] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(88), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8106] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(23), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8139] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(9), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8172] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(6), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8205] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(591), 1,
+      sym_number,
+    ACTIONS(610), 1,
+      sym_identifier,
+    STATE(85), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8238] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(7), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8271] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(86), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8304] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(14), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8337] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(10), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8370] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(18), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8403] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(13), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8436] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(95), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8469] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(99), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8502] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(92), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8535] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(28), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8568] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(97), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8601] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(98), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8634] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(27), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8667] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(93), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8700] = 6,
+    ACTIONS(549), 1,
+      anon_sym_link,
+    ACTIONS(551), 1,
+      anon_sym_property,
+    ACTIONS(553), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(220), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [8727] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(19), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8760] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(24), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8793] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(25), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8826] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(30), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8859] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(3), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8892] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(90), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8925] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(22), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8958] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(29), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [8991] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(26), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9024] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(96), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9057] = 9,
+    ACTIONS(579), 1,
+      anon_sym_LPAREN,
+    ACTIONS(583), 1,
+      anon_sym_global,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(587), 1,
+      sym_identifier,
+    ACTIONS(591), 1,
+      sym_number,
+    STATE(15), 1,
+      sym_expression,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(589), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(8), 3,
+      sym_fncall,
+      sym_binary_expression,
+      sym_string,
+  [9090] = 3,
+    ACTIONS(381), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(612), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9110] = 3,
+    ACTIONS(361), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(614), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9130] = 3,
+    ACTIONS(563), 1,
+      anon_sym_constraint,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(561), 10,
+      anon_sym_link,
+      anon_sym_property,
+      anon_sym_annotation,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [9150] = 3,
+    ACTIONS(383), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(616), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9170] = 3,
+    ACTIONS(507), 1,
+      anon_sym_RBRACE,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(618), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+      sym_identifier,
+  [9190] = 3,
+    ACTIONS(501), 1,
       anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
@@ -12836,294 +13559,42 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
       sym_identifier,
-  [8451] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(18), 1,
-      sym_expression,
+  [9210] = 3,
+    ACTIONS(369), 1,
+      anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8481] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
+    ACTIONS(622), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
       sym_identifier,
-    STATE(11), 1,
-      sym_expression,
+  [9230] = 3,
+    ACTIONS(391), 1,
+      anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8511] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
+    ACTIONS(624), 10,
+      anon_sym_annotation,
+      anon_sym_using,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
       sym_identifier,
-    STATE(99), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8541] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(26), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8571] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(9), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8601] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(8), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8631] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(28), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8661] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(6), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8691] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(5), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8721] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(24), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8751] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(622), 1,
-      sym_identifier,
-    STATE(84), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8781] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(97), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8811] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(22), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8841] = 3,
-    ACTIONS(624), 1,
+  [9250] = 3,
+    ACTIONS(379), 1,
       anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
@@ -13139,174 +13610,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
       sym_identifier,
-  [8861] = 3,
-    ACTIONS(401), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(628), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [8881] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(23), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8911] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(98), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8941] = 3,
-    ACTIONS(577), 1,
-      anon_sym_constraint,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(575), 10,
-      anon_sym_link,
-      anon_sym_property,
-      anon_sym_annotation,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [8961] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(93), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [8991] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(95), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9021] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(27), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9051] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(94), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9081] = 3,
-    ACTIONS(383), 1,
+  [9270] = 3,
+    ACTIONS(628), 1,
       anon_sym_RBRACE,
     ACTIONS(9), 2,
       sym_comment,
@@ -13322,1047 +13627,727 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_multi,
       anon_sym_inheritable,
       sym_identifier,
-  [9101] = 3,
-    ACTIONS(419), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(632), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [9121] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(91), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9151] = 3,
-    ACTIONS(395), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(634), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [9171] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(88), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9201] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(96), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9231] = 3,
+  [9290] = 11,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(632), 1,
+      anon_sym_LBRACE,
+    ACTIONS(634), 1,
+      anon_sym_SEMI,
     ACTIONS(636), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(638), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [9251] = 8,
-    ACTIONS(608), 1,
       anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(87), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9281] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(25), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9311] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
+    ACTIONS(638), 1,
+      anon_sym_on,
     ACTIONS(640), 1,
-      sym_identifier,
-    STATE(75), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9341] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(89), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9371] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(14), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9401] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(13), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9431] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(16), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9461] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(15), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9491] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(29), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9521] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(21), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9551] = 3,
-    ACTIONS(413), 1,
-      anon_sym_RBRACE,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(642), 10,
-      anon_sym_annotation,
-      anon_sym_using,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-      sym_identifier,
-  [9571] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(100), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9601] = 8,
-    ACTIONS(608), 1,
-      anon_sym_LPAREN,
-    ACTIONS(612), 1,
-      anon_sym_global,
-    ACTIONS(614), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(616), 1,
-      sym_identifier,
-    STATE(30), 1,
-      sym_expression,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(618), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(7), 3,
-      sym_fncall,
-      sym_binary_expression,
-      sym_string,
-  [9631] = 4,
-    ACTIONS(644), 1,
-      anon_sym_annotation,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(233), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [9652] = 11,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(646), 1,
-      anon_sym_LBRACE,
-    ACTIONS(648), 1,
-      anon_sym_SEMI,
-    ACTIONS(650), 1,
-      anon_sym_LPAREN,
-    ACTIONS(652), 1,
-      anon_sym_on,
-    ACTIONS(654), 1,
       anon_sym_except,
-    STATE(284), 1,
+    STATE(272), 1,
       sym_argspec,
-    STATE(293), 1,
-      sym_on,
-    STATE(301), 1,
-      sym_except,
-    STATE(341), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9687] = 4,
-    ACTIONS(606), 1,
-      anon_sym_annotation,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    STATE(233), 2,
-      sym_modifier,
-      aux_sym_scalar_type_def_repeat1,
-    ACTIONS(174), 7,
-      anon_sym_abstract,
-      anon_sym_overloaded,
-      anon_sym_required,
-      anon_sym_optional,
-      anon_sym_single,
-      anon_sym_multi,
-      anon_sym_inheritable,
-  [9708] = 11,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(650), 1,
-      anon_sym_LPAREN,
-    ACTIONS(652), 1,
-      anon_sym_on,
-    ACTIONS(654), 1,
-      anon_sym_except,
-    ACTIONS(656), 1,
-      anon_sym_LBRACE,
-    ACTIONS(658), 1,
-      anon_sym_SEMI,
-    STATE(285), 1,
-      sym_argspec,
-    STATE(286), 1,
+    STATE(278), 1,
       sym_on,
     STATE(294), 1,
       sym_except,
-    STATE(336), 1,
+    STATE(332), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [9743] = 9,
-    ACTIONS(188), 1,
+  [9325] = 11,
+    ACTIONS(194), 1,
       anon_sym_extending,
-    ACTIONS(652), 1,
+    ACTIONS(636), 1,
+      anon_sym_LPAREN,
+    ACTIONS(638), 1,
       anon_sym_on,
-    ACTIONS(654), 1,
+    ACTIONS(640), 1,
       anon_sym_except,
-    ACTIONS(660), 1,
+    ACTIONS(642), 1,
       anon_sym_LBRACE,
-    ACTIONS(662), 1,
+    ACTIONS(644), 1,
       anon_sym_SEMI,
-    STATE(288), 1,
+    STATE(273), 1,
+      sym_argspec,
+    STATE(281), 1,
       sym_on,
-    STATE(296), 1,
-      sym_except,
-    STATE(334), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9772] = 9,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(652), 1,
-      anon_sym_on,
-    ACTIONS(654), 1,
-      anon_sym_except,
-    ACTIONS(664), 1,
-      anon_sym_LBRACE,
-    ACTIONS(666), 1,
-      anon_sym_SEMI,
     STATE(290), 1,
-      sym_on,
-    STATE(303), 1,
       sym_except,
-    STATE(339), 1,
+    STATE(329), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [9801] = 7,
-    ACTIONS(188), 1,
+  [9360] = 4,
+    ACTIONS(646), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(220), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [9381] = 4,
+    ACTIONS(553), 1,
+      anon_sym_annotation,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    STATE(220), 2,
+      sym_modifier,
+      aux_sym_scalar_type_def_repeat1,
+    ACTIONS(174), 7,
+      anon_sym_abstract,
+      anon_sym_overloaded,
+      anon_sym_required,
+      anon_sym_optional,
+      anon_sym_single,
+      anon_sym_multi,
+      anon_sym_inheritable,
+  [9402] = 9,
+    ACTIONS(194), 1,
       anon_sym_extending,
-    ACTIONS(654), 1,
+    ACTIONS(638), 1,
+      anon_sym_on,
+    ACTIONS(640), 1,
       anon_sym_except,
-    ACTIONS(664), 1,
+    ACTIONS(648), 1,
       anon_sym_LBRACE,
-    ACTIONS(666), 1,
+    ACTIONS(650), 1,
       anon_sym_SEMI,
-    STATE(303), 1,
+    STATE(277), 1,
+      sym_on,
+    STATE(289), 1,
       sym_except,
-    STATE(339), 1,
+    STATE(325), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [9824] = 2,
+  [9431] = 9,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(638), 1,
+      anon_sym_on,
+    ACTIONS(640), 1,
+      anon_sym_except,
+    ACTIONS(652), 1,
+      anon_sym_LBRACE,
+    ACTIONS(654), 1,
+      anon_sym_SEMI,
+    STATE(282), 1,
+      sym_on,
+    STATE(284), 1,
+      sym_except,
+    STATE(333), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9460] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(656), 6,
+      anon_sym_LBRACE,
+      anon_sym_DASH_GT,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9473] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(658), 6,
+      anon_sym_LBRACE,
+      anon_sym_DASH_GT,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9486] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(660), 6,
+      anon_sym_LBRACE,
+      anon_sym_DASH_GT,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9499] = 7,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(640), 1,
+      anon_sym_except,
+    ACTIONS(662), 1,
+      anon_sym_LBRACE,
+    ACTIONS(664), 1,
+      anon_sym_SEMI,
+    STATE(285), 1,
+      sym_except,
+    STATE(319), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9522] = 7,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(640), 1,
+      anon_sym_except,
+    ACTIONS(648), 1,
+      anon_sym_LBRACE,
+    ACTIONS(650), 1,
+      anon_sym_SEMI,
+    STATE(289), 1,
+      sym_except,
+    STATE(325), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9545] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(666), 6,
+      anon_sym_LBRACE,
+      anon_sym_DASH_GT,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_on,
+      anon_sym_except,
+  [9558] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(668), 6,
       anon_sym_LBRACE,
+      anon_sym_DASH_GT,
       anon_sym_SEMI,
-      anon_sym_RPAREN,
       anon_sym_extending,
       anon_sym_on,
       anon_sym_except,
-  [9837] = 7,
-    ACTIONS(188), 1,
+  [9571] = 7,
+    ACTIONS(194), 1,
       anon_sym_extending,
+    ACTIONS(640), 1,
+      anon_sym_except,
+    ACTIONS(652), 1,
+      anon_sym_LBRACE,
     ACTIONS(654), 1,
+      anon_sym_SEMI,
+    STATE(284), 1,
+      sym_except,
+    STATE(333), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9594] = 7,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(640), 1,
       anon_sym_except,
     ACTIONS(670), 1,
       anon_sym_LBRACE,
     ACTIONS(672), 1,
       anon_sym_SEMI,
-    STATE(307), 1,
+    STATE(286), 1,
       sym_except,
-    STATE(338), 1,
+    STATE(324), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [9860] = 2,
+  [9617] = 5,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    STATE(198), 1,
+      sym_declarations,
+    STATE(317), 1,
+      sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(674), 6,
+  [9634] = 5,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(670), 1,
       anon_sym_LBRACE,
+    ACTIONS(672), 1,
       anon_sym_SEMI,
-      anon_sym_RPAREN,
+    STATE(324), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9651] = 5,
+    ACTIONS(194), 1,
       anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [9873] = 7,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(654), 1,
-      anon_sym_except,
+    ACTIONS(674), 1,
+      anon_sym_LBRACE,
     ACTIONS(676), 1,
-      anon_sym_LBRACE,
+      anon_sym_SEMI,
+    STATE(321), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9668] = 5,
+    ACTIONS(194), 1,
+      anon_sym_extending,
     ACTIONS(678), 1,
-      anon_sym_SEMI,
-    STATE(295), 1,
-      sym_except,
-    STATE(353), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9896] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(680), 6,
       anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [9909] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(682), 6,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-      anon_sym_extending,
-      anon_sym_on,
-      anon_sym_except,
-  [9922] = 7,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(654), 1,
-      anon_sym_except,
-    ACTIONS(660), 1,
-      anon_sym_LBRACE,
-    ACTIONS(662), 1,
-      anon_sym_SEMI,
-    STATE(296), 1,
-      sym_except,
-    STATE(334), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9945] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(664), 1,
-      anon_sym_LBRACE,
-    ACTIONS(666), 1,
-      anon_sym_SEMI,
-    STATE(339), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9962] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(684), 1,
-      anon_sym_LBRACE,
-    ACTIONS(686), 1,
-      anon_sym_SEMI,
-    STATE(346), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [9979] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(670), 1,
-      anon_sym_LBRACE,
-    ACTIONS(672), 1,
+    ACTIONS(680), 1,
       anon_sym_SEMI,
     STATE(338), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [9996] = 5,
-    ACTIONS(654), 1,
-      anon_sym_except,
-    ACTIONS(688), 1,
-      anon_sym_LBRACE,
-    ACTIONS(690), 1,
-      anon_sym_SEMI,
-    STATE(345), 1,
-      sym_except,
+  [9685] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10013] = 4,
-    ACTIONS(692), 1,
+    ACTIONS(682), 4,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_extending,
+      anon_sym_except,
+  [9696] = 4,
+    ACTIONS(684), 1,
       anon_sym_SQUOTE,
-    STATE(299), 1,
+    STATE(295), 1,
       aux_sym_string_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(694), 2,
+    ACTIONS(686), 2,
       sym_unescaped_single_string_fragment,
       sym_escape_sequence,
-  [10028] = 4,
-    ACTIONS(696), 1,
-      anon_sym_SQUOTE,
-    STATE(299), 1,
-      aux_sym_string_repeat1,
-    ACTIONS(3), 2,
+  [9711] = 5,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(662), 1,
+      anon_sym_LBRACE,
+    ACTIONS(664), 1,
+      anon_sym_SEMI,
+    STATE(319), 1,
+      sym_extending,
+    ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(698), 2,
-      sym_unescaped_single_string_fragment,
-      sym_escape_sequence,
-  [10043] = 4,
-    ACTIONS(701), 1,
+  [9728] = 5,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(652), 1,
+      anon_sym_LBRACE,
+    ACTIONS(654), 1,
+      anon_sym_SEMI,
+    STATE(333), 1,
+      sym_extending,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9745] = 4,
+    ACTIONS(688), 1,
       ts_builtin_sym_end,
-    ACTIONS(703), 1,
+    ACTIONS(690), 1,
       anon_sym_module,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(300), 2,
+    STATE(291), 2,
       sym_module,
       aux_sym_source_file_repeat1,
-  [10058] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(660), 1,
-      anon_sym_LBRACE,
-    ACTIONS(662), 1,
-      anon_sym_SEMI,
-    STATE(334), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10075] = 4,
-    ACTIONS(706), 1,
+  [9760] = 4,
+    ACTIONS(693), 1,
       anon_sym_SQUOTE,
-    STATE(298), 1,
+    STATE(292), 1,
       aux_sym_string_repeat1,
     ACTIONS(3), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(708), 2,
+    ACTIONS(695), 2,
       sym_unescaped_single_string_fragment,
       sym_escape_sequence,
-  [10090] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    ACTIONS(676), 1,
+  [9775] = 5,
+    ACTIONS(184), 1,
       anon_sym_LBRACE,
-    ACTIONS(678), 1,
-      anon_sym_SEMI,
-    STATE(353), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10107] = 5,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
+    ACTIONS(194), 1,
       anon_sym_extending,
-    STATE(210), 1,
+    STATE(190), 1,
       sym_declarations,
-    STATE(335), 1,
+    STATE(316), 1,
       sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10124] = 2,
+  [9792] = 5,
+    ACTIONS(194), 1,
+      anon_sym_extending,
+    ACTIONS(648), 1,
+      anon_sym_LBRACE,
+    ACTIONS(650), 1,
+      anon_sym_SEMI,
+    STATE(325), 1,
+      sym_extending,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(710), 4,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_extending,
+  [9809] = 4,
+    ACTIONS(698), 1,
+      anon_sym_SQUOTE,
+    STATE(292), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(3), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(700), 2,
+      sym_unescaped_single_string_fragment,
+      sym_escape_sequence,
+  [9824] = 5,
+    ACTIONS(640), 1,
       anon_sym_except,
-  [10135] = 4,
+    ACTIONS(702), 1,
+      anon_sym_LBRACE,
+    ACTIONS(704), 1,
+      anon_sym_SEMI,
+    STATE(328), 1,
+      sym_except,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9841] = 4,
     ACTIONS(7), 1,
       anon_sym_module,
-    ACTIONS(712), 1,
+    ACTIONS(706), 1,
       ts_builtin_sym_end,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    STATE(300), 2,
+    STATE(291), 2,
       sym_module,
       aux_sym_source_file_repeat1,
-  [10150] = 5,
-    ACTIONS(188), 1,
-      anon_sym_extending,
+  [9856] = 4,
+    ACTIONS(708), 1,
+      anon_sym_COMMA,
+    ACTIONS(710), 1,
+      anon_sym_GT,
+    STATE(299), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9870] = 4,
+    ACTIONS(708), 1,
+      anon_sym_COMMA,
+    ACTIONS(712), 1,
+      anon_sym_GT,
+    STATE(307), 1,
+      aux_sym_enum_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9884] = 3,
     ACTIONS(714), 1,
-      anon_sym_LBRACE,
-    ACTIONS(716), 1,
-      anon_sym_SEMI,
-    STATE(357), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10167] = 5,
-    ACTIONS(718), 1,
-      anon_sym_LBRACE,
-    ACTIONS(720), 1,
-      anon_sym_SEMI,
-    ACTIONS(722), 1,
-      anon_sym_using,
-    STATE(352), 1,
-      sym_uselang,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10184] = 5,
-    ACTIONS(724), 1,
-      anon_sym_LBRACE,
-    ACTIONS(726), 1,
-      anon_sym_SEMI,
-    ACTIONS(728), 1,
-      anon_sym_using,
-    STATE(333), 1,
-      sym_uselang,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10201] = 5,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    ACTIONS(188), 1,
-      anon_sym_extending,
-    STATE(197), 1,
-      sym_declarations,
-    STATE(355), 1,
-      sym_extending,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10218] = 4,
-    ACTIONS(730), 1,
-      anon_sym_COMMA,
-    ACTIONS(732), 1,
-      anon_sym_GT,
-    STATE(319), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10232] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(734), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_extending,
-  [10242] = 4,
-    ACTIONS(730), 1,
-      anon_sym_COMMA,
-    ACTIONS(736), 1,
-      anon_sym_GT,
-    STATE(311), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10256] = 4,
-    ACTIONS(315), 1,
-      anon_sym_RPAREN,
-    ACTIONS(738), 1,
-      anon_sym_COMMA,
-    STATE(314), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10270] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(741), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_using,
-  [10280] = 4,
-    ACTIONS(650), 1,
-      anon_sym_LPAREN,
-    ACTIONS(743), 1,
-      anon_sym_RPAREN,
-    STATE(418), 1,
-      sym_argspec,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10294] = 4,
-    ACTIONS(289), 1,
-      anon_sym_COMMA,
-    ACTIONS(745), 1,
-      anon_sym_RPAREN,
-    STATE(314), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10308] = 4,
-    ACTIONS(747), 1,
-      anon_sym_COMMA,
-    ACTIONS(749), 1,
-      anon_sym_GT,
-    STATE(330), 1,
-      aux_sym__named_tuple_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10322] = 4,
-    ACTIONS(751), 1,
-      anon_sym_COMMA,
-    ACTIONS(754), 1,
-      anon_sym_GT,
-    STATE(319), 1,
-      aux_sym__tuple_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10336] = 4,
-    ACTIONS(756), 1,
-      anon_sym_COMMA,
-    ACTIONS(758), 1,
-      anon_sym_GT,
-    STATE(329), 1,
-      aux_sym_enum_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10350] = 4,
-    ACTIONS(321), 1,
-      anon_sym_RPAREN,
-    ACTIONS(760), 1,
-      anon_sym_COMMA,
-    STATE(321), 1,
-      aux_sym_fncall_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10364] = 4,
-    ACTIONS(289), 1,
-      anon_sym_COMMA,
-    ACTIONS(763), 1,
-      anon_sym_RPAREN,
-    STATE(323), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10378] = 4,
-    ACTIONS(289), 1,
-      anon_sym_COMMA,
-    ACTIONS(765), 1,
-      anon_sym_RPAREN,
-    STATE(314), 1,
-      aux_sym_argspec_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10392] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(767), 3,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_using,
-  [10402] = 4,
-    ACTIONS(297), 1,
-      anon_sym_COMMA,
-    ACTIONS(769), 1,
-      anon_sym_RPAREN,
-    STATE(321), 1,
-      aux_sym_fncall_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10416] = 4,
-    ACTIONS(756), 1,
-      anon_sym_COMMA,
-    ACTIONS(771), 1,
-      anon_sym_GT,
-    STATE(320), 1,
-      aux_sym_enum_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10430] = 4,
-    ACTIONS(773), 1,
-      anon_sym_COMMA,
-    ACTIONS(776), 1,
-      anon_sym_GT,
-    STATE(327), 1,
-      aux_sym__named_tuple_repeat1,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10444] = 3,
-    ACTIONS(778), 1,
       anon_sym_COLON,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(206), 2,
+    ACTIONS(182), 2,
       anon_sym_COMMA,
       anon_sym_GT,
-  [10456] = 4,
-    ACTIONS(780), 1,
+  [9896] = 4,
+    ACTIONS(716), 1,
       anon_sym_COMMA,
-    ACTIONS(783), 1,
+    ACTIONS(718), 1,
       anon_sym_GT,
-    STATE(329), 1,
-      aux_sym_enum_repeat1,
+    STATE(313), 1,
+      aux_sym__tuple_repeat1,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10470] = 4,
-    ACTIONS(747), 1,
+  [9910] = 4,
+    ACTIONS(716), 1,
       anon_sym_COMMA,
-    ACTIONS(785), 1,
+    ACTIONS(720), 1,
       anon_sym_GT,
-    STATE(327), 1,
+    STATE(301), 1,
+      aux_sym__tuple_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9924] = 4,
+    ACTIONS(267), 1,
+      anon_sym_COMMA,
+    ACTIONS(722), 1,
+      anon_sym_RPAREN,
+    STATE(312), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9938] = 4,
+    ACTIONS(275), 1,
+      anon_sym_COMMA,
+    ACTIONS(724), 1,
+      anon_sym_RPAREN,
+    STATE(310), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9952] = 4,
+    ACTIONS(275), 1,
+      anon_sym_COMMA,
+    ACTIONS(726), 1,
+      anon_sym_RPAREN,
+    STATE(310), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [9966] = 4,
+    ACTIONS(728), 1,
+      anon_sym_COMMA,
+    ACTIONS(731), 1,
+      anon_sym_GT,
+    STATE(306), 1,
       aux_sym__named_tuple_repeat1,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10484] = 3,
-    ACTIONS(787), 1,
-      anon_sym_LPAREN,
-    ACTIONS(789), 1,
-      sym_identifier,
+  [9980] = 4,
+    ACTIONS(733), 1,
+      anon_sym_COMMA,
+    ACTIONS(736), 1,
+      anon_sym_GT,
+    STATE(307), 1,
+      aux_sym_enum_repeat1,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10495] = 2,
+  [9994] = 4,
+    ACTIONS(738), 1,
+      anon_sym_COMMA,
+    ACTIONS(740), 1,
+      anon_sym_GT,
+    STATE(306), 1,
+      aux_sym__named_tuple_repeat1,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(791), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [10504] = 3,
-    ACTIONS(718), 1,
+  [10008] = 4,
+    ACTIONS(275), 1,
+      anon_sym_COMMA,
+    ACTIONS(742), 1,
+      anon_sym_RPAREN,
+    STATE(304), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10022] = 4,
+    ACTIONS(319), 1,
+      anon_sym_RPAREN,
+    ACTIONS(744), 1,
+      anon_sym_COMMA,
+    STATE(310), 1,
+      aux_sym_argspec_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10036] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(747), 3,
       anon_sym_LBRACE,
-    ACTIONS(720), 1,
+      anon_sym_SEMI,
+      anon_sym_extending,
+  [10046] = 4,
+    ACTIONS(321), 1,
+      anon_sym_RPAREN,
+    ACTIONS(749), 1,
+      anon_sym_COMMA,
+    STATE(312), 1,
+      aux_sym_fncall_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10060] = 4,
+    ACTIONS(752), 1,
+      anon_sym_COMMA,
+    ACTIONS(755), 1,
+      anon_sym_GT,
+    STATE(313), 1,
+      aux_sym__tuple_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10074] = 4,
+    ACTIONS(738), 1,
+      anon_sym_COMMA,
+    ACTIONS(757), 1,
+      anon_sym_GT,
+    STATE(308), 1,
+      aux_sym__named_tuple_repeat1,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10088] = 3,
+    ACTIONS(759), 1,
+      anon_sym_LBRACE,
+    STATE(340), 1,
+      sym_schema_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10099] = 3,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    STATE(186), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10110] = 3,
+    ACTIONS(184), 1,
+      anon_sym_LBRACE,
+    STATE(189), 1,
+      sym_declarations,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10121] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(761), 2,
+      sym__edgeql_chars,
+      sym_escape_sequence,
+  [10130] = 3,
+    ACTIONS(674), 1,
+      anon_sym_LBRACE,
+    ACTIONS(676), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10515] = 3,
+  [10141] = 3,
+    ACTIONS(638), 1,
+      anon_sym_on,
+    STATE(296), 1,
+      sym_on,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10152] = 3,
+    ACTIONS(763), 1,
+      anon_sym_LBRACE,
+    ACTIONS(765), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10163] = 3,
+    ACTIONS(767), 1,
+      anon_sym_LPAREN,
+    ACTIONS(769), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10174] = 3,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    STATE(391), 1,
+      sym_string,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10185] = 3,
+    ACTIONS(678), 1,
+      anon_sym_LBRACE,
+    ACTIONS(680), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10196] = 3,
+    ACTIONS(662), 1,
+      anon_sym_LBRACE,
+    ACTIONS(664), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10207] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(771), 2,
+      sym__edgeql_chars,
+      sym_escape_sequence,
+  [10216] = 3,
+    ACTIONS(585), 1,
+      anon_sym_SQUOTE,
+    STATE(352), 1,
+      sym_string,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10227] = 3,
+    ACTIONS(773), 1,
+      anon_sym_LBRACE,
+    ACTIONS(775), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10238] = 3,
+    ACTIONS(652), 1,
+      anon_sym_LBRACE,
+    ACTIONS(654), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10249] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(755), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10258] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(777), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [10267] = 3,
+    ACTIONS(648), 1,
+      anon_sym_LBRACE,
+    ACTIONS(650), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10278] = 3,
     ACTIONS(670), 1,
       anon_sym_LBRACE,
     ACTIONS(672), 1,
@@ -14370,591 +14355,424 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10526] = 3,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    STATE(208), 1,
-      sym_declarations,
+  [10289] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10537] = 3,
-    ACTIONS(664), 1,
+    ACTIONS(779), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10298] = 3,
+    ACTIONS(636), 1,
+      anon_sym_LPAREN,
+    STATE(371), 1,
+      sym_argspec,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10309] = 3,
+    ACTIONS(781), 1,
       anon_sym_LBRACE,
-    ACTIONS(666), 1,
+    ACTIONS(783), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10320] = 3,
+    ACTIONS(785), 1,
+      anon_sym_LPAREN,
+    ACTIONS(787), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10331] = 3,
+    ACTIONS(789), 1,
+      anon_sym_LBRACE,
+    ACTIONS(791), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10548] = 3,
-    ACTIONS(652), 1,
-      anon_sym_on,
-    STATE(297), 1,
-      sym_on,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10559] = 3,
-    ACTIONS(714), 1,
-      anon_sym_LBRACE,
-    ACTIONS(716), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10570] = 3,
-    ACTIONS(676), 1,
-      anon_sym_LBRACE,
-    ACTIONS(678), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10581] = 2,
+  [10342] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(793), 2,
-      anon_sym_RPAREN,
       anon_sym_COMMA,
-  [10590] = 3,
-    ACTIONS(660), 1,
-      anon_sym_LBRACE,
-    ACTIONS(662), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10601] = 2,
+      anon_sym_RPAREN,
+  [10351] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
     ACTIONS(795), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [10610] = 3,
-    ACTIONS(789), 1,
-      sym_identifier,
-    ACTIONS(797), 1,
-      anon_sym_LPAREN,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [10360] = 2,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10621] = 3,
+    ACTIONS(797), 2,
+      ts_builtin_sym_end,
+      anon_sym_module,
+  [10369] = 2,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+    ACTIONS(736), 2,
+      anon_sym_COMMA,
+      anon_sym_GT,
+  [10378] = 2,
     ACTIONS(799), 1,
-      anon_sym_LBRACE,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10386] = 2,
     ACTIONS(801), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10632] = 3,
+  [10394] = 2,
     ACTIONS(803), 1,
-      anon_sym_LBRACE,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10402] = 2,
     ACTIONS(805), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10643] = 3,
+  [10410] = 2,
     ACTIONS(807), 1,
-      anon_sym_LBRACE,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10418] = 2,
     ACTIONS(809), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10654] = 3,
+  [10426] = 2,
+    ACTIONS(791), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10434] = 2,
     ACTIONS(811), 1,
-      anon_sym_LBRACE,
-    STATE(332), 1,
-      sym_schema_declarations,
+      sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10665] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(754), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [10674] = 3,
+  [10442] = 2,
     ACTIONS(813), 1,
-      anon_sym_LBRACE,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10450] = 2,
     ACTIONS(815), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10685] = 2,
+  [10458] = 2,
+    ACTIONS(817), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-    ACTIONS(817), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [10694] = 3,
-    ACTIONS(789), 1,
-      sym_identifier,
+  [10466] = 2,
     ACTIONS(819), 1,
-      anon_sym_LPAREN,
+      sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10705] = 3,
+  [10474] = 2,
     ACTIONS(821), 1,
-      anon_sym_LBRACE,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10482] = 2,
     ACTIONS(823), 1,
-      anon_sym_SEMI,
+      anon_sym_using,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10716] = 3,
-    ACTIONS(684), 1,
-      anon_sym_LBRACE,
-    ACTIONS(686), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10727] = 3,
+  [10490] = 2,
     ACTIONS(825), 1,
-      anon_sym_LBRACE,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10498] = 2,
     ACTIONS(827), 1,
-      anon_sym_COLON_EQ,
+      sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10738] = 3,
-    ACTIONS(178), 1,
-      anon_sym_LBRACE,
-    STATE(201), 1,
-      sym_declarations,
+  [10506] = 2,
+    ACTIONS(829), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10749] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(829), 2,
-      ts_builtin_sym_end,
-      anon_sym_module,
-  [10758] = 3,
+  [10514] = 2,
     ACTIONS(831), 1,
-      anon_sym_LBRACE,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10522] = 2,
     ACTIONS(833), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10769] = 2,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-    ACTIONS(783), 2,
-      anon_sym_COMMA,
-      anon_sym_GT,
-  [10778] = 2,
+  [10530] = 2,
     ACTIONS(835), 1,
-      anon_sym_SEMI,
+      anon_sym_RPAREN,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10786] = 2,
+  [10538] = 2,
     ACTIONS(837), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10794] = 2,
+  [10546] = 2,
     ACTIONS(839), 1,
-      sym_identifier,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10802] = 2,
+  [10554] = 2,
     ACTIONS(841), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10810] = 2,
+  [10562] = 2,
     ACTIONS(843), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10818] = 2,
-    ACTIONS(845), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10826] = 2,
-    ACTIONS(847), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10834] = 2,
-    ACTIONS(849), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10842] = 2,
-    ACTIONS(851), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10850] = 2,
-    ACTIONS(853), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10858] = 2,
-    ACTIONS(686), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10866] = 2,
-    ACTIONS(855), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10874] = 2,
-    ACTIONS(857), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10882] = 2,
-    ACTIONS(859), 1,
-      anon_sym_LPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10890] = 2,
-    ACTIONS(861), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10898] = 2,
-    ACTIONS(863), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10906] = 2,
-    ACTIONS(865), 1,
-      anon_sym_edgedb,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10914] = 2,
-    ACTIONS(833), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10922] = 2,
-    ACTIONS(867), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10930] = 2,
-    ACTIONS(869), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10938] = 2,
-    ACTIONS(871), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10946] = 2,
-    ACTIONS(873), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10954] = 2,
-    ACTIONS(875), 1,
-      anon_sym_COLON,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10962] = 2,
-    ACTIONS(877), 1,
       anon_sym_type,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [10970] = 2,
-    ACTIONS(879), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10978] = 2,
-    ACTIONS(881), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10986] = 2,
-    ACTIONS(883), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [10994] = 2,
-    ACTIONS(885), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11002] = 2,
-    ACTIONS(815), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11010] = 2,
-    ACTIONS(887), 1,
-      anon_sym_RPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11018] = 2,
+  [10570] = 2,
     ACTIONS(672), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11026] = 2,
-    ACTIONS(889), 1,
+  [10578] = 2,
+    ACTIONS(845), 1,
+      anon_sym_COLON,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10586] = 2,
+    ACTIONS(847), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11034] = 2,
+  [10594] = 2,
+    ACTIONS(849), 1,
+      anon_sym_enum,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10602] = 2,
+    ACTIONS(851), 1,
+      anon_sym_DASH_GT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10610] = 2,
+    ACTIONS(853), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10618] = 2,
+    ACTIONS(855), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10626] = 2,
+    ACTIONS(857), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10634] = 2,
+    ACTIONS(859), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10642] = 2,
+    ACTIONS(861), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10650] = 2,
+    ACTIONS(863), 1,
+      anon_sym_COLON_EQ,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10658] = 2,
+    ACTIONS(865), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10666] = 2,
+    ACTIONS(867), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10674] = 2,
+    ACTIONS(869), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10682] = 2,
+    ACTIONS(871), 1,
+      sym_identifier,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10690] = 2,
+    ACTIONS(873), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10698] = 2,
+    ACTIONS(875), 1,
+      anon_sym_LPAREN,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10706] = 2,
+    ACTIONS(877), 1,
+      anon_sym_GT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10714] = 2,
+    ACTIONS(879), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10722] = 2,
+    ACTIONS(881), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10730] = 2,
+    ACTIONS(680), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10738] = 2,
+    ACTIONS(883), 1,
+      anon_sym_LT,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10746] = 2,
+    ACTIONS(885), 1,
+      anon_sym_type,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10754] = 2,
+    ACTIONS(887), 1,
+      ts_builtin_sym_end,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10762] = 2,
+    ACTIONS(889), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10770] = 2,
     ACTIONS(891), 1,
       anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11042] = 2,
+  [10778] = 2,
     ACTIONS(893), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11050] = 2,
+  [10786] = 2,
     ACTIONS(895), 1,
-      anon_sym_GT,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11058] = 2,
+  [10794] = 2,
     ACTIONS(897), 1,
-      anon_sym_edgedb,
+      sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11066] = 2,
+  [10802] = 2,
+    ACTIONS(664), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10810] = 2,
+    ACTIONS(676), 1,
+      anon_sym_SEMI,
+    ACTIONS(9), 2,
+      sym_comment,
+      sym__whitespace,
+  [10818] = 2,
     ACTIONS(899), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11074] = 2,
-    ACTIONS(801), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11082] = 2,
+  [10826] = 2,
     ACTIONS(901), 1,
-      anon_sym_LPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11090] = 2,
-    ACTIONS(823), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11098] = 2,
-    ACTIONS(903), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11106] = 2,
-    ACTIONS(905), 1,
-      anon_sym_LPAREN,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11114] = 2,
-    ACTIONS(907), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11122] = 2,
-    ACTIONS(909), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11130] = 2,
-    ACTIONS(678), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11138] = 2,
-    ACTIONS(911), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11146] = 2,
-    ACTIONS(913), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11154] = 2,
-    ACTIONS(915), 1,
-      anon_sym_using,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11162] = 2,
-    ACTIONS(917), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11170] = 2,
-    ACTIONS(919), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11178] = 2,
-    ACTIONS(716), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11186] = 2,
-    ACTIONS(809), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11194] = 2,
-    ACTIONS(921), 1,
-      anon_sym_LT,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11202] = 2,
-    ACTIONS(923), 1,
-      anon_sym_LT,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11210] = 2,
-    ACTIONS(925), 1,
-      anon_sym_LT,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11218] = 2,
-    ACTIONS(927), 1,
-      anon_sym_enum,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11226] = 2,
-    ACTIONS(929), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11234] = 2,
-    ACTIONS(931), 1,
-      anon_sym_SEMI,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11242] = 2,
-    ACTIONS(933), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11250] = 2,
-    ACTIONS(935), 1,
       anon_sym_RPAREN,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11258] = 2,
-    ACTIONS(937), 1,
-      anon_sym_DASH_GT,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11266] = 2,
-    ACTIONS(939), 1,
-      ts_builtin_sym_end,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11274] = 2,
-    ACTIONS(941), 1,
+  [10834] = 2,
+    ACTIONS(903), 1,
       sym_identifier,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
-  [11282] = 2,
-    ACTIONS(943), 1,
-      sym_identifier,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11290] = 2,
-    ACTIONS(945), 1,
-      anon_sym_type,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11298] = 2,
-    ACTIONS(947), 1,
-      anon_sym_COLON_EQ,
-    ACTIONS(9), 2,
-      sym_comment,
-      sym__whitespace,
-  [11306] = 2,
-    ACTIONS(787), 1,
-      anon_sym_LPAREN,
+  [10842] = 2,
+    ACTIONS(765), 1,
+      anon_sym_SEMI,
     ACTIONS(9), 2,
       sym_comment,
       sym__whitespace,
@@ -14963,22 +14781,22 @@ static const uint16_t ts_small_parse_table[] = {
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
   [SMALL_STATE(3)] = 50,
-  [SMALL_STATE(4)] = 97,
-  [SMALL_STATE(5)] = 144,
-  [SMALL_STATE(6)] = 207,
-  [SMALL_STATE(7)] = 272,
-  [SMALL_STATE(8)] = 319,
-  [SMALL_STATE(9)] = 370,
-  [SMALL_STATE(10)] = 429,
-  [SMALL_STATE(11)] = 476,
-  [SMALL_STATE(12)] = 537,
-  [SMALL_STATE(13)] = 584,
-  [SMALL_STATE(14)] = 647,
-  [SMALL_STATE(15)] = 696,
-  [SMALL_STATE(16)] = 743,
-  [SMALL_STATE(17)] = 796,
-  [SMALL_STATE(18)] = 843,
-  [SMALL_STATE(19)] = 900,
+  [SMALL_STATE(4)] = 109,
+  [SMALL_STATE(5)] = 156,
+  [SMALL_STATE(6)] = 203,
+  [SMALL_STATE(7)] = 256,
+  [SMALL_STATE(8)] = 313,
+  [SMALL_STATE(9)] = 360,
+  [SMALL_STATE(10)] = 407,
+  [SMALL_STATE(11)] = 456,
+  [SMALL_STATE(12)] = 503,
+  [SMALL_STATE(13)] = 550,
+  [SMALL_STATE(14)] = 613,
+  [SMALL_STATE(15)] = 676,
+  [SMALL_STATE(16)] = 737,
+  [SMALL_STATE(17)] = 784,
+  [SMALL_STATE(18)] = 831,
+  [SMALL_STATE(19)] = 896,
   [SMALL_STATE(20)] = 947,
   [SMALL_STATE(21)] = 994,
   [SMALL_STATE(22)] = 1061,
@@ -14992,399 +14810,375 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(30)] = 1597,
   [SMALL_STATE(31)] = 1664,
   [SMALL_STATE(32)] = 1721,
-  [SMALL_STATE(33)] = 1778,
-  [SMALL_STATE(34)] = 1830,
-  [SMALL_STATE(35)] = 1882,
-  [SMALL_STATE(36)] = 1930,
-  [SMALL_STATE(37)] = 1978,
-  [SMALL_STATE(38)] = 2028,
-  [SMALL_STATE(39)] = 2076,
-  [SMALL_STATE(40)] = 2124,
-  [SMALL_STATE(41)] = 2172,
-  [SMALL_STATE(42)] = 2220,
-  [SMALL_STATE(43)] = 2268,
-  [SMALL_STATE(44)] = 2316,
-  [SMALL_STATE(45)] = 2364,
-  [SMALL_STATE(46)] = 2412,
-  [SMALL_STATE(47)] = 2460,
-  [SMALL_STATE(48)] = 2508,
-  [SMALL_STATE(49)] = 2556,
-  [SMALL_STATE(50)] = 2614,
-  [SMALL_STATE(51)] = 2672,
-  [SMALL_STATE(52)] = 2730,
-  [SMALL_STATE(53)] = 2775,
-  [SMALL_STATE(54)] = 2820,
-  [SMALL_STATE(55)] = 2851,
-  [SMALL_STATE(56)] = 2882,
-  [SMALL_STATE(57)] = 2913,
-  [SMALL_STATE(58)] = 2944,
-  [SMALL_STATE(59)] = 2975,
-  [SMALL_STATE(60)] = 3006,
-  [SMALL_STATE(61)] = 3037,
-  [SMALL_STATE(62)] = 3082,
-  [SMALL_STATE(63)] = 3127,
-  [SMALL_STATE(64)] = 3161,
-  [SMALL_STATE(65)] = 3195,
-  [SMALL_STATE(66)] = 3229,
-  [SMALL_STATE(67)] = 3268,
-  [SMALL_STATE(68)] = 3303,
-  [SMALL_STATE(69)] = 3332,
-  [SMALL_STATE(70)] = 3367,
-  [SMALL_STATE(71)] = 3396,
-  [SMALL_STATE(72)] = 3425,
-  [SMALL_STATE(73)] = 3464,
-  [SMALL_STATE(74)] = 3510,
-  [SMALL_STATE(75)] = 3546,
-  [SMALL_STATE(76)] = 3600,
-  [SMALL_STATE(77)] = 3636,
-  [SMALL_STATE(78)] = 3672,
-  [SMALL_STATE(79)] = 3726,
-  [SMALL_STATE(80)] = 3772,
-  [SMALL_STATE(81)] = 3818,
-  [SMALL_STATE(82)] = 3850,
-  [SMALL_STATE(83)] = 3882,
-  [SMALL_STATE(84)] = 3918,
-  [SMALL_STATE(85)] = 3967,
-  [SMALL_STATE(86)] = 4002,
-  [SMALL_STATE(87)] = 4037,
-  [SMALL_STATE(88)] = 4086,
-  [SMALL_STATE(89)] = 4134,
-  [SMALL_STATE(90)] = 4182,
-  [SMALL_STATE(91)] = 4212,
-  [SMALL_STATE(92)] = 4260,
-  [SMALL_STATE(93)] = 4290,
-  [SMALL_STATE(94)] = 4338,
-  [SMALL_STATE(95)] = 4386,
-  [SMALL_STATE(96)] = 4434,
-  [SMALL_STATE(97)] = 4482,
-  [SMALL_STATE(98)] = 4530,
-  [SMALL_STATE(99)] = 4578,
-  [SMALL_STATE(100)] = 4626,
-  [SMALL_STATE(101)] = 4674,
-  [SMALL_STATE(102)] = 4701,
-  [SMALL_STATE(103)] = 4738,
-  [SMALL_STATE(104)] = 4775,
-  [SMALL_STATE(105)] = 4812,
-  [SMALL_STATE(106)] = 4849,
-  [SMALL_STATE(107)] = 4876,
-  [SMALL_STATE(108)] = 4903,
-  [SMALL_STATE(109)] = 4930,
-  [SMALL_STATE(110)] = 4955,
-  [SMALL_STATE(111)] = 4984,
-  [SMALL_STATE(112)] = 5021,
-  [SMALL_STATE(113)] = 5058,
-  [SMALL_STATE(114)] = 5083,
-  [SMALL_STATE(115)] = 5110,
-  [SMALL_STATE(116)] = 5137,
-  [SMALL_STATE(117)] = 5162,
-  [SMALL_STATE(118)] = 5199,
-  [SMALL_STATE(119)] = 5236,
-  [SMALL_STATE(120)] = 5261,
-  [SMALL_STATE(121)] = 5288,
-  [SMALL_STATE(122)] = 5315,
-  [SMALL_STATE(123)] = 5352,
-  [SMALL_STATE(124)] = 5379,
-  [SMALL_STATE(125)] = 5404,
-  [SMALL_STATE(126)] = 5431,
-  [SMALL_STATE(127)] = 5468,
-  [SMALL_STATE(128)] = 5505,
-  [SMALL_STATE(129)] = 5530,
-  [SMALL_STATE(130)] = 5557,
-  [SMALL_STATE(131)] = 5586,
-  [SMALL_STATE(132)] = 5613,
-  [SMALL_STATE(133)] = 5638,
-  [SMALL_STATE(134)] = 5665,
-  [SMALL_STATE(135)] = 5690,
-  [SMALL_STATE(136)] = 5717,
-  [SMALL_STATE(137)] = 5753,
-  [SMALL_STATE(138)] = 5777,
-  [SMALL_STATE(139)] = 5801,
-  [SMALL_STATE(140)] = 5825,
-  [SMALL_STATE(141)] = 5849,
-  [SMALL_STATE(142)] = 5873,
-  [SMALL_STATE(143)] = 5897,
-  [SMALL_STATE(144)] = 5933,
-  [SMALL_STATE(145)] = 5957,
-  [SMALL_STATE(146)] = 5993,
-  [SMALL_STATE(147)] = 6017,
-  [SMALL_STATE(148)] = 6041,
-  [SMALL_STATE(149)] = 6065,
-  [SMALL_STATE(150)] = 6089,
-  [SMALL_STATE(151)] = 6125,
-  [SMALL_STATE(152)] = 6161,
-  [SMALL_STATE(153)] = 6197,
-  [SMALL_STATE(154)] = 6221,
-  [SMALL_STATE(155)] = 6257,
-  [SMALL_STATE(156)] = 6281,
-  [SMALL_STATE(157)] = 6305,
-  [SMALL_STATE(158)] = 6329,
-  [SMALL_STATE(159)] = 6365,
-  [SMALL_STATE(160)] = 6389,
-  [SMALL_STATE(161)] = 6413,
-  [SMALL_STATE(162)] = 6437,
-  [SMALL_STATE(163)] = 6461,
-  [SMALL_STATE(164)] = 6485,
-  [SMALL_STATE(165)] = 6521,
-  [SMALL_STATE(166)] = 6557,
-  [SMALL_STATE(167)] = 6581,
-  [SMALL_STATE(168)] = 6617,
-  [SMALL_STATE(169)] = 6641,
-  [SMALL_STATE(170)] = 6677,
-  [SMALL_STATE(171)] = 6713,
-  [SMALL_STATE(172)] = 6737,
-  [SMALL_STATE(173)] = 6761,
-  [SMALL_STATE(174)] = 6797,
-  [SMALL_STATE(175)] = 6821,
-  [SMALL_STATE(176)] = 6845,
-  [SMALL_STATE(177)] = 6869,
-  [SMALL_STATE(178)] = 6893,
-  [SMALL_STATE(179)] = 6929,
-  [SMALL_STATE(180)] = 6953,
-  [SMALL_STATE(181)] = 6977,
-  [SMALL_STATE(182)] = 7001,
-  [SMALL_STATE(183)] = 7025,
-  [SMALL_STATE(184)] = 7061,
-  [SMALL_STATE(185)] = 7085,
-  [SMALL_STATE(186)] = 7109,
-  [SMALL_STATE(187)] = 7145,
-  [SMALL_STATE(188)] = 7181,
-  [SMALL_STATE(189)] = 7217,
-  [SMALL_STATE(190)] = 7241,
-  [SMALL_STATE(191)] = 7277,
-  [SMALL_STATE(192)] = 7313,
-  [SMALL_STATE(193)] = 7337,
-  [SMALL_STATE(194)] = 7360,
-  [SMALL_STATE(195)] = 7383,
-  [SMALL_STATE(196)] = 7406,
-  [SMALL_STATE(197)] = 7429,
-  [SMALL_STATE(198)] = 7452,
-  [SMALL_STATE(199)] = 7475,
-  [SMALL_STATE(200)] = 7498,
-  [SMALL_STATE(201)] = 7521,
-  [SMALL_STATE(202)] = 7544,
-  [SMALL_STATE(203)] = 7567,
-  [SMALL_STATE(204)] = 7590,
-  [SMALL_STATE(205)] = 7613,
-  [SMALL_STATE(206)] = 7636,
-  [SMALL_STATE(207)] = 7659,
-  [SMALL_STATE(208)] = 7682,
-  [SMALL_STATE(209)] = 7705,
-  [SMALL_STATE(210)] = 7728,
-  [SMALL_STATE(211)] = 7751,
-  [SMALL_STATE(212)] = 7774,
-  [SMALL_STATE(213)] = 7805,
-  [SMALL_STATE(214)] = 7836,
-  [SMALL_STATE(215)] = 7867,
-  [SMALL_STATE(216)] = 7896,
-  [SMALL_STATE(217)] = 7927,
-  [SMALL_STATE(218)] = 7947,
-  [SMALL_STATE(219)] = 7975,
-  [SMALL_STATE(220)] = 8003,
-  [SMALL_STATE(221)] = 8023,
-  [SMALL_STATE(222)] = 8051,
-  [SMALL_STATE(223)] = 8071,
-  [SMALL_STATE(224)] = 8091,
-  [SMALL_STATE(225)] = 8119,
-  [SMALL_STATE(226)] = 8143,
-  [SMALL_STATE(227)] = 8171,
-  [SMALL_STATE(228)] = 8199,
-  [SMALL_STATE(229)] = 8227,
-  [SMALL_STATE(230)] = 8247,
-  [SMALL_STATE(231)] = 8275,
-  [SMALL_STATE(232)] = 8295,
-  [SMALL_STATE(233)] = 8317,
-  [SMALL_STATE(234)] = 8341,
-  [SMALL_STATE(235)] = 8371,
-  [SMALL_STATE(236)] = 8398,
-  [SMALL_STATE(237)] = 8431,
-  [SMALL_STATE(238)] = 8451,
-  [SMALL_STATE(239)] = 8481,
-  [SMALL_STATE(240)] = 8511,
-  [SMALL_STATE(241)] = 8541,
-  [SMALL_STATE(242)] = 8571,
+  [SMALL_STATE(33)] = 1773,
+  [SMALL_STATE(34)] = 1825,
+  [SMALL_STATE(35)] = 1873,
+  [SMALL_STATE(36)] = 1921,
+  [SMALL_STATE(37)] = 1969,
+  [SMALL_STATE(38)] = 2017,
+  [SMALL_STATE(39)] = 2065,
+  [SMALL_STATE(40)] = 2115,
+  [SMALL_STATE(41)] = 2163,
+  [SMALL_STATE(42)] = 2211,
+  [SMALL_STATE(43)] = 2259,
+  [SMALL_STATE(44)] = 2307,
+  [SMALL_STATE(45)] = 2355,
+  [SMALL_STATE(46)] = 2403,
+  [SMALL_STATE(47)] = 2451,
+  [SMALL_STATE(48)] = 2499,
+  [SMALL_STATE(49)] = 2557,
+  [SMALL_STATE(50)] = 2615,
+  [SMALL_STATE(51)] = 2673,
+  [SMALL_STATE(52)] = 2704,
+  [SMALL_STATE(53)] = 2735,
+  [SMALL_STATE(54)] = 2766,
+  [SMALL_STATE(55)] = 2811,
+  [SMALL_STATE(56)] = 2856,
+  [SMALL_STATE(57)] = 2887,
+  [SMALL_STATE(58)] = 2932,
+  [SMALL_STATE(59)] = 2977,
+  [SMALL_STATE(60)] = 3008,
+  [SMALL_STATE(61)] = 3039,
+  [SMALL_STATE(62)] = 3070,
+  [SMALL_STATE(63)] = 3104,
+  [SMALL_STATE(64)] = 3138,
+  [SMALL_STATE(65)] = 3172,
+  [SMALL_STATE(66)] = 3201,
+  [SMALL_STATE(67)] = 3230,
+  [SMALL_STATE(68)] = 3265,
+  [SMALL_STATE(69)] = 3294,
+  [SMALL_STATE(70)] = 3329,
+  [SMALL_STATE(71)] = 3368,
+  [SMALL_STATE(72)] = 3407,
+  [SMALL_STATE(73)] = 3443,
+  [SMALL_STATE(74)] = 3497,
+  [SMALL_STATE(75)] = 3533,
+  [SMALL_STATE(76)] = 3569,
+  [SMALL_STATE(77)] = 3623,
+  [SMALL_STATE(78)] = 3655,
+  [SMALL_STATE(79)] = 3687,
+  [SMALL_STATE(80)] = 3733,
+  [SMALL_STATE(81)] = 3779,
+  [SMALL_STATE(82)] = 3815,
+  [SMALL_STATE(83)] = 3861,
+  [SMALL_STATE(84)] = 3896,
+  [SMALL_STATE(85)] = 3931,
+  [SMALL_STATE(86)] = 3980,
+  [SMALL_STATE(87)] = 4029,
+  [SMALL_STATE(88)] = 4059,
+  [SMALL_STATE(89)] = 4107,
+  [SMALL_STATE(90)] = 4137,
+  [SMALL_STATE(91)] = 4185,
+  [SMALL_STATE(92)] = 4233,
+  [SMALL_STATE(93)] = 4281,
+  [SMALL_STATE(94)] = 4329,
+  [SMALL_STATE(95)] = 4361,
+  [SMALL_STATE(96)] = 4409,
+  [SMALL_STATE(97)] = 4457,
+  [SMALL_STATE(98)] = 4505,
+  [SMALL_STATE(99)] = 4553,
+  [SMALL_STATE(100)] = 4601,
+  [SMALL_STATE(101)] = 4626,
+  [SMALL_STATE(102)] = 4653,
+  [SMALL_STATE(103)] = 4680,
+  [SMALL_STATE(104)] = 4705,
+  [SMALL_STATE(105)] = 4730,
+  [SMALL_STATE(106)] = 4755,
+  [SMALL_STATE(107)] = 4780,
+  [SMALL_STATE(108)] = 4807,
+  [SMALL_STATE(109)] = 4834,
+  [SMALL_STATE(110)] = 4861,
+  [SMALL_STATE(111)] = 4886,
+  [SMALL_STATE(112)] = 4911,
+  [SMALL_STATE(113)] = 4936,
+  [SMALL_STATE(114)] = 4963,
+  [SMALL_STATE(115)] = 4988,
+  [SMALL_STATE(116)] = 5017,
+  [SMALL_STATE(117)] = 5044,
+  [SMALL_STATE(118)] = 5071,
+  [SMALL_STATE(119)] = 5098,
+  [SMALL_STATE(120)] = 5127,
+  [SMALL_STATE(121)] = 5154,
+  [SMALL_STATE(122)] = 5181,
+  [SMALL_STATE(123)] = 5208,
+  [SMALL_STATE(124)] = 5233,
+  [SMALL_STATE(125)] = 5260,
+  [SMALL_STATE(126)] = 5287,
+  [SMALL_STATE(127)] = 5323,
+  [SMALL_STATE(128)] = 5359,
+  [SMALL_STATE(129)] = 5383,
+  [SMALL_STATE(130)] = 5419,
+  [SMALL_STATE(131)] = 5443,
+  [SMALL_STATE(132)] = 5467,
+  [SMALL_STATE(133)] = 5503,
+  [SMALL_STATE(134)] = 5527,
+  [SMALL_STATE(135)] = 5551,
+  [SMALL_STATE(136)] = 5575,
+  [SMALL_STATE(137)] = 5599,
+  [SMALL_STATE(138)] = 5623,
+  [SMALL_STATE(139)] = 5647,
+  [SMALL_STATE(140)] = 5671,
+  [SMALL_STATE(141)] = 5707,
+  [SMALL_STATE(142)] = 5743,
+  [SMALL_STATE(143)] = 5779,
+  [SMALL_STATE(144)] = 5803,
+  [SMALL_STATE(145)] = 5839,
+  [SMALL_STATE(146)] = 5875,
+  [SMALL_STATE(147)] = 5899,
+  [SMALL_STATE(148)] = 5923,
+  [SMALL_STATE(149)] = 5947,
+  [SMALL_STATE(150)] = 5971,
+  [SMALL_STATE(151)] = 5995,
+  [SMALL_STATE(152)] = 6031,
+  [SMALL_STATE(153)] = 6055,
+  [SMALL_STATE(154)] = 6079,
+  [SMALL_STATE(155)] = 6115,
+  [SMALL_STATE(156)] = 6139,
+  [SMALL_STATE(157)] = 6163,
+  [SMALL_STATE(158)] = 6199,
+  [SMALL_STATE(159)] = 6223,
+  [SMALL_STATE(160)] = 6247,
+  [SMALL_STATE(161)] = 6283,
+  [SMALL_STATE(162)] = 6319,
+  [SMALL_STATE(163)] = 6355,
+  [SMALL_STATE(164)] = 6379,
+  [SMALL_STATE(165)] = 6415,
+  [SMALL_STATE(166)] = 6451,
+  [SMALL_STATE(167)] = 6475,
+  [SMALL_STATE(168)] = 6499,
+  [SMALL_STATE(169)] = 6523,
+  [SMALL_STATE(170)] = 6559,
+  [SMALL_STATE(171)] = 6595,
+  [SMALL_STATE(172)] = 6631,
+  [SMALL_STATE(173)] = 6667,
+  [SMALL_STATE(174)] = 6691,
+  [SMALL_STATE(175)] = 6715,
+  [SMALL_STATE(176)] = 6751,
+  [SMALL_STATE(177)] = 6787,
+  [SMALL_STATE(178)] = 6811,
+  [SMALL_STATE(179)] = 6835,
+  [SMALL_STATE(180)] = 6859,
+  [SMALL_STATE(181)] = 6883,
+  [SMALL_STATE(182)] = 6919,
+  [SMALL_STATE(183)] = 6943,
+  [SMALL_STATE(184)] = 6967,
+  [SMALL_STATE(185)] = 6991,
+  [SMALL_STATE(186)] = 7015,
+  [SMALL_STATE(187)] = 7038,
+  [SMALL_STATE(188)] = 7061,
+  [SMALL_STATE(189)] = 7084,
+  [SMALL_STATE(190)] = 7107,
+  [SMALL_STATE(191)] = 7130,
+  [SMALL_STATE(192)] = 7153,
+  [SMALL_STATE(193)] = 7176,
+  [SMALL_STATE(194)] = 7199,
+  [SMALL_STATE(195)] = 7222,
+  [SMALL_STATE(196)] = 7245,
+  [SMALL_STATE(197)] = 7268,
+  [SMALL_STATE(198)] = 7291,
+  [SMALL_STATE(199)] = 7314,
+  [SMALL_STATE(200)] = 7337,
+  [SMALL_STATE(201)] = 7360,
+  [SMALL_STATE(202)] = 7391,
+  [SMALL_STATE(203)] = 7422,
+  [SMALL_STATE(204)] = 7453,
+  [SMALL_STATE(205)] = 7484,
+  [SMALL_STATE(206)] = 7513,
+  [SMALL_STATE(207)] = 7543,
+  [SMALL_STATE(208)] = 7563,
+  [SMALL_STATE(209)] = 7591,
+  [SMALL_STATE(210)] = 7615,
+  [SMALL_STATE(211)] = 7643,
+  [SMALL_STATE(212)] = 7663,
+  [SMALL_STATE(213)] = 7683,
+  [SMALL_STATE(214)] = 7711,
+  [SMALL_STATE(215)] = 7731,
+  [SMALL_STATE(216)] = 7759,
+  [SMALL_STATE(217)] = 7779,
+  [SMALL_STATE(218)] = 7807,
+  [SMALL_STATE(219)] = 7843,
+  [SMALL_STATE(220)] = 7871,
+  [SMALL_STATE(221)] = 7895,
+  [SMALL_STATE(222)] = 7923,
+  [SMALL_STATE(223)] = 7951,
+  [SMALL_STATE(224)] = 7971,
+  [SMALL_STATE(225)] = 8007,
+  [SMALL_STATE(226)] = 8040,
+  [SMALL_STATE(227)] = 8073,
+  [SMALL_STATE(228)] = 8106,
+  [SMALL_STATE(229)] = 8139,
+  [SMALL_STATE(230)] = 8172,
+  [SMALL_STATE(231)] = 8205,
+  [SMALL_STATE(232)] = 8238,
+  [SMALL_STATE(233)] = 8271,
+  [SMALL_STATE(234)] = 8304,
+  [SMALL_STATE(235)] = 8337,
+  [SMALL_STATE(236)] = 8370,
+  [SMALL_STATE(237)] = 8403,
+  [SMALL_STATE(238)] = 8436,
+  [SMALL_STATE(239)] = 8469,
+  [SMALL_STATE(240)] = 8502,
+  [SMALL_STATE(241)] = 8535,
+  [SMALL_STATE(242)] = 8568,
   [SMALL_STATE(243)] = 8601,
-  [SMALL_STATE(244)] = 8631,
-  [SMALL_STATE(245)] = 8661,
-  [SMALL_STATE(246)] = 8691,
-  [SMALL_STATE(247)] = 8721,
-  [SMALL_STATE(248)] = 8751,
-  [SMALL_STATE(249)] = 8781,
-  [SMALL_STATE(250)] = 8811,
-  [SMALL_STATE(251)] = 8841,
-  [SMALL_STATE(252)] = 8861,
-  [SMALL_STATE(253)] = 8881,
-  [SMALL_STATE(254)] = 8911,
-  [SMALL_STATE(255)] = 8941,
-  [SMALL_STATE(256)] = 8961,
-  [SMALL_STATE(257)] = 8991,
-  [SMALL_STATE(258)] = 9021,
-  [SMALL_STATE(259)] = 9051,
-  [SMALL_STATE(260)] = 9081,
-  [SMALL_STATE(261)] = 9101,
-  [SMALL_STATE(262)] = 9121,
-  [SMALL_STATE(263)] = 9151,
-  [SMALL_STATE(264)] = 9171,
-  [SMALL_STATE(265)] = 9201,
-  [SMALL_STATE(266)] = 9231,
-  [SMALL_STATE(267)] = 9251,
-  [SMALL_STATE(268)] = 9281,
-  [SMALL_STATE(269)] = 9311,
-  [SMALL_STATE(270)] = 9341,
-  [SMALL_STATE(271)] = 9371,
-  [SMALL_STATE(272)] = 9401,
+  [SMALL_STATE(244)] = 8634,
+  [SMALL_STATE(245)] = 8667,
+  [SMALL_STATE(246)] = 8700,
+  [SMALL_STATE(247)] = 8727,
+  [SMALL_STATE(248)] = 8760,
+  [SMALL_STATE(249)] = 8793,
+  [SMALL_STATE(250)] = 8826,
+  [SMALL_STATE(251)] = 8859,
+  [SMALL_STATE(252)] = 8892,
+  [SMALL_STATE(253)] = 8925,
+  [SMALL_STATE(254)] = 8958,
+  [SMALL_STATE(255)] = 8991,
+  [SMALL_STATE(256)] = 9024,
+  [SMALL_STATE(257)] = 9057,
+  [SMALL_STATE(258)] = 9090,
+  [SMALL_STATE(259)] = 9110,
+  [SMALL_STATE(260)] = 9130,
+  [SMALL_STATE(261)] = 9150,
+  [SMALL_STATE(262)] = 9170,
+  [SMALL_STATE(263)] = 9190,
+  [SMALL_STATE(264)] = 9210,
+  [SMALL_STATE(265)] = 9230,
+  [SMALL_STATE(266)] = 9250,
+  [SMALL_STATE(267)] = 9270,
+  [SMALL_STATE(268)] = 9290,
+  [SMALL_STATE(269)] = 9325,
+  [SMALL_STATE(270)] = 9360,
+  [SMALL_STATE(271)] = 9381,
+  [SMALL_STATE(272)] = 9402,
   [SMALL_STATE(273)] = 9431,
-  [SMALL_STATE(274)] = 9461,
-  [SMALL_STATE(275)] = 9491,
-  [SMALL_STATE(276)] = 9521,
-  [SMALL_STATE(277)] = 9551,
-  [SMALL_STATE(278)] = 9571,
-  [SMALL_STATE(279)] = 9601,
-  [SMALL_STATE(280)] = 9631,
-  [SMALL_STATE(281)] = 9652,
-  [SMALL_STATE(282)] = 9687,
-  [SMALL_STATE(283)] = 9708,
-  [SMALL_STATE(284)] = 9743,
-  [SMALL_STATE(285)] = 9772,
-  [SMALL_STATE(286)] = 9801,
-  [SMALL_STATE(287)] = 9824,
-  [SMALL_STATE(288)] = 9837,
-  [SMALL_STATE(289)] = 9860,
-  [SMALL_STATE(290)] = 9873,
-  [SMALL_STATE(291)] = 9896,
-  [SMALL_STATE(292)] = 9909,
-  [SMALL_STATE(293)] = 9922,
-  [SMALL_STATE(294)] = 9945,
-  [SMALL_STATE(295)] = 9962,
-  [SMALL_STATE(296)] = 9979,
-  [SMALL_STATE(297)] = 9996,
-  [SMALL_STATE(298)] = 10013,
-  [SMALL_STATE(299)] = 10028,
-  [SMALL_STATE(300)] = 10043,
-  [SMALL_STATE(301)] = 10058,
-  [SMALL_STATE(302)] = 10075,
-  [SMALL_STATE(303)] = 10090,
-  [SMALL_STATE(304)] = 10107,
-  [SMALL_STATE(305)] = 10124,
-  [SMALL_STATE(306)] = 10135,
-  [SMALL_STATE(307)] = 10150,
-  [SMALL_STATE(308)] = 10167,
-  [SMALL_STATE(309)] = 10184,
-  [SMALL_STATE(310)] = 10201,
-  [SMALL_STATE(311)] = 10218,
-  [SMALL_STATE(312)] = 10232,
-  [SMALL_STATE(313)] = 10242,
-  [SMALL_STATE(314)] = 10256,
-  [SMALL_STATE(315)] = 10270,
-  [SMALL_STATE(316)] = 10280,
-  [SMALL_STATE(317)] = 10294,
-  [SMALL_STATE(318)] = 10308,
-  [SMALL_STATE(319)] = 10322,
-  [SMALL_STATE(320)] = 10336,
-  [SMALL_STATE(321)] = 10350,
-  [SMALL_STATE(322)] = 10364,
-  [SMALL_STATE(323)] = 10378,
-  [SMALL_STATE(324)] = 10392,
-  [SMALL_STATE(325)] = 10402,
-  [SMALL_STATE(326)] = 10416,
-  [SMALL_STATE(327)] = 10430,
-  [SMALL_STATE(328)] = 10444,
-  [SMALL_STATE(329)] = 10456,
-  [SMALL_STATE(330)] = 10470,
-  [SMALL_STATE(331)] = 10484,
-  [SMALL_STATE(332)] = 10495,
-  [SMALL_STATE(333)] = 10504,
-  [SMALL_STATE(334)] = 10515,
-  [SMALL_STATE(335)] = 10526,
-  [SMALL_STATE(336)] = 10537,
-  [SMALL_STATE(337)] = 10548,
-  [SMALL_STATE(338)] = 10559,
-  [SMALL_STATE(339)] = 10570,
-  [SMALL_STATE(340)] = 10581,
-  [SMALL_STATE(341)] = 10590,
-  [SMALL_STATE(342)] = 10601,
-  [SMALL_STATE(343)] = 10610,
-  [SMALL_STATE(344)] = 10621,
-  [SMALL_STATE(345)] = 10632,
-  [SMALL_STATE(346)] = 10643,
-  [SMALL_STATE(347)] = 10654,
-  [SMALL_STATE(348)] = 10665,
-  [SMALL_STATE(349)] = 10674,
-  [SMALL_STATE(350)] = 10685,
-  [SMALL_STATE(351)] = 10694,
-  [SMALL_STATE(352)] = 10705,
-  [SMALL_STATE(353)] = 10716,
-  [SMALL_STATE(354)] = 10727,
-  [SMALL_STATE(355)] = 10738,
-  [SMALL_STATE(356)] = 10749,
-  [SMALL_STATE(357)] = 10758,
-  [SMALL_STATE(358)] = 10769,
-  [SMALL_STATE(359)] = 10778,
-  [SMALL_STATE(360)] = 10786,
-  [SMALL_STATE(361)] = 10794,
-  [SMALL_STATE(362)] = 10802,
-  [SMALL_STATE(363)] = 10810,
-  [SMALL_STATE(364)] = 10818,
-  [SMALL_STATE(365)] = 10826,
-  [SMALL_STATE(366)] = 10834,
-  [SMALL_STATE(367)] = 10842,
-  [SMALL_STATE(368)] = 10850,
-  [SMALL_STATE(369)] = 10858,
-  [SMALL_STATE(370)] = 10866,
-  [SMALL_STATE(371)] = 10874,
-  [SMALL_STATE(372)] = 10882,
-  [SMALL_STATE(373)] = 10890,
-  [SMALL_STATE(374)] = 10898,
-  [SMALL_STATE(375)] = 10906,
-  [SMALL_STATE(376)] = 10914,
-  [SMALL_STATE(377)] = 10922,
-  [SMALL_STATE(378)] = 10930,
-  [SMALL_STATE(379)] = 10938,
-  [SMALL_STATE(380)] = 10946,
-  [SMALL_STATE(381)] = 10954,
-  [SMALL_STATE(382)] = 10962,
-  [SMALL_STATE(383)] = 10970,
-  [SMALL_STATE(384)] = 10978,
-  [SMALL_STATE(385)] = 10986,
-  [SMALL_STATE(386)] = 10994,
-  [SMALL_STATE(387)] = 11002,
-  [SMALL_STATE(388)] = 11010,
-  [SMALL_STATE(389)] = 11018,
-  [SMALL_STATE(390)] = 11026,
-  [SMALL_STATE(391)] = 11034,
-  [SMALL_STATE(392)] = 11042,
-  [SMALL_STATE(393)] = 11050,
-  [SMALL_STATE(394)] = 11058,
-  [SMALL_STATE(395)] = 11066,
-  [SMALL_STATE(396)] = 11074,
-  [SMALL_STATE(397)] = 11082,
-  [SMALL_STATE(398)] = 11090,
-  [SMALL_STATE(399)] = 11098,
-  [SMALL_STATE(400)] = 11106,
-  [SMALL_STATE(401)] = 11114,
-  [SMALL_STATE(402)] = 11122,
-  [SMALL_STATE(403)] = 11130,
-  [SMALL_STATE(404)] = 11138,
-  [SMALL_STATE(405)] = 11146,
-  [SMALL_STATE(406)] = 11154,
-  [SMALL_STATE(407)] = 11162,
-  [SMALL_STATE(408)] = 11170,
-  [SMALL_STATE(409)] = 11178,
-  [SMALL_STATE(410)] = 11186,
-  [SMALL_STATE(411)] = 11194,
-  [SMALL_STATE(412)] = 11202,
-  [SMALL_STATE(413)] = 11210,
-  [SMALL_STATE(414)] = 11218,
-  [SMALL_STATE(415)] = 11226,
-  [SMALL_STATE(416)] = 11234,
-  [SMALL_STATE(417)] = 11242,
-  [SMALL_STATE(418)] = 11250,
-  [SMALL_STATE(419)] = 11258,
-  [SMALL_STATE(420)] = 11266,
-  [SMALL_STATE(421)] = 11274,
-  [SMALL_STATE(422)] = 11282,
-  [SMALL_STATE(423)] = 11290,
-  [SMALL_STATE(424)] = 11298,
-  [SMALL_STATE(425)] = 11306,
+  [SMALL_STATE(274)] = 9460,
+  [SMALL_STATE(275)] = 9473,
+  [SMALL_STATE(276)] = 9486,
+  [SMALL_STATE(277)] = 9499,
+  [SMALL_STATE(278)] = 9522,
+  [SMALL_STATE(279)] = 9545,
+  [SMALL_STATE(280)] = 9558,
+  [SMALL_STATE(281)] = 9571,
+  [SMALL_STATE(282)] = 9594,
+  [SMALL_STATE(283)] = 9617,
+  [SMALL_STATE(284)] = 9634,
+  [SMALL_STATE(285)] = 9651,
+  [SMALL_STATE(286)] = 9668,
+  [SMALL_STATE(287)] = 9685,
+  [SMALL_STATE(288)] = 9696,
+  [SMALL_STATE(289)] = 9711,
+  [SMALL_STATE(290)] = 9728,
+  [SMALL_STATE(291)] = 9745,
+  [SMALL_STATE(292)] = 9760,
+  [SMALL_STATE(293)] = 9775,
+  [SMALL_STATE(294)] = 9792,
+  [SMALL_STATE(295)] = 9809,
+  [SMALL_STATE(296)] = 9824,
+  [SMALL_STATE(297)] = 9841,
+  [SMALL_STATE(298)] = 9856,
+  [SMALL_STATE(299)] = 9870,
+  [SMALL_STATE(300)] = 9884,
+  [SMALL_STATE(301)] = 9896,
+  [SMALL_STATE(302)] = 9910,
+  [SMALL_STATE(303)] = 9924,
+  [SMALL_STATE(304)] = 9938,
+  [SMALL_STATE(305)] = 9952,
+  [SMALL_STATE(306)] = 9966,
+  [SMALL_STATE(307)] = 9980,
+  [SMALL_STATE(308)] = 9994,
+  [SMALL_STATE(309)] = 10008,
+  [SMALL_STATE(310)] = 10022,
+  [SMALL_STATE(311)] = 10036,
+  [SMALL_STATE(312)] = 10046,
+  [SMALL_STATE(313)] = 10060,
+  [SMALL_STATE(314)] = 10074,
+  [SMALL_STATE(315)] = 10088,
+  [SMALL_STATE(316)] = 10099,
+  [SMALL_STATE(317)] = 10110,
+  [SMALL_STATE(318)] = 10121,
+  [SMALL_STATE(319)] = 10130,
+  [SMALL_STATE(320)] = 10141,
+  [SMALL_STATE(321)] = 10152,
+  [SMALL_STATE(322)] = 10163,
+  [SMALL_STATE(323)] = 10174,
+  [SMALL_STATE(324)] = 10185,
+  [SMALL_STATE(325)] = 10196,
+  [SMALL_STATE(326)] = 10207,
+  [SMALL_STATE(327)] = 10216,
+  [SMALL_STATE(328)] = 10227,
+  [SMALL_STATE(329)] = 10238,
+  [SMALL_STATE(330)] = 10249,
+  [SMALL_STATE(331)] = 10258,
+  [SMALL_STATE(332)] = 10267,
+  [SMALL_STATE(333)] = 10278,
+  [SMALL_STATE(334)] = 10289,
+  [SMALL_STATE(335)] = 10298,
+  [SMALL_STATE(336)] = 10309,
+  [SMALL_STATE(337)] = 10320,
+  [SMALL_STATE(338)] = 10331,
+  [SMALL_STATE(339)] = 10342,
+  [SMALL_STATE(340)] = 10351,
+  [SMALL_STATE(341)] = 10360,
+  [SMALL_STATE(342)] = 10369,
+  [SMALL_STATE(343)] = 10378,
+  [SMALL_STATE(344)] = 10386,
+  [SMALL_STATE(345)] = 10394,
+  [SMALL_STATE(346)] = 10402,
+  [SMALL_STATE(347)] = 10410,
+  [SMALL_STATE(348)] = 10418,
+  [SMALL_STATE(349)] = 10426,
+  [SMALL_STATE(350)] = 10434,
+  [SMALL_STATE(351)] = 10442,
+  [SMALL_STATE(352)] = 10450,
+  [SMALL_STATE(353)] = 10458,
+  [SMALL_STATE(354)] = 10466,
+  [SMALL_STATE(355)] = 10474,
+  [SMALL_STATE(356)] = 10482,
+  [SMALL_STATE(357)] = 10490,
+  [SMALL_STATE(358)] = 10498,
+  [SMALL_STATE(359)] = 10506,
+  [SMALL_STATE(360)] = 10514,
+  [SMALL_STATE(361)] = 10522,
+  [SMALL_STATE(362)] = 10530,
+  [SMALL_STATE(363)] = 10538,
+  [SMALL_STATE(364)] = 10546,
+  [SMALL_STATE(365)] = 10554,
+  [SMALL_STATE(366)] = 10562,
+  [SMALL_STATE(367)] = 10570,
+  [SMALL_STATE(368)] = 10578,
+  [SMALL_STATE(369)] = 10586,
+  [SMALL_STATE(370)] = 10594,
+  [SMALL_STATE(371)] = 10602,
+  [SMALL_STATE(372)] = 10610,
+  [SMALL_STATE(373)] = 10618,
+  [SMALL_STATE(374)] = 10626,
+  [SMALL_STATE(375)] = 10634,
+  [SMALL_STATE(376)] = 10642,
+  [SMALL_STATE(377)] = 10650,
+  [SMALL_STATE(378)] = 10658,
+  [SMALL_STATE(379)] = 10666,
+  [SMALL_STATE(380)] = 10674,
+  [SMALL_STATE(381)] = 10682,
+  [SMALL_STATE(382)] = 10690,
+  [SMALL_STATE(383)] = 10698,
+  [SMALL_STATE(384)] = 10706,
+  [SMALL_STATE(385)] = 10714,
+  [SMALL_STATE(386)] = 10722,
+  [SMALL_STATE(387)] = 10730,
+  [SMALL_STATE(388)] = 10738,
+  [SMALL_STATE(389)] = 10746,
+  [SMALL_STATE(390)] = 10754,
+  [SMALL_STATE(391)] = 10762,
+  [SMALL_STATE(392)] = 10770,
+  [SMALL_STATE(393)] = 10778,
+  [SMALL_STATE(394)] = 10786,
+  [SMALL_STATE(395)] = 10794,
+  [SMALL_STATE(396)] = 10802,
+  [SMALL_STATE(397)] = 10810,
+  [SMALL_STATE(398)] = 10818,
+  [SMALL_STATE(399)] = 10826,
+  [SMALL_STATE(400)] = 10834,
+  [SMALL_STATE(401)] = 10842,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -15392,465 +15186,449 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(357),
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 1),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
   [15] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 5, .production_id = 7),
-  [19] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 5, .production_id = 7),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 3, .production_id = 7),
-  [23] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 3, .production_id = 7),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(242),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(272),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(273),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
-  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
-  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3),
-  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 3),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 4, .production_id = 7),
-  [59] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 4, .production_id = 7),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
-  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [21] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_expression, 3, .production_id = 8),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(230),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3),
+  [35] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 3),
+  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
+  [39] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 3, .production_id = 7),
+  [43] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 3, .production_id = 7),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 5, .production_id = 7),
+  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 5, .production_id = 7),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(251),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(237),
+  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fncall, 4, .production_id = 7),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_fncall, 4, .production_id = 7),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
   [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
   [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 2),
   [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 2),
-  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 1),
-  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 1),
-  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 1),
-  [85] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 2),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 2),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 1),
+  [85] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
   [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 2),
-  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 1),
-  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 2),
+  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 2),
+  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 1),
   [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 1),
-  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 7, .production_id = 2),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 2),
-  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [119] = {.entry = {.count = 1, .reusable = false}}, SHIFT(412),
-  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(413),
-  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(414),
-  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 1),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 6, .production_id = 1),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 5, .production_id = 1),
+  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [119] = {.entry = {.count = 1, .reusable = false}}, SHIFT(388),
+  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(382),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
+  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(300),
   [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2),
-  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(364),
-  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(423),
-  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(380),
-  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(361),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(369),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(366),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(365),
+  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(363),
   [141] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(360),
-  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(386),
-  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(417),
-  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(362),
-  [153] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(220),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
-  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(423),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(358),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(355),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(351),
+  [153] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_schema_declarations_repeat1, 2), SHIFT_REPEAT(211),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
   [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(417),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 2, .production_id = 1),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 2),
-  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
-  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
-  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
-  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 2, .production_id = 1),
-  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
-  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [220] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 2),
-  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 3, .production_id = 5),
-  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
+  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 2),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 2),
+  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 5),
+  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 2, .production_id = 1),
+  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
+  [212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 2, .production_id = 1),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 6),
+  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tuple, 4),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_tuple, 7),
+  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 2, .production_id = 3),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
   [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6),
-  [234] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6), SHIFT_REPEAT(34),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 2, .production_id = 3),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 1),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 6),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 5),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 3),
+  [234] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 6), SHIFT_REPEAT(33),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extending, 3, .production_id = 5),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 5),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum, 6),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extending_repeat1, 2, .production_id = 3),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 3, .production_id = 1),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
   [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 4, .production_id = 2),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
-  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
-  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(380),
-  [270] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(361),
-  [273] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(360),
-  [276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(386),
-  [279] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(337),
-  [282] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(220),
-  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
-  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
-  [303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
-  [307] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
-  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
-  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
-  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
-  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2),
-  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 3, .production_id = 2),
-  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 4),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
+  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [271] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
+  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [275] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
+  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(339),
+  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
+  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(309),
+  [287] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2),
+  [289] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(365),
+  [292] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(363),
+  [295] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(360),
+  [298] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(358),
+  [301] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(320),
+  [304] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2), SHIFT_REPEAT(211),
+  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(320),
+  [311] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 3, .production_id = 2),
+  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 4),
+  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2),
   [321] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fncall_repeat1, 2),
-  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
-  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 2),
-  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(416),
-  [335] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 1),
-  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
-  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
-  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
-  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
-  [351] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [353] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [357] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_repeat1, 2),
-  [359] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(421),
-  [362] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(331),
-  [365] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(220),
-  [368] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(424),
-  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
-  [373] = {.entry = {.count = 1, .reusable = false}}, SHIFT(421),
-  [375] = {.entry = {.count = 1, .reusable = false}}, SHIFT(331),
-  [377] = {.entry = {.count = 1, .reusable = false}}, SHIFT(220),
-  [379] = {.entry = {.count = 1, .reusable = false}}, SHIFT(424),
-  [381] = {.entry = {.count = 1, .reusable = true}}, SHIFT(404),
-  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 1),
-  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 4),
-  [387] = {.entry = {.count = 1, .reusable = true}}, SHIFT(407),
-  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 1),
-  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 1),
-  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 2),
-  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(399),
-  [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(396),
-  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 3, .production_id = 1),
-  [403] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
-  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
+  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 4, .production_id = 2),
+  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, .production_id = 1),
+  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [335] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
+  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 5, .production_id = 1),
+  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
+  [351] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
+  [353] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
+  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
+  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [361] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 2),
+  [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
+  [369] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 2),
+  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 2),
+  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 5, .production_id = 1),
+  [377] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 1),
+  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 4),
+  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 2),
+  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
+  [395] = {.entry = {.count = 1, .reusable = false}}, SHIFT(393),
+  [397] = {.entry = {.count = 1, .reusable = false}}, SHIFT(337),
+  [399] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
+  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(377),
+  [403] = {.entry = {.count = 1, .reusable = true}}, SHIFT(396),
+  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 2),
   [407] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 3),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 4, .production_id = 2),
-  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 6, .production_id = 2),
-  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 2),
-  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 4, .production_id = 2),
-  [421] = {.entry = {.count = 1, .reusable = true}}, SHIFT(401),
-  [423] = {.entry = {.count = 1, .reusable = false}}, SHIFT(425),
-  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(410),
-  [427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 2),
-  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 1),
-  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 2),
-  [433] = {.entry = {.count = 1, .reusable = true}}, SHIFT(408),
-  [435] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
-  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 2),
-  [439] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
-  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 1),
-  [443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 9, .production_id = 2),
-  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(377),
-  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 1),
-  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 1),
-  [451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 1),
-  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 2),
-  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
-  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 2),
-  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 1),
-  [463] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
-  [465] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 3, .production_id = 1),
-  [467] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 1),
-  [469] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 2),
-  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 1),
-  [473] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 2),
-  [475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_constraint_repeat1, 2),
-  [477] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(421),
-  [480] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(425),
-  [483] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(220),
-  [486] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(424),
-  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 1),
-  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 11, .production_id = 2),
-  [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
-  [495] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
-  [497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 2),
-  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(376),
-  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 11, .production_id = 1),
-  [503] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 8, .production_id = 1),
-  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 15, .production_id = 1),
-  [507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3, .production_id = 1),
-  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 10, .production_id = 1),
-  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 2),
-  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 9, .production_id = 1),
-  [515] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 1),
-  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 7, .production_id = 1),
-  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 14, .production_id = 1),
-  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 7, .production_id = 1),
-  [523] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 5, .production_id = 1),
-  [525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 6, .production_id = 4),
-  [527] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 13, .production_id = 1),
-  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5, .production_id = 2),
-  [531] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 12, .production_id = 1),
-  [533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 2),
-  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [537] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [539] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [543] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2),
-  [549] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(360),
-  [552] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(220),
-  [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
-  [559] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 7),
-  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(402),
-  [563] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
-  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
-  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 3),
-  [569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 6),
-  [571] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
-  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
-  [575] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 1),
-  [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
-  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
-  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [585] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 5),
-  [587] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
-  [589] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 4),
-  [591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_uselang, 2, .production_id = 9),
-  [593] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_uselang, 2, .production_id = 9),
+  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 4, .production_id = 1),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 11, .production_id = 2),
+  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 6, .production_id = 1),
+  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 1),
+  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [419] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
+  [421] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 6, .production_id = 2),
+  [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(401),
+  [425] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 3, .production_id = 1),
+  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 1),
+  [431] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
+  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 7, .production_id = 2),
+  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 1),
+  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_constraint_repeat1, 2),
+  [439] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(393),
+  [442] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(337),
+  [445] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(211),
+  [448] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_constraint_repeat1, 2), SHIFT_REPEAT(377),
+  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
+  [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
+  [455] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 7, .production_id = 2),
+  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 8, .production_id = 1),
+  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 1),
+  [461] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [463] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_repeat1, 2),
+  [465] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(393),
+  [468] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(337),
+  [471] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(211),
+  [474] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_function_repeat1, 2), SHIFT_REPEAT(377),
+  [477] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
+  [479] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 5, .production_id = 2),
+  [481] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 8, .production_id = 2),
+  [483] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 1),
+  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 9, .production_id = 2),
+  [489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(394),
+  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_link, 9, .production_id = 2),
+  [493] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 1),
+  [495] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint, 10, .production_id = 2),
+  [497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 5, .production_id = 2),
+  [499] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 9, .production_id = 1),
+  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 5, .production_id = 10),
+  [503] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 1),
+  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 4, .production_id = 2),
+  [507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 4, .production_id = 9),
+  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 5, .production_id = 2),
+  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 7, .production_id = 1),
+  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias, 5, .production_id = 1),
+  [515] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_type_def, 6, .production_id = 4),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object_type, 3, .production_id = 1),
+  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 8, .production_id = 1),
+  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 6, .production_id = 1),
+  [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
+  [525] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
+  [529] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
+  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
+  [533] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
+  [537] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
+  [539] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2),
+  [541] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(360),
+  [544] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_annotation_repeat1, 2), SHIFT_REPEAT(211),
+  [547] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
+  [549] = {.entry = {.count = 1, .reusable = true}}, SHIFT(395),
+  [551] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
+  [553] = {.entry = {.count = 1, .reusable = true}}, SHIFT(400),
+  [555] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 5),
+  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(385),
+  [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(376),
+  [561] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 1),
+  [563] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
+  [565] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_modifier, 1),
+  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 6),
+  [569] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 4),
+  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [575] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 7),
+  [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
+  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [583] = {.entry = {.count = 1, .reusable = false}}, SHIFT(350),
+  [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
+  [587] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [589] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [591] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
   [595] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2),
-  [597] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2), SHIFT_REPEAT(220),
-  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(382),
-  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
-  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
-  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(385),
-  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [612] = {.entry = {.count = 1, .reusable = false}}, SHIFT(395),
-  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
-  [616] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
-  [618] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 1),
-  [622] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
-  [624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_using, 5),
-  [626] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 5),
-  [628] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 3, .production_id = 1),
-  [630] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 1),
-  [632] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 2),
-  [634] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 2),
-  [636] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_computed, 4, .production_id = 7),
-  [638] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_computed, 4, .production_id = 7),
-  [640] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [642] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 6, .production_id = 2),
-  [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(422),
-  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
-  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(400),
-  [656] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
-  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [666] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
-  [668] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 6),
-  [670] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [674] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 3),
-  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [680] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 4),
-  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 5),
-  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [690] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
-  [692] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [694] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
-  [696] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2),
-  [698] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(299),
-  [701] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
-  [703] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(363),
-  [706] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
-  [710] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_on, 4),
-  [712] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [718] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
-  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
-  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except, 4),
-  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [738] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2), SHIFT_REPEAT(248),
-  [741] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 2),
-  [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(419),
-  [745] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
-  [747] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
-  [749] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [751] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(36),
-  [754] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
-  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
-  [758] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [760] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fncall_repeat1, 2), SHIFT_REPEAT(267),
-  [763] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
-  [767] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_returnspec, 1),
-  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [771] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [773] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(367),
-  [776] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
-  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [780] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2), SHIFT_REPEAT(392),
-  [783] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2),
-  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [791] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
+  [597] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_type_def_repeat1, 2), SHIFT_REPEAT(211),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [604] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index, 3),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
+  [608] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [610] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [612] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 3, .production_id = 1),
+  [614] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 1),
+  [616] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 4, .production_id = 2),
+  [618] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 4, .production_id = 9),
+  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_using, 5, .production_id = 10),
+  [622] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 1),
+  [624] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 5, .production_id = 2),
+  [626] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 6, .production_id = 2),
+  [628] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [630] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_computed, 4, .production_id = 7),
+  [632] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [634] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [636] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [638] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
+  [640] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
+  [642] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [656] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 2),
+  [658] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 6),
+  [660] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 4),
+  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [666] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 5),
+  [668] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argspec, 3),
+  [670] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [674] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [680] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_on, 4),
+  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
+  [688] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
+  [690] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(357),
+  [693] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2),
+  [695] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(292),
+  [698] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [700] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
+  [702] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
+  [704] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
+  [706] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
+  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
+  [710] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [718] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
+  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
+  [728] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2), SHIFT_REPEAT(354),
+  [731] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 2),
+  [733] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2), SHIFT_REPEAT(380),
+  [736] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_enum_repeat1, 2),
+  [738] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
+  [740] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [742] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
+  [744] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 2), SHIFT_REPEAT(231),
+  [747] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except, 4),
+  [749] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fncall_repeat1, 2), SHIFT_REPEAT(233),
+  [752] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2), SHIFT_REPEAT(46),
+  [755] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__tuple_repeat1, 2),
+  [757] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [759] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [761] = {.entry = {.count = 1, .reusable = true}}, SHIFT(399),
+  [763] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [767] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
+  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
+  [771] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [773] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [775] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [777] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
+  [779] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
+  [781] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
+  [783] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(327),
+  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [791] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
   [793] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argspec_repeat1, 4),
-  [795] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__named_tuple_repeat1, 4),
-  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(394),
-  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [817] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 3),
-  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
-  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [823] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(406),
-  [827] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [829] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
-  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [837] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
-  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
-  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
-  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
-  [853] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [859] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
-  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
-  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
-  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(388),
-  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
-  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
-  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [875] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(415),
-  [879] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [883] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
-  [887] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
-  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
-  [891] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
-  [895] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [897] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
-  [899] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [901] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [903] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [905] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
-  [907] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [909] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [911] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
-  [913] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [915] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
-  [917] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
-  [919] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
-  [921] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
-  [923] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [925] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [927] = {.entry = {.count = 1, .reusable = true}}, SHIFT(411),
-  [929] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [931] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
-  [933] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
-  [935] = {.entry = {.count = 1, .reusable = true}}, SHIFT(405),
-  [937] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [939] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [941] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [943] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
-  [945] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
-  [947] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [795] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module, 3, .production_id = 1),
+  [797] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_schema_declarations, 2),
+  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
+  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
+  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(335),
+  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [817] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(336),
+  [823] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
+  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
+  [827] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
+  [829] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
+  [837] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(345),
+  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
+  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
+  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [853] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [859] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
+  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(342),
+  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
+  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [875] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
+  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [879] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
+  [883] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
+  [887] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [891] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [895] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [897] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [899] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [901] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
+  [903] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+void *tree_sitter_esdl_external_scanner_create(void);
+void tree_sitter_esdl_external_scanner_destroy(void *);
+bool tree_sitter_esdl_external_scanner_scan(void *, TSLexer *, const bool *);
+unsigned tree_sitter_esdl_external_scanner_serialize(void *, char *);
+void tree_sitter_esdl_external_scanner_deserialize(void *, const char *, unsigned);
+
 #ifdef _WIN32
 #define extern __declspec(dllexport)
 #endif
@@ -15881,6 +15659,15 @@ extern const TSLanguage *tree_sitter_esdl(void) {
     .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
+    .external_scanner = {
+      &ts_external_scanner_states[0][0],
+      ts_external_scanner_symbol_map,
+      tree_sitter_esdl_external_scanner_create,
+      tree_sitter_esdl_external_scanner_destroy,
+      tree_sitter_esdl_external_scanner_scan,
+      tree_sitter_esdl_external_scanner_serialize,
+      tree_sitter_esdl_external_scanner_deserialize,
+    },
   };
   return &language;
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,53 @@
+#include <tree_sitter/parser.h>
+#include <wctype.h>
+
+enum TokenType {
+  EDGEQL_CHARS,
+};
+
+void *tree_sitter_esdl_external_scanner_create() { return NULL; }
+void tree_sitter_esdl_external_scanner_destroy(void *p) {}
+void tree_sitter_esdl_external_scanner_reset(void *p) {}
+unsigned tree_sitter_esdl_external_scanner_serialize(void *p, char *buffer) { return 0; }
+void tree_sitter_esdl_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
+
+static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+static void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+static bool scan_edgeql_chars(TSLexer *lexer) {
+  lexer->result_symbol = EDGEQL_CHARS;
+  int nest_count = 0;
+  
+  for (bool has_content;; has_content = true) {
+    lexer->mark_end(lexer);
+    switch (lexer->lookahead) {
+      case '(':
+        nest_count++;
+        advance(lexer);
+        break;
+      case ')':
+        if (nest_count > 0) {
+          nest_count--;
+          advance(lexer);
+          break;
+        } else {
+          return has_content;
+        }
+      case '\\':
+        return has_content;
+      case '\0':
+        return false;
+      default:
+        advance(lexer);
+    }
+  }
+}
+
+bool tree_sitter_esdl_external_scanner_scan(void *payload, TSLexer *lexer,
+                                                  const bool *valid_symbols) {
+  if (valid_symbols[EDGEQL_CHARS]) {
+    return scan_edgeql_chars(lexer);
+  }
+
+  return false;
+}

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -1,0 +1,17 @@
+==================
+Abstract Annotation
+==================
+
+module default {
+	abstract annotation title;
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (annotation
+        (modifier)
+        (identifier)))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -1,0 +1,23 @@
+==================
+Function declaration
+==================
+
+module default {
+    function foo(s: str) -> str
+      using (select s ++ <str>len(a));
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (function
+        (identifier)
+        (argspec
+          (identifier))
+        (returnspec
+          (type))
+        (using
+          (edgeql_fragment))))))

--- a/test/corpus/object_types.txt
+++ b/test/corpus/object_types.txt
@@ -51,8 +51,8 @@ module default {
     (schema_declarations
       (object_type
         (identifier)
-        (extends
-          (identifier))
+        (extending
+          (type (identifier)))
         (declarations)))))
 
 ==================
@@ -71,9 +71,9 @@ module default {
     (schema_declarations
       (object_type
         (identifier)
-        (extends
-          (identifier)
-          (identifier))
+        (extending
+          (type (identifier))
+          (type (identifier)))
         (declarations)))))
 
 ==================
@@ -83,7 +83,6 @@ Property
 module default {
     type Movie {
       property address -> str;
-      multi link friends -> User;
     }
 }
 
@@ -98,8 +97,31 @@ module default {
         (declarations
           (property
             (identifier)
-            (type))
-          (link
-            (modifier)
+            (type)))))))
+
+
+==================
+Extending Property 
+==================
+
+module default {
+    type Movie {
+      property address extending address_base -> str;
+    }
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (object_type
+        (identifier)
+        (declarations
+          (property
             (identifier)
-            (identifier)))))))
+            (extending
+              (type
+                (identifier)))
+            (type)))))))

--- a/test/corpus/properties.txt
+++ b/test/corpus/properties.txt
@@ -109,7 +109,7 @@ module default {
 
 ---
 
- (source_file
+(source_file
   (module
     (identifier)
     (schema_declarations
@@ -119,5 +119,35 @@ module default {
         (declarations
           (annotation
             (identifier)
-            (expr
-              (str))))))))
+            (expression
+              (string
+                (string_fragment)))))))))
+
+==================
+Computed Property
+==================
+
+module default {
+    type Movie {
+        property is_self := (.id = global current_user_id);
+    }
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (object_type
+        (identifier)
+        (declarations
+          (property
+            (identifier)
+            (expression
+              (expression
+                (binary_expression
+                  (expression
+                    (identifier))
+                  (expression
+                    (identifier)))))))))))

--- a/test/corpus/properties.txt
+++ b/test/corpus/properties.txt
@@ -20,3 +20,104 @@ module default {
           (property
             (identifier)
             (type)))))))
+
+
+==================
+Extending Property 
+==================
+
+module default {
+    type Movie {
+      property address extending address_base -> str;
+    }
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (object_type
+        (identifier)
+        (declarations
+          (property
+            (identifier)
+            (extending
+              (type
+                (identifier)))
+            (type)))))))
+
+==================
+Property with modifiers 
+==================
+
+module default {
+    type Movie {
+        required property address -> str;
+        required overloaded property name -> str;
+    }
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (object_type
+        (identifier)
+        (declarations
+          (property
+            (modifier)
+            (identifier)
+            (type))
+          (property
+            (modifier)
+            (modifier)
+            (identifier)
+            (type)))))))
+      
+==================
+Abstract Property 
+==================
+
+module default {
+    abstract property addess_base {}
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (property
+        (modifier)
+        (identifier)
+        (declarations)))))
+
+==================
+Abstract Property with annotation
+==================
+
+module default {
+    abstract property addess_base {
+      annotation title := 'Mailing address';
+    }
+}
+
+---
+
+ (source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (property
+        (modifier)
+        (identifier)
+        (declarations
+          (annotation
+            (identifier)
+            (expr
+              (str))))))))

--- a/test/corpus/scalar.txt
+++ b/test/corpus/scalar.txt
@@ -1,0 +1,26 @@
+==================
+Scalar declaration
+==================
+
+module default {
+	scalar type posint64 extending int64 {
+	    constraint min_value(0);
+	}
+}
+
+---
+
+(source_file
+  (module
+    (identifier)
+    (schema_declarations
+      (scalar_type_def
+        (identifier)
+        (extending
+          (type))
+        (declarations
+          (constraint
+            (identifier)
+            (argspec
+              (expression
+                (number)))))))))


### PR DESCRIPTION
I copied a bunch from https://github.com/tree-sitter/tree-sitter-javascript for some better parsing strategies (some may need to be updated to better match ESDL), added some new parsing (i.e. functions, abstracts, etc), and added some tests for the new features added. There is definitely some parts I added that need more work but this should at least cover the first couple bases and start providing good highlighting for tree-sitter users.

The features I plan on adding in the future are:
1. Proper EdgeQL parsing (currently using a customer scanner inspired by javascript template parsing).
2. Globals and access policies (recently added to edgedb's newest version).
3. Tree sitter locals

Thank you for putting together this project! I would've never gotten into writing tree-sitter grammars if it wasnt for you! :D